### PR TITLE
Add faction colours to 11th edition faction files

### DIFF
--- a/11th/gdc/adeptasororitas.json
+++ b/11th/gdc/adeptasororitas.json
@@ -2,6 +2,10 @@
   "id": "aee1b46d-3461-4d5d-a612-0efd05dd843d",
   "name": "Adepta Sororitas",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#561113",
+    "header": "#570c0c"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:35.231Z",
   "parent_id": null,

--- a/11th/gdc/adeptuscustodes.json
+++ b/11th/gdc/adeptuscustodes.json
@@ -2,6 +2,10 @@
   "id": "6cc4ee5e-3bc6-4142-8147-2e1a9fb6e82c",
   "name": "Adeptus Custodes",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#6a0e19",
+    "header": "#6d5035"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:35.543Z",
   "parent_id": null,

--- a/11th/gdc/adeptusmechanicus.json
+++ b/11th/gdc/adeptusmechanicus.json
@@ -2,6 +2,10 @@
   "id": "60ecf26b-0c2b-4ea3-8a29-5f06bd02f6d8",
   "name": "Adeptus Mechanicus",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#5d1615",
+    "header": "#9f2628"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:35.400Z",
   "parent_id": null,

--- a/11th/gdc/aeldari.json
+++ b/11th/gdc/aeldari.json
@@ -2,6 +2,10 @@
   "id": "2cb72f92-bfc7-4d2c-a183-b2bff6b26bfc",
   "name": "Asuryani",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#0a353a",
+    "header": "#347379"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:36.831Z",
   "parent_id": null,

--- a/11th/gdc/agents.json
+++ b/11th/gdc/agents.json
@@ -2,6 +2,10 @@
   "id": "2f81671f-3164-4ab0-93c0-4a99746b5996",
   "name": "Agents of the Imperium",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#1a3445",
+    "header": "#244b6a"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:35.728Z",
   "parent_id": null,

--- a/11th/gdc/astramilitarum.json
+++ b/11th/gdc/astramilitarum.json
@@ -2,6 +2,10 @@
   "id": "9b847488-9663-48dc-b819-08ab93ac4382",
   "name": "Astra Militarum",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#0a2118",
+    "header": "#324935"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:34.761Z",
   "parent_id": null,

--- a/11th/gdc/blacktemplar.json
+++ b/11th/gdc/blacktemplar.json
@@ -2,6 +2,10 @@
   "id": "28162de0-fd36-450b-87ee-39e973ead32d",
   "name": "Black Templars",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#202a2f",
+    "header": "#142637"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:33.262Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",

--- a/11th/gdc/bloodangels.json
+++ b/11th/gdc/bloodangels.json
@@ -2,6 +2,10 @@
   "id": "864734c9-d6c7-4486-92de-9b8271a6a1e5",
   "name": "Blood Angels",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#631210",
+    "header": "#72191c"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:33.136Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",

--- a/11th/gdc/chaos_spacemarines.json
+++ b/11th/gdc/chaos_spacemarines.json
@@ -2,6 +2,10 @@
   "id": "d4162ab7-8356-4e4e-adb3-5e3b631d47e6",
   "name": "Heretic Astartes",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#320b0d",
+    "header": "#222a2f"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:34.032Z",
   "parent_id": null,

--- a/11th/gdc/chaosdaemons.json
+++ b/11th/gdc/chaosdaemons.json
@@ -2,6 +2,10 @@
   "id": "40a70c91-675a-4ac5-aa97-daedb9cb6f11",
   "name": "Legiones Daemonica",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#202224",
+    "header": "#393940"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:34.264Z",
   "parent_id": null,

--- a/11th/gdc/chaosknights.json
+++ b/11th/gdc/chaosknights.json
@@ -2,6 +2,10 @@
   "id": "2e79f9cd-94dc-48ca-bddf-6d5e877609c5",
   "name": "Chaos Knights",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#102824",
+    "header": "#49584c"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:34.373Z",
   "parent_id": null,

--- a/11th/gdc/darkangels.json
+++ b/11th/gdc/darkangels.json
@@ -2,6 +2,10 @@
   "id": "fa0e86ef-b5da-4510-9a9f-8cd86267bb6a",
   "name": "Dark Angels",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#16291a",
+    "header": "#013a17"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:32.089Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",

--- a/11th/gdc/deathguard.json
+++ b/11th/gdc/deathguard.json
@@ -2,6 +2,10 @@
   "id": "19176137-2faa-4d6e-adb4-2572510032b7",
   "name": "Death Guard",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#2c290c",
+    "header": "#4d560e"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:32.258Z",
   "parent_id": null,

--- a/11th/gdc/deathwatch.json
+++ b/11th/gdc/deathwatch.json
@@ -2,6 +2,10 @@
   "id": "51ac31b0-93ff-4c94-a9a5-5c1a97fbbb75",
   "name": "Deathwatch",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#232425",
+    "header": "#3d3e41"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:33.481Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",

--- a/11th/gdc/drukhari.json
+++ b/11th/gdc/drukhari.json
@@ -2,6 +2,10 @@
   "id": "43bbfe97-4c14-47be-be2b-90de3e6756b1",
   "name": "Drukhari",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#102929",
+    "header": "#0f454e"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:36.985Z",
   "parent_id": null,

--- a/11th/gdc/emperors_children.json
+++ b/11th/gdc/emperors_children.json
@@ -2,6 +2,10 @@
   "id": "b63a417d-63ea-4d20-b7f0-85c66c56979e",
   "name": "Emperor’s Children",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#2E0B03",
+    "header": "#1A3037"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:37.215Z",
   "parent_id": null,

--- a/11th/gdc/greyknights.json
+++ b/11th/gdc/greyknights.json
@@ -2,6 +2,10 @@
   "id": "93423323-3abb-4a72-a51e-b8ac54f2f98d",
   "name": "Grey Knights",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#325b68",
+    "header": "#4a5e67"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:35.049Z",
   "parent_id": null,

--- a/11th/gdc/gsc.json
+++ b/11th/gdc/gsc.json
@@ -2,6 +2,10 @@
   "id": "800c0387-5033-47da-bad0-f42e53b37453",
   "name": "Genestealer Cults",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#291221",
+    "header": "#391625"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:37.107Z",
   "parent_id": null,

--- a/11th/gdc/imperialknights.json
+++ b/11th/gdc/imperialknights.json
@@ -2,6 +2,10 @@
   "id": "5737b3b6-1c33-4cb3-828c-08b6909197aa",
   "name": "Imperial Knights",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#122d42",
+    "header": "#023e58"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:34.906Z",
   "parent_id": null,

--- a/11th/gdc/necrons.json
+++ b/11th/gdc/necrons.json
@@ -2,6 +2,10 @@
   "id": "47670bc3-64b8-4c2d-9154-7391f132688b",
   "name": "Necrons",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#032b16",
+    "header": "#04532a"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:36.526Z",
   "parent_id": null,

--- a/11th/gdc/orks.json
+++ b/11th/gdc/orks.json
@@ -2,6 +2,10 @@
   "id": "0b30f1e3-1e5c-4823-afa1-07951433a270",
   "name": "Orks",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#283109",
+    "header": "#465b18"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:35.977Z",
   "parent_id": null,

--- a/11th/gdc/space_marines.json
+++ b/11th/gdc/space_marines.json
@@ -2,6 +2,10 @@
   "id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "name": "Adeptus Astartes",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#092135",
+    "header": "#4b6262"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:32.982Z",
   "parent_id": null,

--- a/11th/gdc/spacewolves.json
+++ b/11th/gdc/spacewolves.json
@@ -2,6 +2,10 @@
   "id": "bc367514-36b7-47c6-bd3f-ffbf85f5cfd9",
   "name": "Space Wolves",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#283743",
+    "header": "#435d63"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:33.385Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",

--- a/11th/gdc/tau.json
+++ b/11th/gdc/tau.json
@@ -2,6 +2,10 @@
   "id": "1a241f8e-2d79-47c4-82b1-f6faea353970",
   "name": "T’au Empire",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#175966",
+    "header": "#2e5a6a"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:36.325Z",
   "parent_id": null,

--- a/11th/gdc/thousandsons.json
+++ b/11th/gdc/thousandsons.json
@@ -2,6 +2,10 @@
   "id": "25d2c58f-59b5-4a4f-b597-495ba322ce07",
   "name": "Thousand Sons",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#0b3645",
+    "header": "#185862"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:33.612Z",
   "parent_id": null,

--- a/11th/gdc/titan.json
+++ b/11th/gdc/titan.json
@@ -2,6 +2,10 @@
   "id": "fec6e6a5-f491-4d83-99c0-e46e510f29e8",
   "name": "Adeptus Titanicus",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#092135",
+    "header": "#4b6262"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-06-26T08:37:48.883Z",
   "parent_id": null,

--- a/11th/gdc/tyranids.json
+++ b/11th/gdc/tyranids.json
@@ -2,6 +2,10 @@
   "id": "b30b3258-9140-46b8-9c9e-113be9008ea9",
   "name": "Tyranids",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#411f41",
+    "header": "#381a3a"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:32.499Z",
   "parent_id": null,

--- a/11th/gdc/votann.json
+++ b/11th/gdc/votann.json
@@ -2,6 +2,10 @@
   "id": "a42808ab-f00b-4664-aed5-8d9341b96e36",
   "name": "Leagues of Votann",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#572d0a",
+    "header": "#3c4b3f"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:36.121Z",
   "parent_id": null,

--- a/11th/gdc/worldeaters.json
+++ b/11th/gdc/worldeaters.json
@@ -2,6 +2,10 @@
   "id": "8bd4c67d-4aba-4502-8561-7c6c6faae51d",
   "name": "World Eaters",
   "source": "40k-11e",
+  "colours": {
+    "banner": "#611013",
+    "header": "#4d161a"
+  },
   "compatibleDataVersion": 886,
   "updated": "2026-07-07T09:13:33.759Z",
   "parent_id": null,


### PR DESCRIPTION
## Summary

11th edition faction files were missing the `colours` object that the renderer uses for card header/banner theming. This ports `banner`/`header` colours into all 29 `11th/gdc/*.json` faction files from the matching 10th edition faction, so 11e cards render with the correct faction colours.

## Details

- Matched by filename against `10th/gdc/<faction>.json` and inserted a `colours` block right after the `source` field.
- Surgical change only: 116 insertions (4 lines × 29 files), no reformatting of existing data.
- All 29 files remain valid JSON.

## Related

Required by the 11th edition support in the `ronplanken/game-datacards` app (the renderer reads `cardFaction.colours`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJqFtxzap1qsQRnzk5nrZB)_