### PR TITLE
Enable auto-resize for Starcraft unit in TMG config

### DIFF
--- a/sctmg/starcraft-tmg.json
+++ b/sctmg/starcraft-tmg.json
@@ -237,7 +237,8 @@
             "pointsFormat": "per-unit",
             "pointsLabel": "Models / Supply",
             "hasCombatRole": true,
-            "hasArmySlot": true
+            "hasArmySlot": true,
+            "hasAutoResize": true
           }
         }
       }


### PR DESCRIPTION
## Summary
Added auto-resize capability to a Starcraft unit configuration in the TMG (Tabletop Miniatures Game) data file.

## Changes
- Added `"hasAutoResize": true` property to a unit entry in the Starcraft TMG configuration
- This enables automatic resizing functionality for the affected unit

## Details
The change modifies the unit configuration object to include the `hasAutoResize` flag, allowing the unit to support automatic resizing behavior within the game system. This unit already had combat role and army slot capabilities enabled.

https://claude.ai/code/session_016Ri47u4BNpPqxjk9LGhDaq