### PR TITLE
Fix Starcraft TMG unit data against printed cards and stimpacked.com

### DIFF
--- a/sctmg/starcraft-tmg.json
+++ b/sctmg/starcraft-tmg.json
@@ -81,6 +81,11 @@
                     "type": "string"
                   },
                   {
+                    "key": "target",
+                    "label": "Target",
+                    "type": "string"
+                  },
+                  {
                     "key": "roa",
                     "label": "RoA",
                     "type": "string"
@@ -125,6 +130,11 @@
                   {
                     "key": "rng",
                     "label": "RNG",
+                    "type": "string"
+                  },
+                  {
+                    "key": "target",
+                    "label": "Target",
                     "type": "string"
                   },
                   {
@@ -289,8 +299,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (All)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "All"
                   },
                   {
                     "name": "AGG-12",
@@ -300,9 +311,10 @@
                     "surge": "Armoured",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Long Range (18\"), Specialist",
+                    "keyword": "Long Range (18\"), Specialist",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "Ground"
                   }
                 ]
               },
@@ -318,8 +330,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Indirect Fire, Long Range (18\"), Sidearm, Specialist",
-                    "active": true
+                    "keyword": "Indirect Fire, Long Range (18\"), Sidearm, Specialist",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -336,8 +349,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   },
                   {
                     "name": "Bayonet",
@@ -347,9 +361,10 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
+                    "keyword": "-",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -455,8 +470,9 @@
                     "surge": "Armoured",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Pierce Armoured (2)",
-                    "active": true
+                    "keyword": "Pierce Armoured (2)",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -473,8 +489,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -580,8 +597,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -699,8 +717,9 @@
                     "surge": "Armoured",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (All), Bulky, Pierce Armoured (3)",
-                    "active": true
+                    "keyword": "Bulky, Pierce Armoured (3)",
+                    "active": true,
+                    "target": "All"
                   },
                   {
                     "name": "C-14 Rifle",
@@ -710,9 +729,10 @@
                     "surge": "Light",
                     "sdice": "D3+1",
                     "dmg": "1",
-                    "keyword": "Target (All), Burst Fire 8\" (3)",
+                    "keyword": "Burst Fire 8\" (3)",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "All"
                   }
                 ]
               },
@@ -727,8 +747,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "2",
-                    "keyword": "Target (Ground), Anti-Evade (2), Sidearm, Pinpoint",
-                    "active": true
+                    "keyword": "Anti-Evade (2), Sidearm, Pinpoint",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -745,8 +766,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -877,8 +899,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (All)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "All"
                   }
                 ]
               }
@@ -895,8 +918,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -994,8 +1018,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Long Range (18\")",
-                    "active": true
+                    "keyword": "Long Range (18\")",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               },
@@ -1010,8 +1035,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Pinpoint, Sidearm",
-                    "active": true
+                    "keyword": "Pinpoint, Sidearm",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               },
@@ -1026,8 +1052,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Flying), Anti-Evade (1), Sidearm",
-                    "active": true
+                    "keyword": "Anti-Evade (1), Sidearm",
+                    "active": true,
+                    "target": "Flying"
                   },
                   {
                     "name": "Scatter Missiles",
@@ -1037,9 +1064,10 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Indirect Fire, Locked In (6), Long Range (24\"), Sidearm",
+                    "keyword": "Indirect Fire, Locked In (6), Long Range (24\"), Sidearm",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "Ground"
                   },
                   {
                     "name": "Haywire Missiles",
@@ -1049,9 +1077,10 @@
                     "surge": "Armoured",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Pierce Armoured (3), Sidearm",
+                    "keyword": "Pierce Armoured (3), Sidearm",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1068,8 +1097,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1176,8 +1206,9 @@
                     "surge": "Light, Armoured",
                     "sdice": "D3+1",
                     "dmg": "2",
-                    "keyword": "Target (All)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "All"
                   }
                 ]
               }
@@ -1194,8 +1225,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1296,8 +1328,9 @@
                     "surge": "Light, Armoured",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (All)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "All"
                   }
                 ]
               }
@@ -1314,8 +1347,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "2",
-                    "keyword": "Target (Ground), Critical Hit (2)",
-                    "active": true
+                    "keyword": "Critical Hit (2)",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1498,8 +1532,9 @@
                     "surge": "Light, Armoured",
                     "sdice": "D6",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Instant",
-                    "active": true
+                    "keyword": "Instant",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1597,8 +1632,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               },
@@ -1613,8 +1649,9 @@
                     "surge": "Light, Armoured",
                     "sdice": "D3",
                     "dmg": "2",
-                    "keyword": "Target (Flying)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Flying"
                   }
                 ]
               }
@@ -1631,8 +1668,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1761,8 +1799,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1779,8 +1818,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1898,8 +1938,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -1916,8 +1957,9 @@
                     "surge": "Light",
                     "sdice": "D3+1",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2043,8 +2085,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2110,8 +2153,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2128,8 +2172,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2265,8 +2310,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   },
                   {
                     "name": "Shredding Claws",
@@ -2276,9 +2322,10 @@
                     "surge": "Light, Armoured",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
+                    "keyword": "-",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2382,8 +2429,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   },
                   {
                     "name": "Shredding Claws",
@@ -2393,9 +2441,10 @@
                     "surge": "Light, Armoured",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
+                    "keyword": "-",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2513,8 +2562,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2622,8 +2672,9 @@
                     "surge": "Light",
                     "sdice": "D3+1",
                     "dmg": "1",
-                    "keyword": "Target (All), Anti-Evade (1)",
-                    "active": true
+                    "keyword": "Anti-Evade (1)",
+                    "active": true,
+                    "target": "All"
                   }
                 ]
               }
@@ -2640,8 +2691,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   },
                   {
                     "name": "Glaive Strike",
@@ -2651,9 +2703,10 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground), Pierce Light (2)",
+                    "keyword": "Pierce Light (2)",
                     "active": true,
-                    "upgrade": true
+                    "upgrade": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2748,8 +2801,9 @@
                     "surge": "Armoured",
                     "sdice": "D3",
                     "dmg": "3",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   },
                   {
                     "name": "Twilight Blades Sweep",
@@ -2759,8 +2813,9 @@
                     "surge": "Light",
                     "sdice": "D3+1",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -2864,8 +2919,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -3036,8 +3092,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (All), Instant",
-                    "active": true
+                    "keyword": "Instant",
+                    "active": true,
+                    "target": "All"
                   }
                 ]
               }
@@ -3054,8 +3111,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -3179,8 +3237,9 @@
                     "surge": "Armoured",
                     "sdice": "D3",
                     "dmg": "2",
-                    "keyword": "Target (All)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "All"
                   }
                 ]
               }
@@ -3197,8 +3256,9 @@
                     "surge": "-",
                     "sdice": "-",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }
@@ -3298,8 +3358,9 @@
                     "surge": "Light",
                     "sdice": "D3",
                     "dmg": "1",
-                    "keyword": "Target (Ground)",
-                    "active": true
+                    "keyword": "-",
+                    "active": true,
+                    "target": "Ground"
                   }
                 ]
               }

--- a/sctmg/starcraft-tmg.json
+++ b/sctmg/starcraft-tmg.json
@@ -393,12 +393,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Damage Dealer",
-            "Light",
             "Biological",
-            "Ground",
-            "Terran"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Terran"
@@ -525,12 +522,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Tank",
             "Armoured",
             "Biological",
-            "Ground",
-            "Terran"
+            "Ground"
           ],
           "factionKeywords": [
             "Terran"
@@ -653,12 +647,9 @@
             }
           ],
           "keywords": [
-            "Support",
-            "Lifesaver",
-            "Light",
             "Biological",
-            "Ground",
-            "Terran"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Terran"
@@ -772,17 +763,12 @@
               "category": "movement",
               "name": "Orders",
               "type": "ACTIVE",
-              "description": "Repeatable. Select another Friendly Biological Unit Within 8\", spend CP and apply one of the following effects:\n• 1CP: That Unit's first used weapon gains Critical Hit (2).\n• 1CP: That Unit ignores the Disengage penalty for the remainder of the Round.\n• 2CP: Remove the Activation Marker from that Unit."
+              "description": "Repeatable. Select another Friendly Biological Unit Within 8\", spend CP and apply one of the following effects:\n\u2022 1CP: That Unit's first used weapon gains Critical Hit (2).\n\u2022 1CP: That Unit ignores the Disengage penalty for the remainder of the Round.\n\u2022 2CP: Remove the Activation Marker from that Unit."
             }
           ],
           "keywords": [
-            "Hero",
-            "Tactician",
-            "Unique",
-            "Light",
             "Biological",
-            "Ground",
-            "Terran"
+            "Ground"
           ],
           "factionKeywords": [
             "Terran"
@@ -838,12 +824,9 @@
             }
           ],
           "keywords": [
-            "Lifesaver",
             "Armoured",
             "Flying",
-            "Mechanical",
-            "Terran",
-            "Raynor's Raiders"
+            "Mechanical"
           ],
           "factionKeywords": [
             "Terran",
@@ -957,13 +940,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Damage Dealer",
-            "Light",
             "Biological",
-            "Ground",
-            "Terran",
-            "Raynor's Raiders"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Terran",
@@ -1123,12 +1102,9 @@
             }
           ],
           "keywords": [
-            "Elite",
-            "Damage Dealer",
             "Armoured",
             "Mechanical",
-            "Ground",
-            "Terran"
+            "Ground"
           ],
           "factionKeywords": [
             "Terran"
@@ -1267,12 +1243,9 @@
             }
           ],
           "keywords": [
-            "Elite",
-            "Damage Dealer",
-            "Light",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -1393,13 +1366,9 @@
             }
           ],
           "keywords": [
-            "Hero",
-            "Damage Dealer",
-            "Unique",
             "Biological",
             "Psionic",
-            "Ground",
-            "Zerg"
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -1469,13 +1438,9 @@
             }
           ],
           "keywords": [
-            "Tactician",
-            "Unique",
             "Armoured",
             "Biological",
-            "Ground",
-            "Zerg",
-            "Kerrigan's Swarm"
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg",
@@ -1577,14 +1542,9 @@
             }
           ],
           "keywords": [
-            "Elite",
-            "Damage Dealer",
-            "Unique",
-            "Light",
             "Biological",
-            "Ground",
-            "Zerg",
-            "Kerrigan's Swarm"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg",
@@ -1741,12 +1701,10 @@
             }
           ],
           "keywords": [
-            "Support",
-            "Lifesaver",
             "Armoured",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Psionic",
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -1881,12 +1839,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Tank",
             "Armoured",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -2033,12 +1988,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Tank",
             "Armoured",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -2099,11 +2051,9 @@
             }
           ],
           "keywords": [
-            "Tank",
-            "Light",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -2249,12 +2199,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Tank",
             "Armoured",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -2369,12 +2316,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Damage Dealer",
-            "Light",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -2508,12 +2452,9 @@
             }
           ],
           "keywords": [
-            "Elite",
-            "Damage Dealer",
-            "Light",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -2609,12 +2550,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Damage Dealer",
-            "Light",
             "Biological",
-            "Ground",
-            "Zerg"
+            "Light",
+            "Ground"
           ],
           "factionKeywords": [
             "Zerg"
@@ -2753,12 +2691,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Damage Dealer",
             "Biological",
             "Light",
-            "Ground",
-            "Protoss"
+            "Ground"
           ],
           "factionKeywords": [
             "Protoss"
@@ -2867,13 +2802,9 @@
             }
           ],
           "keywords": [
-            "Hero",
-            "Tank",
-            "Unique",
             "Biological",
             "Psionic",
-            "Ground",
-            "Protoss"
+            "Ground"
           ],
           "factionKeywords": [
             "Protoss"
@@ -2984,14 +2915,9 @@
             }
           ],
           "keywords": [
-            "Elite",
-            "Damage Dealer",
-            "Unique",
             "Biological",
             "Light",
-            "Ground",
-            "Khalai",
-            "Protoss"
+            "Ground"
           ],
           "factionKeywords": [
             "Protoss",
@@ -3049,11 +2975,8 @@
             }
           ],
           "keywords": [
-            "Tactician",
-            "Armoured",
-            "Ground",
-            "Khalai",
-            "Protoss"
+            "Armored",
+            "Ground"
           ],
           "factionKeywords": [
             "Protoss",
@@ -3193,13 +3116,10 @@
             }
           ],
           "keywords": [
-            "Support",
-            "Lifesaver",
-            "Mechanical",
             "Light",
+            "Mechanical",
             "Psionic",
-            "Ground",
-            "Protoss"
+            "Ground"
           ],
           "factionKeywords": [
             "Protoss"
@@ -3315,12 +3235,9 @@
             }
           ],
           "keywords": [
-            "Elite",
-            "Damage Dealer",
             "Armoured",
             "Mechanical",
-            "Ground",
-            "Protoss"
+            "Ground"
           ],
           "factionKeywords": [
             "Protoss"
@@ -3439,12 +3356,9 @@
             }
           ],
           "keywords": [
-            "Core",
-            "Damage Dealer",
             "Biological",
             "Light",
-            "Ground",
-            "Protoss"
+            "Ground"
           ],
           "factionKeywords": [
             "Protoss"

--- a/sctmg/starcraft-tmg.json
+++ b/sctmg/starcraft-tmg.json
@@ -295,7 +295,7 @@
                   {
                     "name": "AGG-12",
                     "rng": "12",
-                    "roa": "3",
+                    "roa": "2",
                     "hit": "3+",
                     "surge": "Armoured",
                     "sdice": "D3",
@@ -371,9 +371,15 @@
             {
               "category": "movement",
               "name": "Combat Shield",
-              "type": "PASSIVE",
+              "type": "ACTIVE",
               "upgrade": true,
-              "description": "This Unit is always eligible to make an Evade Roll against any Close Combat Attack targeting it and any Damage from an Enemy Special Ability."
+              "description": "This Unit is always eligible to make an Evade Roll against any Close Combat Attack targeting it and any Damage from an Enemy Special Ability.",
+              "costs": [
+                {
+                  "amount": "1",
+                  "unit": "CP"
+                }
+              ]
             },
             {
               "category": "assault",
@@ -832,7 +838,8 @@
             "Terran",
             "Raynor's Raiders"
           ],
-          "combatRole": "Lifesaver"
+          "combatRole": "Lifesaver",
+          "armySlot": "Other"
         },
         {
           "id": "raynors-raider-marine-001",
@@ -1446,7 +1453,8 @@
             "Zerg",
             "Kerrigan's Swarm"
           ],
-          "combatRole": "Tactician"
+          "combatRole": "Tactician",
+          "armySlot": "Other"
         },
         {
           "id": "kerrigan-swarm-raptor-001",
@@ -1905,7 +1913,7 @@
                     "rng": "E",
                     "roa": "3",
                     "hit": "4+",
-                    "surge": "Light, Armoured",
+                    "surge": "Light",
                     "sdice": "D3+1",
                     "dmg": "1",
                     "keyword": "Target (Ground)",
@@ -2058,7 +2066,8 @@
           "factionKeywords": [
             "Zerg"
           ],
-          "combatRole": "Tank"
+          "combatRole": "Tank",
+          "armySlot": "Other"
         },
         {
           "id": "vile-roach-001",
@@ -2982,7 +2991,8 @@
             "Protoss",
             "Khalai"
           ],
-          "combatRole": "Tactician"
+          "combatRole": "Tactician",
+          "armySlot": "Other"
         },
         {
           "id": "sentry-001",


### PR DESCRIPTION
## Summary

End-to-end audit and correction of the Starcraft TMG datasource against the printed unit cards and stimpacked.com.

### Schema changes
- Reorder unit `stats` fields to **Shield, Speed, Armour, Evade, Hit Points, Size** to match the printed cards.
- Add a `Target` column to the Assault and Combat weapon schemas (between RNG and RoA, as printed). Previously `Target (X)` was being smuggled into the keyword string.

### Stat fixes (front-of-card)
All three factions, every unit. Highlights:
- **Protoss**: Adept, Artanis, Praetor Guard, Pylon, Sentry, Stalker, Zealot — multiple shield/speed/armour/evade/hp/size/swap fixes.
- **Terran**: Marine, Marauder, Medic, Jim Raynor, Point Defense Drone, Raynor's Raider, Goliath.
- **Zerg**: Hydralisk, Kerrigan, Omega Worm, Kerrigan Swarm Raptor, Queen, Roach, Corpser (Roach), Roachling, Vile (Roach), Zergling, Raptor, Swarmling.
- Plus Kerrigan Swarm Raptor supply costs (1-3 → 0, 4-6 → 1).

### Weapon profile fixes
- **Artanis** Twilight Blades Strike RoA `4` → `2`
- **Marine AGG-12** RoA `3` → `2`
- **Goliath** Autocannon RoA `6` → `9`, Hellfire Missiles RoA `3` → `6`
- **Corpser (Roach) Claws** surge `Light, Armoured` → `Light`
- Drop stray `Long Range (18")` from **Marine** and **Raynor's Raider** C-14 Rifle base profiles
- Combat profile RNG normalised from `M` to `E` for Marine/Marauder/Medic Strike, Jim Raynor & Raynor's Raider Bayonet, Goliath Stomp, Hydralisk Scythe, Marine Bayonet upgrade
- Migrated 51 weapon profiles: `Target (X)` moved out of `keyword` into the new `target` column

### Ability fixes (back-of-card / upgrades)
- **Sentry Guardian Shield**: dropped wrong `upgrade: true` flag (it's on the front)
- **Queen Psionic Link**: dropped wrong `upgrade: true` flag (it's on the front)
- **Queen**: added missing back-card upgrades — `Creep Speed` (any-phase passive) and `Domineering Presence` (movement active 1BM)

### Keywords / tags
Cleaned the `keywords` array on every unit so it now contains only the **Combat Tags** printed on the front of each card. Army-slot, combat-role, faction and `Unique` are no longer duplicated there since they live in `armySlot`, `combatRole`, `factionKeywords`. Notable specifics:
- **Adept** down to `Biological, Light, Ground` (was 6 entries)
- **Queen** missing `Psionic` restored
- **Jim Raynor** spurious `Light` and `Unique` removed
- **Pylon** matched to card text `Armored` (without u)

### armySlot fixes
Set `armySlot: "Other"` for Pylon, Point Defense Drone, Roachling, Omega Worm (was previously unset; stimpacked confirms `Other`).

### Method
Cross-checked every unit (stats, weapons, abilities, tags, role/slot) against the live unit pages on stimpacked.com (single canonical source). Stat differences came out to 5 weapon-level diffs and 4 armySlot diffs, all listed above. Empty backs (no upgrades) confirmed for Artanis, Praetor Guard, Pylon, Point Defense Drone, Raynor's Raider, Kerrigan, Omega Worm, Kerrigan Swarm Raptor, Roachling.

## Test plan
- [ ] Render Adept card — Glaive Cannon should show `Target=All` in its own column and `Anti-Evade (1)` as the only keyword.
- [ ] Spot-check a handful of cards across factions (Stalker, Marine, Goliath, Hydralisk, Queen) — stats columns appear in Shield/Speed/Armour/Evade/HP/Size order.
- [ ] Verify upgrade/back of Marine still shows Combat Shield as ACTIVE 1CP, Adept shows Resonating Glaives + Guidance + Glaive Strike, Sentry shows Solid-Field Projectors + Hallucination.

https://claude.ai/code/session_01G4agF6bLToL1bdXKuTteng


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4agF6bLToL1bdXKuTteng)_