### PR TITLE
AoS: add battlepack mission data (GHB 2024-25 and 2025-26)

### DIFF
--- a/aos/gdc/battlepacks/generals_handbook_2024_25.json
+++ b/aos/gdc/battlepacks/generals_handbook_2024_25.json
@@ -1,0 +1,2853 @@
+{
+  "id": "48f9fd56-bf1b-563e-9afd-801a9f8675b2",
+  "name": "General's Handbook 2024-25",
+  "cardType": "Battlepack",
+  "source": "aos-4e",
+  "updated": "2026-07-04T16:16:48.545Z",
+  "compatibleDataVersion": 434,
+  "description": "The Mortal Realms have been wounded. Warpflame irrevocably scours the land, and those places not stripped to nothingness are overrun with starving rodents. Many are claiming a new era has been ushered in – the Second Age of Chaos. Only leaders with unshakeable hearts can hope to reunite these people fractured by fear.",
+  "battleTacticsCardLimit": null,
+  "armyBuilder": {
+    "noLoresCost": true,
+    "noEnhancementsCost": true,
+    "noBattleFormationsCost": true,
+    "noFactionTerrainCost": true
+  },
+  "battleplans": [
+    {
+      "id": "b0b6545e-fbd9-5b3e-9377-b89affa36487",
+      "name": "Border War",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 1 (Table 1)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "Victory points scored by each player from controlling objectives are capped at a maximum of 6 per turn.\n\nAdd 1 to hit rolls for units in the **underdog**’s army if they charged this turn and are contesting the objective wholly within enemy territory.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control the objective wholly within friendly territory.\n\n• Score 2 victory points for each objective on the border of friendly territory that you control.\n\n• Score 5 victory points if you control the objective wholly within enemy territory.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/e32ccafe-0ea0-46fb-93b5-24f673317e3d",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory.\n\nThere are four gold circles indicating objectives: two on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge, and one at the centre of each player's territory."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/02f55d8c-9db3-4e64-a3dc-f51b645bb17e",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/5ad701b1-7b5f-43ce-8377-598c037070c5",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power to the left of the objective on the border between territories, a medium Area Terrain or Obstacle to the left of the objective in their territory, a small Area Terrain or Obstacle slightly above and to the right of the objective in their territory, and a medium Obscuring Terrain in the centre of the rightmost large quarter."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "Victory points scored by each player from controlling objectives are capped at a maximum of 6 per turn.\n\nAdd 1 to hit rolls for units in the **underdog**’s army if they charged this turn and are contesting the objective wholly within enemy territory.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control the objective wholly within friendly territory.\n\n• Score 2 victory points for each objective on the border of friendly territory that you control.\n\n• Score 5 victory points if you control the objective wholly within enemy territory.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/e32ccafe-0ea0-46fb-93b5-24f673317e3d",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory.\n\nThere are four gold circles indicating objectives: two on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge, and one at the centre of each player's territory."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Focal Points, Shifting Objectives, The Jaws of Gallet and Battle for the Pass."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/02f55d8c-9db3-4e64-a3dc-f51b645bb17e",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/5ad701b1-7b5f-43ce-8377-598c037070c5",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power to the left of the objective on the border between territories, a medium Area Terrain or Obstacle to the left of the objective in their territory, a small Area Terrain or Obstacle slightly above and to the right of the objective in their territory, and a medium Obscuring Terrain in the centre of the rightmost large quarter."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "Two armies approach the same battlefield, determined to capture the vital ground that separates their territories and, if possible, strike deep into enemy territory."
+        }
+      ]
+    },
+    {
+      "id": "418bce02-64c5-52f1-8a95-33512202514b",
+      "name": "Focal Points",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 2 (Table 1)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "At the start of each battle round, after determining which player is the **underdog** and before players use any **Start of Battle Round** abilities, the **underdog** can change the central objective to be a home objective or flank objective until the start of the next battle round.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control at least 1 objective.\n\n• Score 1 victory point if you control 2 or more objectives.\n\n• Score 1 victory point if you control more objectives than your opponent.\n\n• Score 3 victory points if you control 2 or more home objectives and/or 2 or more flank objectives.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/d3e847bb-4e5a-4b11-b67d-12a94378fc62",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves by a line that goes along the top of the most southwesterly small quarter, up the left side and along the top of the small quarter northeast of it, along the bottom and up the right side of the small quarter northeast of that, and along the bottom of the most northeasterly small quarter. The northern section is the attacker's territory; the southern section is the defender's territory. \n\nThere are five gold circles indicating objectives: one labelled Central Objective at the centre of the battlefield; one labelled Home Objective in each player's territory, equidistant from the centre of the battlefield and the long battlefield edge; and two labelled Flank Objective on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/ac44b659-7ea4-420f-a522-42dbff4243f9",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/d03887c2-c5b4-4773-86c6-8b4aa45d06f1",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power on the border between territories diagonally right of the corner of the battlefield, a medium Obscuring Terrain to the left of the Home Objective, a small Area Terrain or Obstacle slightly above and to the right of the Home Objective, and a medium Area Terrain or Obstacle near the centre of the rightmost large quarter."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "At the start of each battle round, after determining which player is the **underdog** and before players use any **Start of Battle Round** abilities, the **underdog** can change the central objective to be a home objective or flank objective until the start of the next battle round.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control at least 1 objective.\n\n• Score 1 victory point if you control 2 or more objectives.\n\n• Score 1 victory point if you control more objectives than your opponent.\n\n• Score 3 victory points if you control 2 or more home objectives and/or 2 or more flank objectives.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/d3e847bb-4e5a-4b11-b67d-12a94378fc62",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves by a line that goes along the top of the most southwesterly small quarter, up the left side and along the top of the small quarter northeast of it, along the bottom and up the right side of the small quarter northeast of that, and along the bottom of the most northeasterly small quarter. The northern section is the attacker's territory; the southern section is the defender's territory. \n\nThere are five gold circles indicating objectives: one labelled Central Objective at the centre of the battlefield; one labelled Home Objective in each player's territory, equidistant from the centre of the battlefield and the long battlefield edge; and two labelled Flank Objective on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Border War, Shifting Objectives, The Jaws of Gallet, Battle for the Pass and The Vice."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/ac44b659-7ea4-420f-a522-42dbff4243f9",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/d03887c2-c5b4-4773-86c6-8b4aa45d06f1",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power on the border between territories diagonally right of the corner of the battlefield, a medium Obscuring Terrain to the left of the Home Objective, a small Area Terrain or Obstacle slightly above and to the right of the Home Objective, and a medium Area Terrain or Obstacle near the centre of the rightmost large quarter."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "In this region, five focal points of geomantic energy are arranged in a square formation. Energy surges between these focal points, and it can be harnessed for use in rituals of awesome power."
+        }
+      ]
+    },
+    {
+      "id": "8296096e-2bff-5946-aece-36a74bb89f47",
+      "name": "Starstrike",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 3 (Table 1)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "At the start of the first battle round, after determining the active player, the active player must set up 1 objective on the boundary between both players’ territories.\n\nAt the start of the third battle round, after determining the active player, the active player must set up 1 objective on each of the long parallel lines in each player’s territories.\n\nTo determine the location of each objective, roll 2D6 and refer to the map below. Roll separately for each objective.\n\nIf an objective would be set up wholly or partially on a faction terrain feature, that terrain feature and any units on it are destroyed, then the objective is set up normally. If the objective would be set up wholly or partially on other terrain features, do not do so. Instead, inflict D6 mortal damage on each unit wholly or partially on that terrain feature (roll separately for each unit). The **underdog** can make the active player re-roll the dice when the mortal damage inflicted on each of the **underdog**’s units is being determined. Then, that terrain feature becomes an **impact site**. Control of an impact site terrain feature (Core Rules, 32.3) counts as control of an objective for the purposes of scoring victory points.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 3 victory points if you control at least 1 objective.\n\n• Score 3 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/8eb2b43e-f997-48b5-b71c-edd3e8dee497",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. The border between territories is labelled Battle Round 1 Objective. The horizontal lines that bisect each player's territory are labelled Battle Round 3 Objective. There are six vertical lines that split the battlefield into eight equal segments; from left to right, these are labelled 2-3, 4-5, 6, 7, 8, 9-10, 11-12."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/e2a1f731-7dc9-446e-b1e4-992bec5eb3a7",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/e93bbadb-d3e5-4e48-a0e3-7e1d1b57225c",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a medium Obscuring Terrain slightly above and to the left of the centre of the leftmost large quarter, a small Area Terrain or Obstacle slightly below and to the right of that, a medium Obscuring Terrain to the left of the centre of the rightmost large quarter, and a small Area Terrain or Obstacle to the right of that."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "At the start of the first battle round, after determining the active player, the active player must set up 1 objective on the boundary between both players’ territories.\n\nAt the start of the third battle round, after determining the active player, the active player must set up 1 objective on each of the long parallel lines in each player’s territories.\n\nTo determine the location of each objective, roll 2D6 and refer to the map below. Roll separately for each objective.\n\nIf an objective would be set up wholly or partially on a faction terrain feature, that terrain feature and any units on it are destroyed, then the objective is set up normally. If the objective would be set up wholly or partially on other terrain features, do not do so. Instead, inflict D6 mortal damage on each unit wholly or partially on that terrain feature (roll separately for each unit). The **underdog** can make the active player re-roll the dice when the mortal damage inflicted on each of the **underdog**’s units is being determined. Then, that terrain feature becomes an **impact site**. Control of an impact site terrain feature (Core Rules, 32.3) counts as control of an objective for the purposes of scoring victory points.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 3 victory points if you control at least 1 objective.\n\n• Score 3 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/8eb2b43e-f997-48b5-b71c-edd3e8dee497",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. The border between territories is labelled Battle Round 1 Objective. The horizontal lines that bisect each player's territory are labelled Battle Round 3 Objective. There are six vertical lines that split the battlefield into eight equal segments; from left to right, these are labelled 2-3, 4-5, 6, 7, 8, 9-10, 11-12."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Border War, Shifting Objectives, The Jaws of Gallet, Battle for the Pass and The Vice."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples: Ruins:** debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/e2a1f731-7dc9-446e-b1e4-992bec5eb3a7",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/e93bbadb-d3e5-4e48-a0e3-7e1d1b57225c",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a medium Obscuring Terrain slightly above and to the left of the centre of the leftmost large quarter, a small Area Terrain or Obstacle slightly below and to the right of that, a medium Obscuring Terrain to the left of the centre of the rightmost large quarter, and a small Area Terrain or Obstacle to the right of that."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "In certain places in the Mortal Realms, the land is bombarded by fragments of magical ore that fall burning from the skies. These remnants of stars are coveted by ambitious warlords, as they can be used to forge deadly blades that will cut through any armour."
+        }
+      ]
+    },
+    {
+      "id": "a38b1932-02b1-5f95-9e30-656eaa2913e7",
+      "name": "Shifting Objectives",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 4 (Table 1)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "At the start of each battle round, after determining the active player, the active player must roll a D3 to determine which objective is the **primary** **objective** for that battle round. The other 2 objectives are the secondary objectives for that battle round.\n\nThe **underdog** can make the active player re-roll the dice to determine which objective is the **primary objective**.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point for each secondary objective that\nyou control.\n\n• Score 2 victory points if you control the **primary objective**.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/f770ca95-1ff6-4a4c-9af4-2509e3bc0e05",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the most northeasterly small quarter and the two small quarters west of it. The defender's territory comprises the most southwesterly small quarter and the two small quarters east of it. The rest is neutral territory. \n\nThere are three gold circles indicating objectives: one labelled with a 1 on the central horizontal line, equidistant from the centre of the battlefield and the western short battlefield edge; one labelled with a 2 at the centre of the battlefield; and one labelled with a 3 on the central horizontal line, equidistant from the centre of the battlefield and the eastern short battlefield edge."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/7b86ed88-d1a2-4f54-82c3-c27ce2ebea79",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/86aa9ffe-9f9d-49a8-bcea-5e68e0e4e52f",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing their territory, from left to right, there is a small Area Terrain or Obstacle on the central horizontal line to the left of the objective, a medium Obscuring Terrain to the right of the centre of the leftmost large quarter, a small Area Terrain or Obstacle diagonally right of the central objective, and a medium Place of Power in the centre of the rightmost large quarter."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "At the start of each battle round, after determining the active player, the active player must roll a D3 to determine which objective is the **primary** **objective** for that battle round. The other 2 objectives are the secondary objectives for that battle round.\n\nThe **underdog** can make the active player re-roll the dice to determine which objective is the **primary objective**.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point for each secondary objective that\nyou control.\n\n• Score 2 victory points if you control the **primary objective**.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/f770ca95-1ff6-4a4c-9af4-2509e3bc0e05",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the most northeasterly small quarter and the two small quarters west of it. The defender's territory comprises the most southwesterly small quarter and the two small quarters east of it. The rest is neutral territory. \n\nThere are three gold circles indicating objectives: one labelled with a 1 on the central horizontal line, equidistant from the centre of the battlefield and the western short battlefield edge; one labelled with a 2 at the centre of the battlefield; and one labelled with a 3 on the central horizontal line, equidistant from the centre of the battlefield and the eastern short battlefield edge."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Border War, Focal Points, The Jaws of Gallet, Battle for the Pass and The Vice."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/7b86ed88-d1a2-4f54-82c3-c27ce2ebea79",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/86aa9ffe-9f9d-49a8-bcea-5e68e0e4e52f",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing their territory, from left to right, there is a small Area Terrain or Obstacle on the central horizontal line to the left of the objective, a medium Obscuring Terrain to the right of the centre of the leftmost large quarter, a small Area Terrain or Obstacle diagonally right of the central objective, and a medium Place of Power in the centre of the rightmost large quarter."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "In order to be successful, a general must learn to react with lightning swiftness to the changing conditions of battle, striking with all their might first in one direction and then in another in order to ensure victory."
+        }
+      ]
+    },
+    {
+      "id": "d8693cf6-b6a8-53f5-81fb-1aeeeaa9bb27",
+      "name": "Feral Foray",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 5 (Table 1)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "At the start of the battle round, each player can raid 1 objective they control in enemy territory. An objective that has been raided cannot be contested or controlled this battle round. The **underdog** can raid an objective in enemy territory that they contest but do not control.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/0683bf22-235a-46d4-8a9c-5e7d41dd0b27",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/ecf7775c-b9c1-4490-9555-903942e8d7ed",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/4e4d28e7-ddf9-4427-9bbf-ba1ca63789f6",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power slightly above and to the left of the leftmost objective, a medium Obscuring Terrain slightly above and to the left of the central objective, a medium Obscuring Terrain slightly below and to the right of the central objective, and a small Area Terrain or Obstacle above the rightmost objective."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "At the start of the battle round, each player can raid 1 objective they control in enemy territory. An objective that has been raided cannot be contested or controlled this battle round. The **underdog** can raid an objective in enemy territory that they contest but do not control.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/0683bf22-235a-46d4-8a9c-5e7d41dd0b27",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for The Better Part of Valour and Close to the Chest."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples: Ruins:** debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/ecf7775c-b9c1-4490-9555-903942e8d7ed",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/4e4d28e7-ddf9-4427-9bbf-ba1ca63789f6",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power slightly above and to the left of the leftmost objective, a medium Obscuring Terrain slightly above and to the left of the central objective, a medium Obscuring Terrain slightly below and to the right of the central objective, and a small Area Terrain or Obstacle above the rightmost objective."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "A major road is littered with the remains of convoys preyed upon by beasts of the wild. Often, supplies remain amidst the ruins, and so two armies have arrived, each seeking to carry off the abandoned loot before their enemy can do the same."
+        }
+      ]
+    },
+    {
+      "id": "75f5c26f-120a-5aee-bd43-b0dafd71f6e0",
+      "name": "The Jaws of Gallet",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 6 (Table 1)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "From the second battle round, at the end of their turn, after scoring victory points, the **underdog** can pick 1 objective. That objective is removed from play. If there is no **underdog**, no objective is removed.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/ea67b4df-64e7-43d6-af77-74b295a2ee6a",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the most northeasterly small quarter, the two small quarters west of it and the two small quarters south of it. The defender's territory comprises the most southwesterly small quarter, the two small quarters east of it and the two small quarters north of it. The rest is neutral territory. \n\nThere are five gold circles indicating objectives: one at the centre of the battlefield and one in the centre of each large quarter."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/90127e8c-49e2-40e4-a2e4-4d439a33e47c",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/360b0786-9f9b-409c-95c0-c74f133ffb89",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a small Area Terrain or Obstacle diagonally right of the corner of the battlefield, a small Area Terrain or Obstacle diagonally left of the central objective, a medium Place of Power diagonally right of the central objective, and a medium Obscuring Terrain on the central horizontal line in their opponent's territory."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "From the second battle round, at the end of their turn, after scoring victory points, the **underdog** can pick 1 objective. That objective is removed from play. If there is no **underdog**, no objective is removed.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/ea67b4df-64e7-43d6-af77-74b295a2ee6a",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the most northeasterly small quarter, the two small quarters west of it and the two small quarters south of it. The defender's territory comprises the most southwesterly small quarter, the two small quarters east of it and the two small quarters north of it. The rest is neutral territory. \n\nThere are five gold circles indicating objectives: one at the centre of the battlefield and one in the centre of each large quarter."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Border War, Focal Points, Shifting Objectives, Battle for the Pass and The Vice."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/90127e8c-49e2-40e4-a2e4-4d439a33e47c",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/360b0786-9f9b-409c-95c0-c74f133ffb89",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a small Area Terrain or Obstacle diagonally right of the corner of the battlefield, a small Area Terrain or Obstacle diagonally left of the central objective, a medium Place of Power diagonally right of the central objective, and a medium Obscuring Terrain on the central horizontal line in their opponent's territory."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "In Ghur, the land itself is possessed of a hungry animus. This is particularly evident in Gallet, where sinkholes open up with perilous frequency, swallowing in moments assets that had been acquired at a steep cost in blood."
+        }
+      ]
+    },
+    {
+      "id": "c85ba719-ea01-56c1-b3b6-2b6168d2594e",
+      "name": "Battle for the Pass",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 1 (Table 2)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "Victory points scored by each player from controlling objectives are capped at a maximum of 6 per turn.\n\nThe **underdog** can add 2 to the control scores of friendly non-**HERO** units.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control the objective wholly within friendly territory.\n\n• Score 2 victory points for each objective on the border of friendly territory that you control.\n\n• Score 5 victory points if you control the objective wholly within enemy territory.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/2bb9d1d3-359d-4576-924b-7c7e989807cf",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the northwestern large quarter and the two small quarters immediately south of it. The defender's territory comprises the southeastern large quarter and the two small quarters immediately north of it. The rest is neutral territory. \n\nThere are four gold circles indicating objectives: two on the central horizontal line, each equidistant from the centre of the battlefield and a different short battlefield edge, and two on the border between territories, each equidistant from the centre of the battlefield and a different long battlefield edge."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/27da7816-f813-43cd-8d96-1e92d6a334a5",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/2673cfb4-9648-4fab-92fc-a2dec91aba12",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a medium Obscuring Terrain in the centre of the leftmost large quarter, a small Place of Power below and to the right of that, a medium Area Terrain or Obstacle diagonally left of the objective in their territory, and a small Area Terrain or Obstacle to the right of the centre of the rightmost large quarter."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "Victory points scored by each player from controlling objectives are capped at a maximum of 6 per turn.\n\nThe **underdog** can add 2 to the control scores of friendly non-**HERO** units.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control the objective wholly within friendly territory.\n\n• Score 2 victory points for each objective on the border of friendly territory that you control.\n\n• Score 5 victory points if you control the objective wholly within enemy territory.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/2bb9d1d3-359d-4576-924b-7c7e989807cf",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the northwestern large quarter and the two small quarters immediately south of it. The defender's territory comprises the southeastern large quarter and the two small quarters immediately north of it. The rest is neutral territory. \n\nThere are four gold circles indicating objectives: two on the central horizontal line, each equidistant from the centre of the battlefield and a different short battlefield edge, and two on the border between territories, each equidistant from the centre of the battlefield and a different long battlefield edge."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Border War, Focal Points, Shifting Objectives, The Jaws of Gallet and The Vice."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/27da7816-f813-43cd-8d96-1e92d6a334a5",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/2673cfb4-9648-4fab-92fc-a2dec91aba12",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a medium Obscuring Terrain in the centre of the leftmost large quarter, a small Place of Power below and to the right of that, a medium Area Terrain or Obstacle diagonally left of the objective in their territory, and a small Area Terrain or Obstacle to the right of the centre of the rightmost large quarter."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "Many kingdoms in the Mortal Realms are separated by towering mountain ranges that can only be navigated by traversing a narrow pass. These defiles are of vital strategic importance, and many blood battles are fought over their control."
+        }
+      ]
+    },
+    {
+      "id": "9e18d973-2850-5e5a-b7f4-b21c38f22bd2",
+      "name": "Scorched Earth",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 2 (Table 2)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "From the second battle round, at the end of their turn, after scoring victory points, the active player can pick 1 objective that is wholly within enemy territory, that they control and that is being contested by any of their units. That objective is removed from play.\n\nAt the start of each battle round, the **underdog** can pick 1 objective in their territory that they control. Until the end of that battle round, they can subtract 5 from the control scores of enemy units contesting that objective, to a minimum of 1.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/7c799158-635f-48f3-bae5-fe08710c6a1e",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/806acd3c-cf33-48d2-9704-7eb77fd29a4b",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/f04bcc98-3d5f-4187-8173-68c4e1ff04ab",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Obscuring Terrain slightly below and to the right of the leftmost objective, a medium Area Terrain or Obstacle halfway between the two centre-most objectives, a medium Obscuring Terrain slightly above and to the left of the rightmost objective, and a small Area Terrain or Obstacle above the rightmost objective."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "From the second battle round, at the end of their turn, after scoring victory points, the active player can pick 1 objective that is wholly within enemy territory, that they control and that is being contested by any of their units. That objective is removed from play.\n\nAt the start of each battle round, the **underdog** can pick 1 objective in their territory that they control. Until the end of that battle round, they can subtract 5 from the control scores of enemy units contesting that objective, to a minimum of 1.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/7c799158-635f-48f3-bae5-fe08710c6a1e",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+          }
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/806acd3c-cf33-48d2-9704-7eb77fd29a4b",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/f04bcc98-3d5f-4187-8173-68c4e1ff04ab",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Obscuring Terrain slightly below and to the right of the leftmost objective, a medium Area Terrain or Obstacle halfway between the two centre-most objectives, a medium Obscuring Terrain slightly above and to the left of the rightmost objective, and a small Area Terrain or Obstacle above the rightmost objective."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "Sometimes battles are fought not to destroy the enemy but to seize their resources and carry them off. Raiding parties will strike into enemy territory, capturing an objective and searching for any hidden treasures, before razing what remains to the ground to deny its use to the enemy."
+        }
+      ]
+    },
+    {
+      "id": "6d6df7e0-74a4-5882-bb4d-ff545094d225",
+      "name": "The Better Part of Valour",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 3 (Table 2)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "Each time an enemy unit contesting an objective is destroyed by a **FIGHT** ability used by a friendly non-**HERO** unit contesting the same objective, that friendly unit gains the **DOMINANT** keyword. If that friendly unit stops contesting that objective, it is no longer **DOMINANT**.\n\nAdd 10 to the control scores of **DOMINANT** units.\n\nAdd 1 to hit rolls for combat attacks made by units in the **underdog’s** army that target a **DOMINANT** unit.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/e0bc86e8-88d0-4c7a-afb6-309c462ba634",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/60b382eb-05e9-42e6-989c-11343a9bce64",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/19d42f46-a673-4f65-a760-37d0189f8c0b",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle slightly below and to the left of the leftmost objective, a medium Place of Power slightly above and to the left of the central objective, a medium Obscuring Terrain slightly below and to the right of the central objective, and a small Area Terrain or Obstacle slightly above and to the right of the rightmost objective."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "Each time an enemy unit contesting an objective is destroyed by a **FIGHT** ability used by a friendly non-**HERO** unit contesting the same objective, that friendly unit gains the **DOMINANT** keyword. If that friendly unit stops contesting that objective, it is no longer **DOMINANT**.\n\nAdd 10 to the control scores of **DOMINANT** units.\n\nAdd 1 to hit rolls for combat attacks made by units in the **underdog’s** army that target a **DOMINANT** unit.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/e0bc86e8-88d0-4c7a-afb6-309c462ba634",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Feral Foray and Close to the Chest."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins: debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/60b382eb-05e9-42e6-989c-11343a9bce64",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/19d42f46-a673-4f65-a760-37d0189f8c0b",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle slightly below and to the left of the leftmost objective, a medium Place of Power slightly above and to the left of the central objective, a medium Obscuring Terrain slightly below and to the right of the central objective, and a small Area Terrain or Obstacle slightly above and to the right of the rightmost objective."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "It is important to learn when to hold on in order to ensure victory and when to fall back in the face of unbeatable odds. A battle can be decided by the general who is most capable of resolving this difficult dilemma."
+        }
+      ]
+    },
+    {
+      "id": "61dce481-7a15-53ae-aec7-8ea1260f1567",
+      "name": "The Vice",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 4 (Table 2)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "At the start of the second battle round, after determining which player is the active player, the active player must remove the 4 starting objectives and set up a new objective at each of the next locations shown on the map.\n\nAt the start of the fourth battle round, after determining which player is the active player, the active player must remove the 4 objectives and set up 1 new objective in the location shown in the centre of the map.\n\nAt the end of their turn, the **underdog** can pick 1 objective. Inflict D3 mortal damage on each unit contesting that objective (roll separately for each unit).\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• In battle rounds 4 and 5 only, score 2 victory points if there are no enemy units within 6\" of the remaining objective.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/19cab5dc-e0bb-4ac5-aebb-ca04b5f6722d",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are four gold circles, one on each corner of the battlefield, indicating starting objectives. There are arrows pointing diagonally from each corner of the battlefield to a semi-transparent gold circle at the centre of each large quarter, then there are arrows pointing diagonally from the centre of each large quarter to a semi-transparent gold circle at the centre of the battlefield."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/4fae63b5-8e88-4727-bc6a-3e70f616555a",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/2e543171-961c-4408-b176-8999bcbf9f88",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle slightly below and to the left of the centre of the leftmost large quarter, a medium Area Terrain or Obstacle diagonally left of the centre of the battlefield, a small Place of Power diagonally right of the centre of the battlefield, and a medium Obscuring Terrain on the border between territories, diagonally right of the centre of the rightmost large quarter."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "At the start of the second battle round, after determining which player is the active player, the active player must remove the 4 starting objectives and set up a new objective at each of the next locations shown on the map.\n\nAt the start of the fourth battle round, after determining which player is the active player, the active player must remove the 4 objectives and set up 1 new objective in the location shown in the centre of the map.\n\nAt the end of their turn, the **underdog** can pick 1 objective. Inflict D3 mortal damage on each unit contesting that objective (roll separately for each unit).\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• In battle rounds 4 and 5 only, score 2 victory points if there are no enemy units within 6\" of the remaining objective.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/19cab5dc-e0bb-4ac5-aebb-ca04b5f6722d",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are four gold circles, one on each corner of the battlefield, indicating starting objectives. There are arrows pointing diagonally from each corner of the battlefield to a semi-transparent gold circle at the centre of each large quarter, then there are arrows pointing diagonally from the centre of each large quarter to a semi-transparent gold circle at the centre of the battlefield."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Border War, Focal Points, Shifting Objectives, The Jaws of Gallet and Battle for the Pass."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/4fae63b5-8e88-4727-bc6a-3e70f616555a",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/2e543171-961c-4408-b176-8999bcbf9f88",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle slightly below and to the left of the centre of the leftmost large quarter, a medium Area Terrain or Obstacle diagonally left of the centre of the battlefield, a small Place of Power diagonally right of the centre of the battlefield, and a medium Obscuring Terrain on the border between territories, diagonally right of the centre of the rightmost large quarter."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "Two forces have come to blows amidst the shadows of an ancient crevasse. As the battle unfolds, both generals discover that the chasm is gradually closing in around them. Victory here must be swift for any hope of escape."
+        }
+      ]
+    },
+    {
+      "id": "85e0d19a-e312-502a-8cab-b0da8902f980",
+      "name": "Close to the Chest",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 5 (Table 2)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "At the start of each turn, the player who is not the active player must pick 1 objective in their territory to be the **primary objective** until the start of the next turn.\n\nAt the start of their turn, after their opponent has picked the **primary objective**, the **underdog** can roll a dice. On a 5+, their opponent must pick a different objective to be the **primary objective** for that turn.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control at least 1 objective.\n\n• Score 1 victory point if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 2 victory points if you control the **primary objective**.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/ca7834e2-3994-40e5-adf0-0dc016d91223",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the northwestern large quarter, the two small quarters immediately east of it and the small quarter north of the most southwesterly small quarter. The defender's territory comprises the southeastern large quarter, the two small quarters immediately west of it and the small quarter south of the most northeasterly small quarter. The rest is neutral territory. \n\nThere are six gold circles indicating objectives: two on the central vertical line, each equidistant from the centre of the battlefield and a different long battlefield edge, and one in the centre of each large quarter."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/eff3d22d-70f4-4f6d-976e-3e1293adbde7",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/fd94a466-dd04-452b-a108-55891b018785",
+          "altText": "The battlefield terrain layout map.It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a medium Obscuring Terrain on the central horizontal line, left of the centre of the leftmost large quarter; a small Obscuring Terrain slightly below and to the left of the central objective; a medium Place of Power slightly above and to the right of the central objective; and a small Area Terrain or Obstacle diagonally left of the corner of the battlefield."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "At the start of each turn, the player who is not the active player must pick 1 objective in their territory to be the **primary objective** until the start of the next turn.\n\nAt the start of their turn, after their opponent has picked the **primary objective**, the **underdog** can roll a dice. On a 5+, their opponent must pick a different objective to be the **primary objective** for that turn.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control at least 1 objective.\n\n• Score 1 victory point if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 2 victory points if you control the **primary objective**.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/ca7834e2-3994-40e5-adf0-0dc016d91223",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the northwestern large quarter, the two small quarters immediately east of it and the small quarter north of the most southwesterly small quarter. The defender's territory comprises the southeastern large quarter, the two small quarters immediately west of it and the small quarter south of the most northeasterly small quarter. The rest is neutral territory. \n\nThere are six gold circles indicating objectives: two on the central vertical line, each equidistant from the centre of the battlefield and a different long battlefield edge, and one in the centre of each large quarter."
+          }
+        },
+        {
+          "type": "text",
+          "text": "This map layout can also be used for Feral Foray and The Better Part of Valour."
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/eff3d22d-70f4-4f6d-976e-3e1293adbde7",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/fd94a466-dd04-452b-a108-55891b018785",
+            "altText": "The battlefield terrain layout map.It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a medium Obscuring Terrain on the central horizontal line, left of the centre of the leftmost large quarter; a small Obscuring Terrain slightly below and to the left of the central objective; a medium Place of Power slightly above and to the right of the central objective; and a small Area Terrain or Obstacle diagonally left of the corner of the battlefield."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "This vast cavern is rich in treasures, though your learned advisors inform you that some are more valuable than others. Seize what you can, and make use of your runners to ensure that the most lucrative artefacts do not fall into the enemy’s hands."
+        }
+      ]
+    },
+    {
+      "id": "add6caf4-f3c4-509a-a241-efae6cc16e17",
+      "name": "Limited Resources",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 6 (Table 2)",
+      "section": "Battleplans",
+      "twist": {
+        "text": "Twist",
+        "abilities": []
+      },
+      "scoring": "When a player gains control of an objective, they start to extract resources from it. After scoring victory points, if the active player controls an objective that they controlled at the end of their previous turn, they have extracted all the resources from that objective. For the rest of the battle, that player cannot control that objective.\n\nOnce a player has extracted all of the resources from an objective, they can still contest it to prevent their opponent from controlling it, but they do not and cannot control it themselves.\n\nThe **underdog** can add 3 to the control scores of friendly units that are contesting an objective from which they are extracting resources.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/a254b296-1874-47ba-8d43-e525e16e134f",
+          "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: two on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge; two on the horizontal line bisecting the attacker's territory, northeast of the objectives on the border between territories; and two on the horizontal line bisecting the defender's territory, southwest of the objectives on the border between territories."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/17f2be86-7224-4450-84e5-7c8343454ea6",
+          "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/7d6fe428-50d3-48d5-8fe3-11e5f8ba5e8a",
+          "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle above the leftmost objective, a medium Area Terrain or Obstacle halfway between both objectives in their territory, a small Area Terrain or Obstacle slightly above and to the right of that, and a medium Obscuring Terrain in the centre of the rightmost large quarter."
+        }
+      ],
+      "components": [
+        {
+          "type": "header",
+          "text": "Twist"
+        },
+        {
+          "type": "text",
+          "text": "When a player gains control of an objective, they start to extract resources from it. After scoring victory points, if the active player controls an objective that they controlled at the end of their previous turn, they have extracted all the resources from that objective. For the rest of the battle, that player cannot control that objective.\n\nOnce a player has extracted all of the resources from an objective, they can still contest it to prevent their opponent from controlling it, but they do not and cannot control it themselves.\n\nThe **underdog** can add 3 to the control scores of friendly units that are contesting an objective from which they are extracting resources.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/a254b296-1874-47ba-8d43-e525e16e134f",
+            "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: two on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge; two on the horizontal line bisecting the attacker's territory, northeast of the objectives on the border between territories; and two on the horizontal line bisecting the defender's territory, southwest of the objectives on the border between territories."
+          }
+        },
+        {
+          "type": "header",
+          "text": "Area Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+        },
+        {
+          "type": "header",
+          "text": "Obstacles"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Obscuring Terrain"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Places of Power"
+        },
+        {
+          "type": "text",
+          "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+        },
+        {
+          "type": "header",
+          "text": "Key"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/17f2be86-7224-4450-84e5-7c8343454ea6",
+            "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/7d6fe428-50d3-48d5-8fe3-11e5f8ba5e8a",
+            "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle above the leftmost objective, a medium Area Terrain or Obstacle halfway between both objectives in their territory, a small Area Terrain or Obstacle slightly above and to the right of that, and a medium Obscuring Terrain in the centre of the rightmost large quarter."
+          }
+        },
+        {
+          "type": "loreAccordion",
+          "title": "Lore",
+          "text": "Wracked with lightning and viridian fire, the realms suffer for the clashing of their denizens. Resources dwindle, burnt away or stolen by perfidious ratmen. The little that remains is a tantalising prize indeed. For your armies to thrive and your goals to be furthered, you must march deep into the ravaged lands and seize what is rightfully yours."
+        }
+      ]
+    }
+  ],
+  "battleTacticCards": [],
+  "sections": [
+    {
+      "id": "2d77551c-8e06-56a3-90e3-7197d1145a6c",
+      "name": "The Player's Code",
+      "containers": [
+        {
+          "id": "e15f7452-a3e5-5465-a299-ca3ecfdc0c6a",
+          "title": "Cardinal Rules",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "bullets"
+            }
+          ]
+        },
+        {
+          "id": "f137f1aa-446b-5523-9dfa-36ca8a8e0733",
+          "title": "Principles",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "bullets"
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "e8ad4f58-19b5-54c7-a8dd-ec1f06ea5d59",
+      "name": "Matched Play Battlepack",
+      "containers": [
+        {
+          "id": "83110c29-9df7-5187-89b7-658b94b9b1de",
+          "title": "1. Pick Your Armies",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Each player picks an army using the rules in Army Composition (Advanced Rules)."
+            }
+          ]
+        },
+        {
+          "id": "b2725c4c-e5c1-5464-8fd1-fc12ac4d1285",
+          "title": "2. Determine the Battleplan",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "One player rolls a dice to determine which battleplan table to use. On a 1-3, use battleplan table 1. On a 4-6, use battleplan table 2. The other player then rolls a dice to determine the battleplan. Alternatively, feel free to pick the battleplan you wish to play."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/12e5a720-4a3e-440b-ba8a-c048ac7d5f02",
+                "altText": "Two tables labelled battleplan table 1 and battleplan table 2. Each table has two columns with the headers D6 and Battleplan. \n\nBattleplan table 1 has six rows as follows: 1, Border War. 2, Focal Points. 3, Starstrike. 4, Shifting Objectives. 5, Feral Foray. 6, The Jaws of Gallet.\n\nBattleplan table 2 has six rows as follows: 1, Battle for the Pass. 2, Scorched Earth. 3, The Better Part of Valour. 4, The Vice. 5, Close to the Chest. 6, Limited Resources."
+              }
+            }
+          ]
+        },
+        {
+          "id": "73dc5912-128a-5e60-a5e4-441e09e54428",
+          "title": "3. Set up the Battlefield",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "The players roll off. The winner chooses which player is the **attacker** and which is the **defender**.\n\nNext, the defender sets up objectives in the locations indicated by gold circles on the battlefield map. Then, the defender sets up terrain features. We recommend 4 small and 4 medium terrain features. Each terrain feature must be set up more than 3\" from the battlefield edge, more than 3\" from all objectives and more than 6\" from all other terrain features. Alternatively, the battlefield can be set up as shown on the corresponding battlefield terrain layout map while maintaining the distance restrictions between the battlefield edge, objectives and other terrain features as detailed above.\n\nAfter objectives and terrain have been set up, the attacker picks which territory is their territory. The other territory is the defender’s territory. The players then resolve the deployment phase. The attacker begins deployment (Core Rules, 10.0)."
+            }
+          ]
+        },
+        {
+          "id": "5ef53eb2-6f6c-516a-b815-cebc522a1347",
+          "title": "Battle Length",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Battles that use this battlepack last for 5 battle rounds."
+            }
+          ]
+        },
+        {
+          "id": "235eca05-2b27-54e7-8ad5-7fe3d87a8f15",
+          "title": "Glorious Victory",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Each battleplan will describe how to score victory points. At the end of the battle, if one player has at least 5 victory points more than their opponent, they win a **major victory**. If one player has fewer than 5 more victory points than their opponent, they win a **minor victory**. If the players are tied on victory points, the player who completed the most battle tactics wins a **minor victory**. If the players are tied on victory points and completed the same number of battle tactics, the battle is a **draw**."
+            }
+          ]
+        },
+        {
+          "id": "c5812915-9170-5ae5-a5a1-84a88b23ddfc",
+          "title": "Battle Tactics",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "If you are using this battlepack, when picking battle tactics to attempt, you must pick from the battle tactics in this battlepack.\n\nWhen you pick a battle tactic, you must reveal your choice to your opponent. If the battle tactic instructs you to pick something, you must tell your opponent what you pick. You cannot pick the same battle tactic more than once per battle.\n\nIf a battle tactic has a Grand Alliance keyword (**ORDER, CHAOS, DEATH, DESTRUCTION**), you cannot pick that battle tactic unless your general has that keyword."
+            }
+          ]
+        },
+        {
+          "id": "e01c6e57-f7c3-5bad-bbb7-0d47c22a235b",
+          "title": "Advanced Rules",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "In addition to the Core Rules and the Season Rules 2024-25, this battlepack uses the following Advanced Rules:\n\n• Commands\n• Terrain\n• Magic\n• Army Composition\n• Command Models\n• Battle Tactics"
+            }
+          ]
+        },
+        {
+          "id": "7366a08e-980f-5ce4-8271-f330ffc6eb58",
+          "title": "Battlefield Size",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "The battleplans in the Battleplan section have been designed for 1000 or 2000 point battles.\n\nFor a 1000 point battle, we recommend a **30\" × 44\"** battlefield with **4** terrain features.\n\nFor a 2000 point battle, we recommend a **44\" × 60\"** battlefield with **8** terrain features.\n\nIf you have agreed on a points limit outside these bounds, feel free to adjust the battlefield size and number of terrain features appropriately."
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "966e5b22-91aa-5189-b343-f67ae3a37fb5",
+      "name": "Matched Play Publications 2024-25",
+      "containers": [
+        {
+          "id": "a2d0771d-5632-5f91-970a-c13f1e1cea01",
+          "title": "Introduction",
+          "subtitle": null,
+          "containerType": "introduction",
+          "components": [
+            {
+              "type": "text",
+              "text": "As Warhammer Age of Sigmar continues to grow, naturally, we will continue to write rules for the game. However, when you are playing competitively, sometimes it’s hard to know which of these rules are ‘legal’ – in other words, which rules you can use in Matched Play battles. On this page, we’ve provided a handy at-a-glance list that shows you all the publications whose rules you are allowed to use in Matched Play battles."
+            }
+          ]
+        },
+        {
+          "id": "9dd74609-50c3-5f22-8fa0-a0d49db1f3a2",
+          "title": "Core",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "textItalic",
+              "text": "• Warhammer Age of Sigmar Core Book\n• General’s Handbook 2024-25\n• Warhammer Age of Sigmar Faction Packs \n• Battle Profiles 2024-25"
+            }
+          ]
+        },
+        {
+          "id": "eb0c2ba7-c0ea-5a87-8839-9a6360daedd6",
+          "title": "Battletomes",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Throughout this edition of Warhammer Age of Sigmar, we will be releasing battletomes for each faction. Battletomes contain additional and/or updated faction rules, which include battle traits, battle formations and enhancements. When a battletome is released, it will supersede the rules set out in the Faction Pack for that faction.\n\nOccasionally, we release a battletome in a box with a selection of new and existing miniatures from that faction. We call these boxes ‘army sets’, and these can be available to purchase before the battletome and the new miniatures go on sale separately. To ensure a level playing field, a battletome released in an army set will not be legal to use in Warhammer Age of Sigmar Matched Play battles until that battletome is on general sale. This also means that the single-use code found in the battletome that grants access to the faction’s data on the Warhammer Age of Sigmar app will not work until the battletome is on general sale."
+            }
+          ]
+        },
+        {
+          "id": "87afa6b7-1408-50b6-b028-6424c7975ee7",
+          "title": "Digital Updates",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "We sometimes release digital updates on warhammer-community.com. When we do, we will say whether that rules set is legal for use and, if so, in which types of battlepacks it can be used."
+            }
+          ]
+        },
+        {
+          "id": "9e37fb4e-491f-5c67-80fa-b857e5547052",
+          "title": "Battlescrolls",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Battlescrolls are rules updates that focus on balancing the game meta more actively. Sometimes they are simply useful summaries of corrections that also appear in the relevant errata documents. At other times, they appear as sets of entirely new rules that, while not compulsory, are highly recommended for use in Matched Play battles. The rules in battlescrolls will always be used at official Warhammer Age of Sigmar events."
+            }
+          ]
+        },
+        {
+          "id": "41b1d15c-684f-5107-a45c-d165cb1d4f1c",
+          "title": "Errata",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Periodically, we release errata documents for our publications that correct any errors. These include things like outright mistakes, rules that didn’t quite work the way we intended them to, and rules that have had an unforeseen and undesirable impact on the game meta. The errata documents are considered to be part of the publications that they are correcting, so we don’t list them separately here."
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "182019a5-e6be-5631-a785-bab52f35e85c",
+      "name": "Season Rules 2024-25",
+      "containers": [
+        {
+          "id": "2e09dbf2-7c71-5405-a557-a3d8ee337fd7",
+          "title": "Taking a Double Turn",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "If the player who went second in the previous battle round wins the priority roll and chooses to go first, this is called ‘taking a double turn’.\n\n**Seizing The Initiative**\nWhen a player takes a double turn **and** they are **not** behind by 6 or more victory points, this is called ‘seizing the initiative’. The first time in a battle that a player seizes the initiative, the rules for determining the underdog change: for the rest of the battle, the underdog is always the opponent of the player who most recently seized the initiative.\n\n**Battle Tactics**\nPlayers who take a double turn while they are behind by 6 or more victory points can still use the ‘Tactical Gambit’ ability to pick a battle tactic."
+            }
+          ]
+        },
+        {
+          "id": "563578a8-4661-5cf2-a6e9-0d2c729206cf",
+          "title": "Honour Guard",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Each player can use one of the following **HONOUR GUARD** abilities in each battle. When using that ability, they must pick a unit in their general’s regiment to be the honour guard.\n\n**Regimented Forces**\nIf a player has more regiments than their opponent, they can use a second, different **HONOUR GUARD** ability, but they must pick a unit that is in a different regiment that is not led by the general to be the **honour guard** for that ability. You cannot pick units in a Regiment of Renown to be an honour guard. If you chose not to pick an **honour guard** unit in your general’s regiment, you can still pick an honour guard unit for a different regiment as described above."
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "*A wise general surrounds themselves with trusted veterans, warriors whose battlefield exploits are renowned amongst their peers.*"
+            },
+            {
+              "type": "ability",
+              "ability": {
+                "id": "f45d6541-ca08-5b18-8a11-86c67c0ce229",
+                "name": "Special Assignment",
+                "phase": "startOfTurn",
+                "phaseDetails": "Once Per Battle, Deployment Phase",
+                "icon": "special",
+                "cpCost": null,
+                "declare": "Pick a friendly unit in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                "effect": "Pick 1 of the following weapon abilities:\n\n• **Anti-INFANTRY (+1 Rend)**\n• **Anti-CAVALRY (+1 Rend)**\n• **Anti-MONSTER (+1 Rend)**\n• **Anti-WAR MACHINE (+1 Rend)**\n• **Anti-BEAST (+1 Rend)**\n\nIn any turn in which that **honour guard** charged, that unit’s melee weapons have the weapon ability you picked.",
+                "usedBy": null,
+                "additionalRulesText": null,
+                "keywords": ["Honour Guard"]
+              }
+            },
+            {
+              "type": "ability",
+              "ability": {
+                "id": "315604ee-c191-570a-8d9e-b80d739442a9",
+                "name": "Priority Target",
+                "phase": "startOfTurn",
+                "phaseDetails": "Once Per Battle, Deployment Phase",
+                "icon": "offensive",
+                "cpCost": null,
+                "declare": "Pick a friendly unit in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                "effect": "Add 1 to hit rolls and wound rolls for attacks made by that **honour guard** unit that target the enemy general, or the enemy **honour guard** if it is in the enemy general’s regiment, if the target of the attack is within 12\".",
+                "usedBy": null,
+                "additionalRulesText": null,
+                "keywords": ["Honour Guard"]
+              }
+            },
+            {
+              "type": "ability",
+              "ability": {
+                "id": "2654418e-c81a-5175-b0cb-179a9bdc4486",
+                "name": "Bodyguard",
+                "phase": "startOfTurn",
+                "phaseDetails": "Once Per Battle, Deployment Phase",
+                "icon": "offensive",
+                "cpCost": null,
+                "declare": "Pick a friendly unit in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                "effect": "Subtract 1 from the Attacks characteristic of enemy units’ melee weapons while they are in combat with the unit leading that regiment if both of the following are true:\n• That regiment’s **honour guard** is wholly within 6\" of the leader of that regiment.\n• Neither that regiment’s **honour guard** nor the regiment’s leader charged this turn.",
+                "usedBy": null,
+                "additionalRulesText": null,
+                "keywords": ["Honour Guard"]
+              }
+            },
+            {
+              "type": "ability",
+              "ability": {
+                "id": "c8103acd-6aea-5d63-a982-b51ae623c1b5",
+                "name": "Field Sergeant",
+                "phase": "startOfTurn",
+                "phaseDetails": "Once Per Battle, Deployment Phase",
+                "icon": "movement",
+                "cpCost": null,
+                "declare": "Pick a friendly non-**FLY** **INFANTRY HERO** in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                "effect": "Add 2\" to the Move characteristic of friendly non-**FLY INFANTRY** units while they are wholly within 12\" of the **honour guard**.",
+                "usedBy": null,
+                "additionalRulesText": null,
+                "keywords": ["Honour Guard"]
+              }
+            },
+            {
+              "type": "ability",
+              "ability": {
+                "id": "2829316c-7135-580a-a9f3-c1734ffea3d7",
+                "name": "Prized Beast",
+                "phase": "startOfTurn",
+                "phaseDetails": "Once Per Battle, Deployment Phase",
+                "icon": "special",
+                "cpCost": null,
+                "declare": "Pick a friendly non-**UNIQUE MONSTER** unit that has not been reinforced and which is in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                "effect": "That unit can ignore the effects of the ‘Battle Damaged’ ability. In addition, add 1 to hit rolls for combat attacks made by the **honour guard**. This ability also affects **Companion** weapons.",
+                "usedBy": null,
+                "additionalRulesText": null,
+                "keywords": ["Honour Guard"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "30bf98bd-8660-580d-84da-44ac0696e715",
+          "title": "Universal Battle Tactics",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "accordion",
+              "title": "Do Not Waver",
+              "text": "You complete this battle tactic at the end of your turn if 2 or more friendly units fought this turn and no friendly units were destroyed this turn."
+            },
+            {
+              "type": "accordion",
+              "title": "Take Their Land",
+              "text": "Pick a terrain feature wholly or partially within enemy territory and wholly outside friendly territory. You complete this battle tactic if you control that terrain feature at the end of your turn."
+            },
+            {
+              "type": "accordion",
+              "title": "Slay the Entourage",
+              "text": "Pick a unit in the enemy general’s regiment. You complete this battle tactic if that unit is destroyed this turn."
+            },
+            {
+              "type": "accordion",
+              "title": "Seize the Centre",
+              "text": "You complete this battle tactic at the end of your turn if 2 or more friendly units are within 3\" of the centre of the battlefield and are not in combat."
+            },
+            {
+              "type": "accordion",
+              "title": "Attack on Two Fronts",
+              "text": "You complete this battle tactic at the end of your turn if you control 2 or more objectives that you did not control at the start of your turn and at least 1 of those objectives was controlled by your opponent at the start of your turn."
+            },
+            {
+              "type": "accordion",
+              "title": "Take the Flanks",
+              "text": "You complete this battle tactic at the end of your turn if you have at least 1 friendly unit within 6\" of each short battlefield edge, none of those units are wholly within friendly territory, and none of those units were set up this turn."
+            }
+          ]
+        },
+        {
+          "id": "0d8cc040-7dc0-5cb4-a3be-08629bc4b36d",
+          "title": "Order Battle Tactics",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "accordion",
+              "title": "Reclaim the Realms",
+              "text": "You complete this battle tactic at the end of your turn if there are 1 or more friendly units wholly within each quarter of the battlefield and more than 6\" from all enemy units.\n\n**Keywords: ORDER**"
+            },
+            {
+              "type": "accordion",
+              "title": "Slay the Tyrants",
+              "text": "You complete this battle tactic at the end of your turn if an enemy **HERO** was slain this turn by a combat attack made by a friendly unit.\n\n**Keywords: ORDER**"
+            }
+          ]
+        },
+        {
+          "id": "35d06f56-49c3-51b0-a653-cce3c98c5341",
+          "title": "Chaos Battle Tactics",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "accordion",
+              "title": "Offering of Carnage",
+              "text": "You complete this battle tactic at the end of your turn if 2 or more enemy units were destroyed this turn.\n\n**Keywords: CHAOS**"
+            },
+            {
+              "type": "accordion",
+              "title": "Ordained Charge",
+              "text": "Pick an objective controlled by your opponent. You complete this battle tactic at the end of your turn if 2 or more friendly units charged this turn, 1 or more of those units are contesting that objective, and you control that objective.\n\n**Keywords: CHAOS**"
+            }
+          ]
+        },
+        {
+          "id": "7870ea0a-e18a-56ed-9aab-16d4fe799a33",
+          "title": "Death Battle Tactics",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "accordion",
+              "title": "Marked for the Grave",
+              "text": "Pick a non-**HERO** enemy unit that has not had any models slain this battle. If there are no non-**HERO** enemy units on the battlefield, you can pick any enemy unit. You complete this battle tactic at the end of your turn if that unit is destroyed this turn.\n\n**Keywords: DEATH**"
+            },
+            {
+              "type": "accordion",
+              "title": "Inevitable Demise",
+              "text": "You complete this battle tactic at the end of your turn if 2 or more friendly units are wholly within enemy territory and more than 9\" from all enemy units, and none of those units were set up this turn.\n\n**Keywords: DEATH**"
+            }
+          ]
+        },
+        {
+          "id": "59572051-ab60-594f-b4f2-624eb5eebb6b",
+          "title": "Destruction Battle Tactics",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "accordion",
+              "title": "Time to get Stuck in!",
+              "text": "Pick 3 friendly units that are not in combat and are wholly within friendly territory. You complete this battle tactic at the end of your turn if each of those units is wholly outside your territory and used a **FIGHT** ability this turn.\n\n**Keywords: DESTRUCTION**"
+            },
+            {
+              "type": "accordion",
+              "title": "The Kunnin' Approach",
+              "text": "Pick an enemy unit that is in combat and a friendly unit that is not in combat. You complete this battle tactic at the end of your turn if that friendly unit was in combat with that enemy unit this turn and that enemy unit was destroyed this turn.\n\n**Keywords: DESTRUCTION**"
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "58123bb3-2b4a-5d69-90ce-7f54b3d2f8a9",
+      "name": "Battleplans",
+      "containers": [
+        {
+          "id": "6335c8a6-2503-5e3a-817f-1a8541af23e2",
+          "title": "Border War",
+          "subtitle": "Battleplan 1 (Table 1)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "Victory points scored by each player from controlling objectives are capped at a maximum of 6 per turn.\n\nAdd 1 to hit rolls for units in the **underdog**’s army if they charged this turn and are contesting the objective wholly within enemy territory.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control the objective wholly within friendly territory.\n\n• Score 2 victory points for each objective on the border of friendly territory that you control.\n\n• Score 5 victory points if you control the objective wholly within enemy territory.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/e32ccafe-0ea0-46fb-93b5-24f673317e3d",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory.\n\nThere are four gold circles indicating objectives: two on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge, and one at the centre of each player's territory."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Focal Points, Shifting Objectives, The Jaws of Gallet and Battle for the Pass."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/02f55d8c-9db3-4e64-a3dc-f51b645bb17e",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/5ad701b1-7b5f-43ce-8377-598c037070c5",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power to the left of the objective on the border between territories, a medium Area Terrain or Obstacle to the left of the objective in their territory, a small Area Terrain or Obstacle slightly above and to the right of the objective in their territory, and a medium Obscuring Terrain in the centre of the rightmost large quarter."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Two armies approach the same battlefield, determined to capture the vital ground that separates their territories and, if possible, strike deep into enemy territory."
+            }
+          ]
+        },
+        {
+          "id": "f312d061-e471-5325-b865-f24e24da79c2",
+          "title": "Focal Points",
+          "subtitle": "Battleplan 2 (Table 1)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "At the start of each battle round, after determining which player is the **underdog** and before players use any **Start of Battle Round** abilities, the **underdog** can change the central objective to be a home objective or flank objective until the start of the next battle round.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control at least 1 objective.\n\n• Score 1 victory point if you control 2 or more objectives.\n\n• Score 1 victory point if you control more objectives than your opponent.\n\n• Score 3 victory points if you control 2 or more home objectives and/or 2 or more flank objectives.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/d3e847bb-4e5a-4b11-b67d-12a94378fc62",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves by a line that goes along the top of the most southwesterly small quarter, up the left side and along the top of the small quarter northeast of it, along the bottom and up the right side of the small quarter northeast of that, and along the bottom of the most northeasterly small quarter. The northern section is the attacker's territory; the southern section is the defender's territory. \n\nThere are five gold circles indicating objectives: one labelled Central Objective at the centre of the battlefield; one labelled Home Objective in each player's territory, equidistant from the centre of the battlefield and the long battlefield edge; and two labelled Flank Objective on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Border War, Shifting Objectives, The Jaws of Gallet, Battle for the Pass and The Vice."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/ac44b659-7ea4-420f-a522-42dbff4243f9",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/d03887c2-c5b4-4773-86c6-8b4aa45d06f1",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power on the border between territories diagonally right of the corner of the battlefield, a medium Obscuring Terrain to the left of the Home Objective, a small Area Terrain or Obstacle slightly above and to the right of the Home Objective, and a medium Area Terrain or Obstacle near the centre of the rightmost large quarter."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "In this region, five focal points of geomantic energy are arranged in a square formation. Energy surges between these focal points, and it can be harnessed for use in rituals of awesome power."
+            }
+          ]
+        },
+        {
+          "id": "33fa9c4b-f239-5dea-8375-3e2e2be4c3d9",
+          "title": "Starstrike",
+          "subtitle": "Battleplan 3 (Table 1)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "At the start of the first battle round, after determining the active player, the active player must set up 1 objective on the boundary between both players’ territories.\n\nAt the start of the third battle round, after determining the active player, the active player must set up 1 objective on each of the long parallel lines in each player’s territories.\n\nTo determine the location of each objective, roll 2D6 and refer to the map below. Roll separately for each objective.\n\nIf an objective would be set up wholly or partially on a faction terrain feature, that terrain feature and any units on it are destroyed, then the objective is set up normally. If the objective would be set up wholly or partially on other terrain features, do not do so. Instead, inflict D6 mortal damage on each unit wholly or partially on that terrain feature (roll separately for each unit). The **underdog** can make the active player re-roll the dice when the mortal damage inflicted on each of the **underdog**’s units is being determined. Then, that terrain feature becomes an **impact site**. Control of an impact site terrain feature (Core Rules, 32.3) counts as control of an objective for the purposes of scoring victory points.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 3 victory points if you control at least 1 objective.\n\n• Score 3 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/8eb2b43e-f997-48b5-b71c-edd3e8dee497",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. The border between territories is labelled Battle Round 1 Objective. The horizontal lines that bisect each player's territory are labelled Battle Round 3 Objective. There are six vertical lines that split the battlefield into eight equal segments; from left to right, these are labelled 2-3, 4-5, 6, 7, 8, 9-10, 11-12."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Border War, Shifting Objectives, The Jaws of Gallet, Battle for the Pass and The Vice."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples: Ruins:** debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/e2a1f731-7dc9-446e-b1e4-992bec5eb3a7",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/e93bbadb-d3e5-4e48-a0e3-7e1d1b57225c",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a medium Obscuring Terrain slightly above and to the left of the centre of the leftmost large quarter, a small Area Terrain or Obstacle slightly below and to the right of that, a medium Obscuring Terrain to the left of the centre of the rightmost large quarter, and a small Area Terrain or Obstacle to the right of that."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "In certain places in the Mortal Realms, the land is bombarded by fragments of magical ore that fall burning from the skies. These remnants of stars are coveted by ambitious warlords, as they can be used to forge deadly blades that will cut through any armour."
+            }
+          ]
+        },
+        {
+          "id": "3144e81d-a8b5-5a22-ae2c-de5c66243b88",
+          "title": "Shifting Objectives",
+          "subtitle": "Battleplan 4 (Table 1)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "At the start of each battle round, after determining the active player, the active player must roll a D3 to determine which objective is the **primary** **objective** for that battle round. The other 2 objectives are the secondary objectives for that battle round.\n\nThe **underdog** can make the active player re-roll the dice to determine which objective is the **primary objective**.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point for each secondary objective that\nyou control.\n\n• Score 2 victory points if you control the **primary objective**.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/f770ca95-1ff6-4a4c-9af4-2509e3bc0e05",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the most northeasterly small quarter and the two small quarters west of it. The defender's territory comprises the most southwesterly small quarter and the two small quarters east of it. The rest is neutral territory. \n\nThere are three gold circles indicating objectives: one labelled with a 1 on the central horizontal line, equidistant from the centre of the battlefield and the western short battlefield edge; one labelled with a 2 at the centre of the battlefield; and one labelled with a 3 on the central horizontal line, equidistant from the centre of the battlefield and the eastern short battlefield edge."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Border War, Focal Points, The Jaws of Gallet, Battle for the Pass and The Vice."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/7b86ed88-d1a2-4f54-82c3-c27ce2ebea79",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/86aa9ffe-9f9d-49a8-bcea-5e68e0e4e52f",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing their territory, from left to right, there is a small Area Terrain or Obstacle on the central horizontal line to the left of the objective, a medium Obscuring Terrain to the right of the centre of the leftmost large quarter, a small Area Terrain or Obstacle diagonally right of the central objective, and a medium Place of Power in the centre of the rightmost large quarter."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "In order to be successful, a general must learn to react with lightning swiftness to the changing conditions of battle, striking with all their might first in one direction and then in another in order to ensure victory."
+            }
+          ]
+        },
+        {
+          "id": "a9383cba-133d-5f91-9896-2fffabcdc6a2",
+          "title": "Feral Foray",
+          "subtitle": "Battleplan 5 (Table 1)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "At the start of the battle round, each player can raid 1 objective they control in enemy territory. An objective that has been raided cannot be contested or controlled this battle round. The **underdog** can raid an objective in enemy territory that they contest but do not control.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/0683bf22-235a-46d4-8a9c-5e7d41dd0b27",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for The Better Part of Valour and Close to the Chest."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples: Ruins:** debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/ecf7775c-b9c1-4490-9555-903942e8d7ed",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/4e4d28e7-ddf9-4427-9bbf-ba1ca63789f6",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Place of Power slightly above and to the left of the leftmost objective, a medium Obscuring Terrain slightly above and to the left of the central objective, a medium Obscuring Terrain slightly below and to the right of the central objective, and a small Area Terrain or Obstacle above the rightmost objective."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "A major road is littered with the remains of convoys preyed upon by beasts of the wild. Often, supplies remain amidst the ruins, and so two armies have arrived, each seeking to carry off the abandoned loot before their enemy can do the same."
+            }
+          ]
+        },
+        {
+          "id": "304aef05-c610-566a-8f69-19a2f53e0bfe",
+          "title": "The Jaws of Gallet",
+          "subtitle": "Battleplan 6 (Table 1)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "From the second battle round, at the end of their turn, after scoring victory points, the **underdog** can pick 1 objective. That objective is removed from play. If there is no **underdog**, no objective is removed.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/ea67b4df-64e7-43d6-af77-74b295a2ee6a",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the most northeasterly small quarter, the two small quarters west of it and the two small quarters south of it. The defender's territory comprises the most southwesterly small quarter, the two small quarters east of it and the two small quarters north of it. The rest is neutral territory. \n\nThere are five gold circles indicating objectives: one at the centre of the battlefield and one in the centre of each large quarter."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Border War, Focal Points, Shifting Objectives, Battle for the Pass and The Vice."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/90127e8c-49e2-40e4-a2e4-4d439a33e47c",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/360b0786-9f9b-409c-95c0-c74f133ffb89",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a small Area Terrain or Obstacle diagonally right of the corner of the battlefield, a small Area Terrain or Obstacle diagonally left of the central objective, a medium Place of Power diagonally right of the central objective, and a medium Obscuring Terrain on the central horizontal line in their opponent's territory."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "In Ghur, the land itself is possessed of a hungry animus. This is particularly evident in Gallet, where sinkholes open up with perilous frequency, swallowing in moments assets that had been acquired at a steep cost in blood."
+            }
+          ]
+        },
+        {
+          "id": "19014ecf-95e1-5298-959d-69398e730110",
+          "title": "Battle for the Pass",
+          "subtitle": "Battleplan 1 (Table 2)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "Victory points scored by each player from controlling objectives are capped at a maximum of 6 per turn.\n\nThe **underdog** can add 2 to the control scores of friendly non-**HERO** units.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control the objective wholly within friendly territory.\n\n• Score 2 victory points for each objective on the border of friendly territory that you control.\n\n• Score 5 victory points if you control the objective wholly within enemy territory.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/2bb9d1d3-359d-4576-924b-7c7e989807cf",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the northwestern large quarter and the two small quarters immediately south of it. The defender's territory comprises the southeastern large quarter and the two small quarters immediately north of it. The rest is neutral territory. \n\nThere are four gold circles indicating objectives: two on the central horizontal line, each equidistant from the centre of the battlefield and a different short battlefield edge, and two on the border between territories, each equidistant from the centre of the battlefield and a different long battlefield edge."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Border War, Focal Points, Shifting Objectives, The Jaws of Gallet and The Vice."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/27da7816-f813-43cd-8d96-1e92d6a334a5",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/2673cfb4-9648-4fab-92fc-a2dec91aba12",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a medium Obscuring Terrain in the centre of the leftmost large quarter, a small Place of Power below and to the right of that, a medium Area Terrain or Obstacle diagonally left of the objective in their territory, and a small Area Terrain or Obstacle to the right of the centre of the rightmost large quarter."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Many kingdoms in the Mortal Realms are separated by towering mountain ranges that can only be navigated by traversing a narrow pass. These defiles are of vital strategic importance, and many blood battles are fought over their control."
+            }
+          ]
+        },
+        {
+          "id": "1279537a-3010-5e4a-b440-23f70bac9878",
+          "title": "Scorched Earth",
+          "subtitle": "Battleplan 2 (Table 2)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "From the second battle round, at the end of their turn, after scoring victory points, the active player can pick 1 objective that is wholly within enemy territory, that they control and that is being contested by any of their units. That objective is removed from play.\n\nAt the start of each battle round, the **underdog** can pick 1 objective in their territory that they control. Until the end of that battle round, they can subtract 5 from the control scores of enemy units contesting that objective, to a minimum of 1.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/7c799158-635f-48f3-bae5-fe08710c6a1e",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+              }
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/806acd3c-cf33-48d2-9704-7eb77fd29a4b",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/f04bcc98-3d5f-4187-8173-68c4e1ff04ab",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Obscuring Terrain slightly below and to the right of the leftmost objective, a medium Area Terrain or Obstacle halfway between the two centre-most objectives, a medium Obscuring Terrain slightly above and to the left of the rightmost objective, and a small Area Terrain or Obstacle above the rightmost objective."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Sometimes battles are fought not to destroy the enemy but to seize their resources and carry them off. Raiding parties will strike into enemy territory, capturing an objective and searching for any hidden treasures, before razing what remains to the ground to deny its use to the enemy."
+            }
+          ]
+        },
+        {
+          "id": "54b33663-bb35-5989-8360-301d72213563",
+          "title": "The Better Part of Valour",
+          "subtitle": "Battleplan 3 (Table 2)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "Each time an enemy unit contesting an objective is destroyed by a **FIGHT** ability used by a friendly non-**HERO** unit contesting the same objective, that friendly unit gains the **DOMINANT** keyword. If that friendly unit stops contesting that objective, it is no longer **DOMINANT**.\n\nAdd 10 to the control scores of **DOMINANT** units.\n\nAdd 1 to hit rolls for combat attacks made by units in the **underdog’s** army that target a **DOMINANT** unit.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/e0bc86e8-88d0-4c7a-afb6-309c462ba634",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: one in the centre of each player's territory and one in the centre of each large quarter."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Feral Foray and Close to the Chest."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins: debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/60b382eb-05e9-42e6-989c-11343a9bce64",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/19d42f46-a673-4f65-a760-37d0189f8c0b",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle slightly below and to the left of the leftmost objective, a medium Place of Power slightly above and to the left of the central objective, a medium Obscuring Terrain slightly below and to the right of the central objective, and a small Area Terrain or Obstacle slightly above and to the right of the rightmost objective."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "It is important to learn when to hold on in order to ensure victory and when to fall back in the face of unbeatable odds. A battle can be decided by the general who is most capable of resolving this difficult dilemma."
+            }
+          ]
+        },
+        {
+          "id": "935de3ee-c35e-5751-a472-95399fd6b970",
+          "title": "The Vice",
+          "subtitle": "Battleplan 4 (Table 2)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "At the start of the second battle round, after determining which player is the active player, the active player must remove the 4 starting objectives and set up a new objective at each of the next locations shown on the map.\n\nAt the start of the fourth battle round, after determining which player is the active player, the active player must remove the 4 objectives and set up 1 new objective in the location shown in the centre of the map.\n\nAt the end of their turn, the **underdog** can pick 1 objective. Inflict D3 mortal damage on each unit contesting that objective (roll separately for each unit).\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• In battle rounds 4 and 5 only, score 2 victory points if there are no enemy units within 6\" of the remaining objective.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/19cab5dc-e0bb-4ac5-aebb-ca04b5f6722d",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are four gold circles, one on each corner of the battlefield, indicating starting objectives. There are arrows pointing diagonally from each corner of the battlefield to a semi-transparent gold circle at the centre of each large quarter, then there are arrows pointing diagonally from the centre of each large quarter to a semi-transparent gold circle at the centre of the battlefield."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Border War, Focal Points, Shifting Objectives, The Jaws of Gallet and Battle for the Pass."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/4fae63b5-8e88-4727-bc6a-3e70f616555a",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/2e543171-961c-4408-b176-8999bcbf9f88",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle slightly below and to the left of the centre of the leftmost large quarter, a medium Area Terrain or Obstacle diagonally left of the centre of the battlefield, a small Place of Power diagonally right of the centre of the battlefield, and a medium Obscuring Terrain on the border between territories, diagonally right of the centre of the rightmost large quarter."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Two forces have come to blows amidst the shadows of an ancient crevasse. As the battle unfolds, both generals discover that the chasm is gradually closing in around them. Victory here must be swift for any hope of escape."
+            }
+          ]
+        },
+        {
+          "id": "5e63a028-4690-589d-bdc6-945eae6aa9ee",
+          "title": "Close to the Chest",
+          "subtitle": "Battleplan 5 (Table 2)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "At the start of each turn, the player who is not the active player must pick 1 objective in their territory to be the **primary objective** until the start of the next turn.\n\nAt the start of their turn, after their opponent has picked the **primary objective**, the **underdog** can roll a dice. On a 5+, their opponent must pick a different objective to be the **primary objective** for that turn.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 1 victory point if you control at least 1 objective.\n\n• Score 1 victory point if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 2 victory points if you control the **primary objective**.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/ca7834e2-3994-40e5-adf0-0dc016d91223",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The attacker's territory comprises the northwestern large quarter, the two small quarters immediately east of it and the small quarter north of the most southwesterly small quarter. The defender's territory comprises the southeastern large quarter, the two small quarters immediately west of it and the small quarter south of the most northeasterly small quarter. The rest is neutral territory. \n\nThere are six gold circles indicating objectives: two on the central vertical line, each equidistant from the centre of the battlefield and a different long battlefield edge, and one in the centre of each large quarter."
+              }
+            },
+            {
+              "type": "text",
+              "text": "This map layout can also be used for Feral Foray and The Better Part of Valour."
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/eff3d22d-70f4-4f6d-976e-3e1293adbde7",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/fd94a466-dd04-452b-a108-55891b018785",
+                "altText": "The battlefield terrain layout map.It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in the long half of the battlefield containing most of their territory, from left to right, there is a medium Obscuring Terrain on the central horizontal line, left of the centre of the leftmost large quarter; a small Obscuring Terrain slightly below and to the left of the central objective; a medium Place of Power slightly above and to the right of the central objective; and a small Area Terrain or Obstacle diagonally left of the corner of the battlefield."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "This vast cavern is rich in treasures, though your learned advisors inform you that some are more valuable than others. Seize what you can, and make use of your runners to ensure that the most lucrative artefacts do not fall into the enemy’s hands."
+            }
+          ]
+        },
+        {
+          "id": "0e4a5cb0-6a99-55f4-841a-46f63b934812",
+          "title": "Limited Resources",
+          "subtitle": "Battleplan 6 (Table 2)",
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Twist"
+            },
+            {
+              "type": "text",
+              "text": "When a player gains control of an objective, they start to extract resources from it. After scoring victory points, if the active player controls an objective that they controlled at the end of their previous turn, they have extracted all the resources from that objective. For the rest of the battle, that player cannot control that objective.\n\nOnce a player has extracted all of the resources from an objective, they can still contest it to prevent their opponent from controlling it, but they do not and cannot control it themselves.\n\nThe **underdog** can add 3 to the control scores of friendly units that are contesting an objective from which they are extracting resources.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 2 victory points if you control at least 1 objective.\n\n• Score 2 victory points if you control 2 or more objectives.\n\n• Score 2 victory points if you control more objectives than your opponent.\n\n• Score 4 victory points if you completed the battle tactic you chose to attempt this turn."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/a254b296-1874-47ba-8d43-e525e16e134f",
+                "altText": "The battlefield map. An icon at the top right points upwards to show which way is north. The battlefield is divided into halves along its width. The northern half is the attacker's territory; the southern half is the defender's territory. \n\nThere are six gold circles indicating objectives: two on the border between territories, each equidistant from the centre of the battlefield and a different short battlefield edge; two on the horizontal line bisecting the attacker's territory, northeast of the objectives on the border between territories; and two on the horizontal line bisecting the defender's territory, southwest of the objectives on the border between territories."
+              }
+            },
+            {
+              "type": "header",
+              "text": "Area Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Hills, Stormvault\n\n**Terrain Abilities:** Cover"
+            },
+            {
+              "type": "header",
+              "text": "Obstacles"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Ruins, debris, statues, barricades\n\n**Terrain Abilities:** Cover, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Obscuring Terrain"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Wyldwood, fortress wall\n\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Places of Power"
+            },
+            {
+              "type": "text",
+              "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n\n**Terrain Abilities:** Cover, Place of Power, Unstable"
+            },
+            {
+              "type": "header",
+              "text": "Key"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/17f2be86-7224-4450-84e5-7c8343454ea6",
+                "altText": "Key for terrain features showing icons for small and medium Area Terrain or Obstacles, small and medium Obscuring Terrain, and small and medium Places of Power."
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/7d6fe428-50d3-48d5-8fe3-11e5f8ba5e8a",
+                "altText": "The battlefield terrain layout map. It is the same as the battlefield map and shows the position of eight terrain features that have 180º rotational symmetry. \n\nFrom each player's perspective, in their territory, from left to right, there is a small Area Terrain or Obstacle above the leftmost objective, a medium Area Terrain or Obstacle halfway between both objectives in their territory, a small Area Terrain or Obstacle slightly above and to the right of that, and a medium Obscuring Terrain in the centre of the rightmost large quarter."
+              }
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Wracked with lightning and viridian fire, the realms suffer for the clashing of their denizens. Resources dwindle, burnt away or stolen by perfidious ratmen. The little that remains is a tantalising prize indeed. For your armies to thrive and your goals to be furthered, you must march deep into the ravaged lands and seize what is rightfully yours."
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "97f80e23-abc8-5202-ad57-aa5ed4cd4873",
+      "name": "Addenda, Errata and FAQs",
+      "containers": [],
+      "sections": [
+        {
+          "id": "c1db9758-9405-52b7-bd8c-d74e389c5c57",
+          "name": "Errata",
+          "containers": [
+            {
+              "id": "6ffa8c5b-24fe-5677-9535-0df2e869cd19",
+              "title": "Errata",
+              "subtitle": null,
+              "containerType": "introduction",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The following rules updates correct errors in order to clarify ambiguities and/or avoid unintended interactions."
+                }
+              ]
+            },
+            {
+              "id": "9095d9d5-39d7-55eb-8b16-3d92e7354603",
+              "title": "Season Rules 2024-25",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "header",
+                  "text": "Taking A Double Turn"
+                },
+                {
+                  "type": "text",
+                  "text": "If the player who went second in the previous battle round wins the priority roll and chooses to go first, this is called ‘taking a double turn’.\n\n**Seizing The Initiative**\nWhen a player takes a double turn **and** they are **not** behind by 6 or more victory points, this is called ‘seizing the initiative’. The first time in a battle that a player seizes the initiative, the rules for determining the underdog change: for the rest of the battle, the underdog is always the opponent of the player who most recently seized the initiative.\n\n**Battle Tactics**\nPlayers who take a double turn while they are behind by 6 or more victory points can still use the ‘Tactical Gambit’ ability to pick a battle tactic."
+                },
+                {
+                  "type": "header",
+                  "text": "Honour Guard"
+                },
+                {
+                  "type": "text",
+                  "text": "Each player can use one of the following Honour Guard abilities in each battle. When using that ability, they must pick a unit in their general’s regiment to be the honour guard.\n\n**Regimented Forces**\nIf a player has more regiments than their opponent, they can use a second, different **HONOUR GUARD** ability, but they must pick a unit that is in a different regiment that is not led by the general to be the **honour guard** for that ability. You cannot pick units in a Regiment of Renown to be an honour guard. If you chose not to pick an **honour guard** unit in your general’s regiment, you can still pick an honour guard unit for a different regiment as described above."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "f45d6541-ca08-5b18-8a11-86c67c0ce229",
+                    "name": "Special Assignment",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle, Deployment Phase",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                    "effect": "Pick 1 of the following weapon abilities:\n\n• **Anti-INFANTRY (+1 Rend)**\n• **Anti-CAVALRY (+1 Rend)**\n• **Anti-MONSTER (+1 Rend)**\n• **Anti-WAR MACHINE (+1 Rend)**\n• **Anti-BEAST (+1 Rend)**\n\nIn any turn in which that **honour guard** charged, that unit’s melee weapons have the weapon ability you picked.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Honour Guard"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "2654418e-c81a-5175-b0cb-179a9bdc4486",
+                    "name": "Bodyguard",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle, Deployment Phase",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                    "effect": "Subtract 1 from the Attacks characteristic of enemy units’ melee weapons while they are in combat with the unit leading that regiment if both of the following are true:\n• That regiment’s **honour guard** is wholly within 6\" of the leader of that regiment.\n• Neither that regiment’s **honour guard** nor the regiment’s leader charged this turn.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Honour Guard"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "315604ee-c191-570a-8d9e-b80d739442a9",
+                    "name": "Priority Target",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle, Deployment Phase",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                    "effect": "Add 1 to hit rolls and wound rolls for attacks made by that **honour guard** unit that target the enemy general, or the enemy **honour guard** if it is in the enemy general’s regiment, if the target of the attack is within 12\".",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Honour Guard"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "c8103acd-6aea-5d63-a982-b51ae623c1b5",
+                    "name": "Field Sergeant",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle, Deployment Phase",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": "Pick a friendly non-**FLY** **INFANTRY HERO** in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                    "effect": "Add 2\" to the Move characteristic of friendly non-**FLY INFANTRY** units while they are wholly within 12\" of the **honour guard**.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Honour Guard"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "2829316c-7135-580a-a9f3-c1734ffea3d7",
+                    "name": "Prized Beast",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle, Deployment Phase",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick a friendly non-**UNIQUE MONSTER** unit that has not been reinforced and which is in, but not leading, a regiment to be that regiment’s **honour guard**. You can pick a unit in reserve.",
+                    "effect": "That unit can ignore the effects of the ‘Battle Damaged’ ability. In addition, add 1 to hit rolls for combat attacks made by the **honour guard**. This ability also affects **Companion** weapons.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Honour Guard"]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "d2efd30d-c367-523d-9324-17f63fbdf0ed",
+              "title": "Battleplan: Border War",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Remove ‘The Vice’ from the list of battleplans that can use the Border War map layout."
+                }
+              ]
+            },
+            {
+              "id": "ec015c2b-d74a-5a72-9303-c4801d91550a",
+              "title": "Battleplan: Starstrike",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the twist:\n\nReplace:\n‘If an objective would be set up wholly or partially on a terrain feature, do not do so. Instead, inflict D6 mortal damage on each unit wholly or partially on that terrain feature.’\n\nWith:\n‘If an objective would be set up wholly or partially on a faction terrain feature, that terrain feature and any units on it are destroyed, then the objective is set up normally. If the objective would be set up wholly or partially on other terrain features, do not do so. Instead, inflict D6 mortal damage on each unit wholly or partially on that terrain feature.’"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "55e1d052-e712-50a4-a5dd-e509e8644396",
+          "name": "Frequently Asked Questions",
+          "containers": [
+            {
+              "id": "0a89a703-1111-5522-bc5e-ba469d564ad2",
+              "title": "Frequently Asked Questions",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "boxedText",
+                  "text": "In this series of questions and answers, the rules-writing team respond to players’ queries and explain how the rules are intended to be used."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: When using the ‘Priority Target’ ability, does each model in the attacking unit need to be within 12\" of the target to benefit from the +1 to hit and wound rolls, or does the attacking unit need to be within 12\" of the target unit?*\n\nA: The attacking unit needs to be within 12\" of the target."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    }
+  ]
+}

--- a/aos/gdc/battlepacks/generals_handbook_2025_26.json
+++ b/aos/gdc/battlepacks/generals_handbook_2025_26.json
@@ -1,0 +1,2842 @@
+{
+  "id": "035de91c-56f6-5063-9e9b-1ddd177db35e",
+  "name": "General's Handbook 2025-26",
+  "cardType": "Battlepack",
+  "source": "aos-4e",
+  "updated": "2026-07-04T16:16:49.176Z",
+  "compatibleDataVersion": 434,
+  "description": "Across the densely wooded isle of Neos, potent nexuses of life magic pulse. Armies now gather to battle under those vibrant boughs, slipping along hidden paths and seizing sites of Ghyranite power to preserve or turn to their own ends.",
+  "battleTacticsCardLimit": 2,
+  "armyBuilder": {
+    "noLoresCost": false,
+    "noEnhancementsCost": false,
+    "noBattleFormationsCost": false,
+    "noFactionTerrainCost": false
+  },
+  "battleplans": [
+    {
+      "id": "13e2eef2-c91d-5b5b-b8a6-cdced0aaacfa",
+      "name": "Passing Seasons",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 1 (Table 1)",
+      "section": "Passing Seasons",
+      "twist": {
+        "text": "**TWIST**: In battle rounds 2 and 4, if you are the **underdog**, you can use the ‘Burgeoning Rejuvenation’ ability. In battle rounds 3 and 5, while you are the **underdog**, your army has the ‘Powerful Resurgence’ ability.",
+        "abilities": [
+          {
+            "id": "fa2c3731-2f13-5560-99ba-45409f37115a",
+            "name": "Burgeoning Rejuvenation",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "defensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Pick 1 of the following:\n\n• **Heal (D3)** every friendly unit contesting an **Oakenbrow** objective.\n•  For the rest of the battle round, while a friendly unit is contesting a **Gnarlroot**\n-  If it has a ward save, add 1 to ward rolls for that unit.\n-  If it does not have a ward save, it has **WARD (6+).**",
+            "usedBy": null,
+            "additionalRulesText": null
+          },
+          {
+            "id": "8e429249-545a-52c2-b2f1-71daef680d30",
+            "name": "Powerful Resurgence",
+            "phase": "combatPhase",
+            "phaseDetails": "Passive",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Add 1 to wound rolls for combat attacks made by friendly units while they are contesting a **Gnarlroot** objective.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• In battle rounds 1, 3 and 5, score 5 victory points for each **Gnarlroot** objective that you control.\n• In battle rounds 2 and 4, score 5 victory points for each **Oakenbrow** objective that you control.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/37123a64-820e-4fbf-b627-9f1cd06d24e8",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/bb92f734-4558-40c5-a691-76871aca3359",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: In battle rounds 2 and 4, if you are the **underdog**, you can use the ‘Burgeoning Rejuvenation’ ability. In battle rounds 3 and 5, while you are the **underdog**, your army has the ‘Powerful Resurgence’ ability."
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "fa2c3731-2f13-5560-99ba-45409f37115a",
+            "name": "Burgeoning Rejuvenation",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "defensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Pick 1 of the following:\n\n• **Heal (D3)** every friendly unit contesting an **Oakenbrow** objective.\n•  For the rest of the battle round, while a friendly unit is contesting a **Gnarlroot**\n-  If it has a ward save, add 1 to ward rolls for that unit.\n-  If it does not have a ward save, it has **WARD (6+).**",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "8e429249-545a-52c2-b2f1-71daef680d30",
+            "name": "Powerful Resurgence",
+            "phase": "combatPhase",
+            "phaseDetails": "Passive",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Add 1 to wound rolls for combat attacks made by friendly units while they are contesting a **Gnarlroot** objective.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• In battle rounds 1, 3 and 5, score 5 victory points for each **Gnarlroot** objective that you control.\n• In battle rounds 2 and 4, score 5 victory points for each **Oakenbrow** objective that you control."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/37123a64-820e-4fbf-b627-9f1cd06d24e8",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/bb92f734-4558-40c5-a691-76871aca3359",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "acc476e3-01d2-5f62-817a-26ce6f2aaa7c",
+      "name": "Paths of the Fey",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 2 (Table 1)",
+      "section": "Paths of the Fey",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you must use the ‘The Spirit Paths Open’ ability. Both players can use the ‘Stumbling Forth’ ability.",
+        "abilities": [
+          {
+            "id": "5f047493-fd5e-578e-9819-4a6500854b9f",
+            "name": "The Spirit Paths Open",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "movement",
+            "cpCost": null,
+            "declare": "Pick 2 objectives to be the targets.",
+            "effect": "All units, excluding faction terrain and **MANIFESTATIONS**, within 6\" of any target objectives must be removed from the battlefield by their commander. Those units are **vanished**. Then, starting with you, players must take it in turns to set up each friendly **vanished** unit wholly within 3\" of either target objective and more than 3\" from all enemy units. Those units cannot use **MOVE** abilities in the first movement phase of the battle round. If it is impossible for a unit to be set up in this way, it is set up in reserve as a **lost** unit.",
+            "usedBy": null,
+            "additionalRulesText": null
+          },
+          {
+            "id": "f3321551-0cd6-5fa1-afff-ceb05ade26d0",
+            "name": "Stumbling Forth",
+            "phase": "movementPhase",
+            "phaseDetails": "Your Movement Phase",
+            "icon": "movement",
+            "cpCost": null,
+            "declare": "Pick a friendly **lost** unit (see above) to be the target.",
+            "effect": "Set up the target on the battlefield, more than 9\" from all enemy units and wholly within 7\" of a battlefield edge.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/a534c383-30c4-4f92-a234-704f395210a2",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/651358e8-81e4-4010-8006-13d81f9e970e",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you must use the ‘The Spirit Paths Open’ ability. Both players can use the ‘Stumbling Forth’ ability."
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "5f047493-fd5e-578e-9819-4a6500854b9f",
+            "name": "The Spirit Paths Open",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "movement",
+            "cpCost": null,
+            "declare": "Pick 2 objectives to be the targets.",
+            "effect": "All units, excluding faction terrain and **MANIFESTATIONS**, within 6\" of any target objectives must be removed from the battlefield by their commander. Those units are **vanished**. Then, starting with you, players must take it in turns to set up each friendly **vanished** unit wholly within 3\" of either target objective and more than 3\" from all enemy units. Those units cannot use **MOVE** abilities in the first movement phase of the battle round. If it is impossible for a unit to be set up in this way, it is set up in reserve as a **lost** unit.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "f3321551-0cd6-5fa1-afff-ceb05ade26d0",
+            "name": "Stumbling Forth",
+            "phase": "movementPhase",
+            "phaseDetails": "Your Movement Phase",
+            "icon": "movement",
+            "cpCost": null,
+            "declare": "Pick a friendly **lost** unit (see above) to be the target.",
+            "effect": "Set up the target on the battlefield, more than 9\" from all enemy units and wholly within 7\" of a battlefield edge.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/a534c383-30c4-4f92-a234-704f395210a2",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/651358e8-81e4-4010-8006-13d81f9e970e",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "ba806f89-0d9a-52cd-a286-3ed2969fee5b",
+      "name": "Roiling Roots",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 3 (Table 1)",
+      "section": "Roiling Roots",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you must use the ‘Tangling Tendrils’ ability:",
+        "abilities": [
+          {
+            "id": "18f47b6c-ac1c-5672-aa00-36ed8cf16605",
+            "name": "Tangling Tendrils",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "defensive",
+            "cpCost": null,
+            "declare": "Pick a pair of objectives to be the targets.",
+            "effect": "For the rest of the battle round, units (friendly and enemy) have **STRIKE‑LAST** while they are contesting either target objective.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control more objectives than your opponent.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/ba01e007-dc2c-45f2-ac66-5b8ea21e1b58",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/adec1e47-684d-4cb9-bc97-43687a8ca672",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you must use the ‘Tangling Tendrils’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "18f47b6c-ac1c-5672-aa00-36ed8cf16605",
+            "name": "Tangling Tendrils",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "defensive",
+            "cpCost": null,
+            "declare": "Pick a pair of objectives to be the targets.",
+            "effect": "For the rest of the battle round, units (friendly and enemy) have **STRIKE‑LAST** while they are contesting either target objective.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/ba01e007-dc2c-45f2-ac66-5b8ea21e1b58",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/adec1e47-684d-4cb9-bc97-43687a8ca672",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "13545272-f2c2-5510-b850-b3fecbf1021e",
+      "name": "Cyclic Shifts",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 4 (Table 1)",
+      "section": "Cyclic Shifts",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you can use the ‘Unpredictable Evolution’ ability:",
+        "abilities": [
+          {
+            "id": "77d14343-b197-5731-bc47-5d649ea18b60",
+            "name": "Unpredictable Evolution",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "control",
+            "cpCost": null,
+            "declare": "Pick a pair of objectives to be the targets.",
+            "effect": "The target objectives are no longer controlled by either player (if they were) and they cannot be controlled this battle round.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/9a2026ae-ac22-4420-86ab-ee667ebfd1c0",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/97368535-7643-4f30-b7d1-b87ffd42eeac",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you can use the ‘Unpredictable Evolution’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "77d14343-b197-5731-bc47-5d649ea18b60",
+            "name": "Unpredictable Evolution",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "control",
+            "cpCost": null,
+            "declare": "Pick a pair of objectives to be the targets.",
+            "effect": "The target objectives are no longer controlled by either player (if they were) and they cannot be controlled this battle round.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/9a2026ae-ac22-4420-86ab-ee667ebfd1c0",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/97368535-7643-4f30-b7d1-b87ffd42eeac",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "e040e806-1139-5b61-aaee-be580d71a142",
+      "name": "Surge of Slaughter",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 5 (Table 1)",
+      "section": "Surge of Slaughter",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you can use the ‘Defence of the Realm’ ability:",
+        "abilities": [
+          {
+            "id": "09600a01-f650-5ab9-be49-3499daa535a2",
+            "name": "Defence of the Realm",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": "Pick a pair of objectives to be the targets.",
+            "effect": "For the rest of the battle round, add 1 to the Rend characteristic of friendly units’ melee weapons while they are contesting either of the target objectives.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control more objectives than your opponent.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/b111de11-153f-4e5e-a184-19dc09bb5a41",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/03ec2826-07f1-4b86-9b44-d3451d6288c5",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you can use the ‘Defence of the Realm’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "09600a01-f650-5ab9-be49-3499daa535a2",
+            "name": "Defence of the Realm",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": "Pick a pair of objectives to be the targets.",
+            "effect": "For the rest of the battle round, add 1 to the Rend characteristic of friendly units’ melee weapons while they are contesting either of the target objectives.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/b111de11-153f-4e5e-a184-19dc09bb5a41",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/03ec2826-07f1-4b86-9b44-d3451d6288c5",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "6d59172e-1b0d-5b5b-bf3d-53e681484aa8",
+      "name": "Linked Ley Lines",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 6 (Table 1)",
+      "section": "Linked Ley Lines",
+      "twist": {
+        "text": "**TWIST**: While you are the **underdog**, your army has the ‘Rooted in the Realm’ and ‘Full of Life’ abilities:",
+        "abilities": [
+          {
+            "id": "7ef98963-80ba-59b4-9b91-4f1cd4e52d60",
+            "name": "Rooted in the Realm",
+            "phase": "combatPhase",
+            "phaseDetails": "Passive",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Friendly units’ weapons have **Anti‑MANIFESTATION (+1 Rend)** while those units are a contesting an objective that is both controlled by you and on a **linked ley line** (see below).",
+            "usedBy": null,
+            "additionalRulesText": null
+          },
+          {
+            "id": "1102de06-a351-5067-874d-e69fb7dc94fa",
+            "name": "Full of Life",
+            "phase": "combatPhase",
+            "phaseDetails": "Passive",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Friendly **MANIFESTATIONS** have **STRIKE-FIRST**.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "A linked ley line is formed from the middle of one edge of the battlefield to the middle of the opposite edge while one player controls all the objectives on that line.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 3 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control all of the objectives on a linked ley line.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/65b56453-3b41-4553-9780-e90b2905e84b",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/978b3154-5c4f-4c80-92ae-8510d0a3b62f",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: While you are the **underdog**, your army has the ‘Rooted in the Realm’ and ‘Full of Life’ abilities:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "7ef98963-80ba-59b4-9b91-4f1cd4e52d60",
+            "name": "Rooted in the Realm",
+            "phase": "combatPhase",
+            "phaseDetails": "Passive",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Friendly units’ weapons have **Anti‑MANIFESTATION (+1 Rend)** while those units are a contesting an objective that is both controlled by you and on a **linked ley line** (see below).",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "1102de06-a351-5067-874d-e69fb7dc94fa",
+            "name": "Full of Life",
+            "phase": "combatPhase",
+            "phaseDetails": "Passive",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Friendly **MANIFESTATIONS** have **STRIKE-FIRST**.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "A linked ley line is formed from the middle of one edge of the battlefield to the middle of the opposite edge while one player controls all the objectives on that line.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 3 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control all of the objectives on a linked ley line."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/65b56453-3b41-4553-9780-e90b2905e84b",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/978b3154-5c4f-4c80-92ae-8510d0a3b62f",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "b4adc2c4-4907-58b7-95d7-f4ad8d044822",
+      "name": "Noxious Nexus",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 1 (Table 2)",
+      "section": "Noxious Nexus",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you can use the ‘Caustic Sap’ ability:",
+        "abilities": [
+          {
+            "id": "355208fe-585b-5d97-8286-333eb30a62e1",
+            "name": "Caustic Sap",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": "Pick an objective. Each unit contesting that objective is a target.",
+            "effect": "Roll a D3 for each target. On a 2+, inflict an amount of mortal damage on the target equal to the roll. If you picked the **Heartwood** objective, roll a D6 for each target instead.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Objectives cannot be controlled in the first battle round.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control the **Oakenbrow** objective.\n• Score 3 victory points if you control the **Gnarlroot** objective.\n• Score 2 victory points if you control the **Heartwood** objective.\n\nIn addition, at the end of the battle, a player scores 10 victory points if they control the **Heartwood** objective.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/da81ad62-efc5-4012-83eb-3e9665215d5f",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/72381d13-c129-4781-93cc-0ee58827486b",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you can use the ‘Caustic Sap’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "355208fe-585b-5d97-8286-333eb30a62e1",
+            "name": "Caustic Sap",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "offensive",
+            "cpCost": null,
+            "declare": "Pick an objective. Each unit contesting that objective is a target.",
+            "effect": "Roll a D3 for each target. On a 2+, inflict an amount of mortal damage on the target equal to the roll. If you picked the **Heartwood** objective, roll a D6 for each target instead.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Objectives cannot be controlled in the first battle round.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control the **Oakenbrow** objective.\n• Score 3 victory points if you control the **Gnarlroot** objective.\n• Score 2 victory points if you control the **Heartwood** objective.\n\nIn addition, at the end of the battle, a player scores 10 victory points if they control the **Heartwood** objective."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/da81ad62-efc5-4012-83eb-3e9665215d5f",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/72381d13-c129-4781-93cc-0ee58827486b",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "3d472b5e-7de3-584e-a60d-1413c98ceb27",
+      "name": "The Liferoots",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 2 (Table 2)",
+      "section": "The Liferoots",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you can use the ‘Life Begets Life’ ability:",
+        "abilities": [
+          {
+            "id": "b8fb6c36-649d-5dad-b463-f174cd4abacf",
+            "name": "Life Begets Life",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "rallying",
+            "cpCost": null,
+            "declare": "Pick a friendly unit that has all of its models within 1\" of a terrain feature to be the target.",
+            "effect": "Return 1 slain model to the target unit.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores 1 **liferoot point** at the end of each of their turns for each non-**FACTION TERRAIN** terrain feature they control.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control both objectives.\n• Score 2 victory points if you have more **liferoot points** than your opponent.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/73b44613-b55a-4a50-bd06-2ea3aabe891e",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/29d1eef8-7417-4f7b-bbb1-9675826815f6",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you can use the ‘Life Begets Life’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "b8fb6c36-649d-5dad-b463-f174cd4abacf",
+            "name": "Life Begets Life",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "rallying",
+            "cpCost": null,
+            "declare": "Pick a friendly unit that has all of its models within 1\" of a terrain feature to be the target.",
+            "effect": "Return 1 slain model to the target unit.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores 1 **liferoot point** at the end of each of their turns for each non-**FACTION TERRAIN** terrain feature they control.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control both objectives.\n• Score 2 victory points if you have more **liferoot points** than your opponent."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/73b44613-b55a-4a50-bd06-2ea3aabe891e",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/29d1eef8-7417-4f7b-bbb1-9675826815f6",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "89a845d9-8a56-56ce-8532-f31c4b31282b",
+      "name": "Bountiful Equinox",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 3 (Table 2)",
+      "section": "Bountiful Equinox",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you can use the ‘Rejuvenating Bloom’ ability:",
+        "abilities": [
+          {
+            "id": "a00c1ba4-b2d3-5f42-af8e-1f6b64759a46",
+            "name": "Rejuvenating Bloom",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "defensive",
+            "cpCost": null,
+            "declare": "Pick an objective to be the target.",
+            "effect": "**Heal (3)** each unit (friendly and enemy) contesting the target objective.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control at least 1 **Oakenbrow** , 1 **Gnarlroot** and 1 **Heartwood** objective.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/7ff7cff9-1ee4-46f0-b257-a961fe88f491",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/ee2b273b-6fc1-48e1-ba8a-2eecd60e56f9",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you can use the ‘Rejuvenating Bloom’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "a00c1ba4-b2d3-5f42-af8e-1f6b64759a46",
+            "name": "Rejuvenating Bloom",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "defensive",
+            "cpCost": null,
+            "declare": "Pick an objective to be the target.",
+            "effect": "**Heal (3)** each unit (friendly and enemy) contesting the target objective.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control at least 1 **Oakenbrow** , 1 **Gnarlroot** and 1 **Heartwood** objective."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/7ff7cff9-1ee4-46f0-b257-a961fe88f491",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/ee2b273b-6fc1-48e1-ba8a-2eecd60e56f9",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "11385df2-e964-5340-a091-625cca964d90",
+      "name": "Lifecycle",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 4 (Table 2)",
+      "section": "Lifecycle",
+      "twist": {
+        "text": "**TWIST**: At the start of the second battle round, the **underdog** must use the ‘Lifecycle’ ability. If there is no **underdog**, the players roll off and the winner must use the ‘Lifecycle’ ability:",
+        "abilities": [
+          {
+            "id": "11385df2-e964-5340-a091-625cca964d90",
+            "name": "Lifecycle",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle, Start of Second Battle Round",
+            "icon": "special",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Pick either the **Oakenbrow** or the **Gnarlroot** objective to be the primary objective. At the start of each subsequent battle round, the next objective in the cycle becomes the primary objective. The objectives before and after the primary objective in the cycle order (see below) are the secondary objectives.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 4 victory points if you control at least 1 objective.\n• Score 2 victory points if you control more objectives than your opponent.\n• Score 4 victory points if you control both the **Oakenbrow** and **Gnarlroot** objectives (first battle round only).\n• Score 2 victory points if you control the primary objective.\n• Score 1 victory point for each secondary objective that you control.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/4fdba5fc-adbb-4bd4-9ddd-ceb607c38299",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/982ded7a-4d2e-4f7d-b676-ae4baf371193",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/b9ceebf6-6210-4167-9ca8-6051fcb08751",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: At the start of the second battle round, the **underdog** must use the ‘Lifecycle’ ability. If there is no **underdog**, the players roll off and the winner must use the ‘Lifecycle’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "11385df2-e964-5340-a091-625cca964d90",
+            "name": "Lifecycle",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle, Start of Second Battle Round",
+            "icon": "special",
+            "cpCost": null,
+            "declare": null,
+            "effect": "Pick either the **Oakenbrow** or the **Gnarlroot** objective to be the primary objective. At the start of each subsequent battle round, the next objective in the cycle becomes the primary objective. The objectives before and after the primary objective in the cycle order (see below) are the secondary objectives.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "header",
+          "text": "Cycle Order"
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/4fdba5fc-adbb-4bd4-9ddd-ceb607c38299",
+            "altText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 4 victory points if you control at least 1 objective.\n• Score 2 victory points if you control more objectives than your opponent.\n• Score 4 victory points if you control both the **Oakenbrow** and **Gnarlroot** objectives (first battle round only).\n• Score 2 victory points if you control the primary objective.\n• Score 1 victory point for each secondary objective that you control."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/982ded7a-4d2e-4f7d-b676-ae4baf371193",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/b9ceebf6-6210-4167-9ca8-6051fcb08751",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "86334384-1753-588c-a60e-ee1d19618b83",
+      "name": "Creeping Corruption",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 5 (Table 2)",
+      "section": "Creeping Corruption",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you can use the ‘Pulsing Life Energies’ ability:",
+        "abilities": [
+          {
+            "id": "1279662a-627c-55df-a80c-fed6a4aba128",
+            "name": "Pulsing Life Energies",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "special",
+            "cpCost": null,
+            "declare": "Pick an objective you control and 1 other objective (whether you control it or not). Draw a line between the centres of those objectives. Then, choose **propagation** or **corruption**.",
+            "effect": "Apply the appropriate effect:\n\n***Propagation:*** Add 1 to casting rolls, chanting rolls and banishment rolls for each unit crossed by the line for the rest of the battle round.\n\n***Corruption:*** Inflict D3 mortal damage on each unit crossed by the line.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/d7ea47c1-3251-4c7f-bc82-96f891c53981",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/4f6159a4-80db-49ca-8ea5-5ba069fb5c0f",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you can use the ‘Pulsing Life Energies’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "1279662a-627c-55df-a80c-fed6a4aba128",
+            "name": "Pulsing Life Energies",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "special",
+            "cpCost": null,
+            "declare": "Pick an objective you control and 1 other objective (whether you control it or not). Draw a line between the centres of those objectives. Then, choose **propagation** or **corruption**.",
+            "effect": "Apply the appropriate effect:\n\n***Propagation:*** Add 1 to casting rolls, chanting rolls and banishment rolls for each unit crossed by the line for the rest of the battle round.\n\n***Corruption:*** Inflict D3 mortal damage on each unit crossed by the line.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/d7ea47c1-3251-4c7f-bc82-96f891c53981",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/4f6159a4-80db-49ca-8ea5-5ba069fb5c0f",
+            "altText": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "4e8bb5e8-f58d-5f22-a021-619f64f8355a",
+      "name": "Grasp of Thorns",
+      "cardType": "Battleplan",
+      "source": "aos-4e",
+      "subtitle": "Battleplan 6 (Table 2)",
+      "section": "Grasp of Thorns",
+      "twist": {
+        "text": "**TWIST**: If you are the **underdog**, you can use the ‘Carnivorous Flora’ ability:",
+        "abilities": [
+          {
+            "id": "e4d9eab0-f0e3-5411-a4de-4c0523333d6d",
+            "name": "Carnivorous Flora",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "special",
+            "cpCost": null,
+            "declare": "Pick an objective to be **grasping**.",
+            "effect": "Roll a dice for each unit contesting that objective. On a 3+, every model in that unit that is within the control zone of that objective is **entangled** for the rest of the battle round.\n\n**Entangled** models must stay within the control zone of the **grasping** objective for the rest of the battle round. While a unit has any **entangled** models, it cannot be removed from the battlefield by an ability that would allow it to be set up elsewhere on the battlefield. That objective cannot be moved while there are any entangled models contesting it.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        ]
+      },
+      "scoring": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent.",
+      "images": [
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/7e6e3ae4-1ab2-4db0-8c59-7137c42fd5c2",
+          "altText": null
+        },
+        {
+          "url": "https://dhss9aar8ocw.cloudfront.net/6e6f6ac2-255d-4362-984c-cbafab2025cb",
+          "altText": null
+        }
+      ],
+      "components": [
+        {
+          "type": "text",
+          "text": "**TWIST**: If you are the **underdog**, you can use the ‘Carnivorous Flora’ ability:"
+        },
+        {
+          "type": "ability",
+          "ability": {
+            "id": "e4d9eab0-f0e3-5411-a4de-4c0523333d6d",
+            "name": "Carnivorous Flora",
+            "phase": "startOfTurn",
+            "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+            "icon": "special",
+            "cpCost": null,
+            "declare": "Pick an objective to be **grasping**.",
+            "effect": "Roll a dice for each unit contesting that objective. On a 3+, every model in that unit that is within the control zone of that objective is **entangled** for the rest of the battle round.\n\n**Entangled** models must stay within the control zone of the **grasping** objective for the rest of the battle round. While a unit has any **entangled** models, it cannot be removed from the battlefield by an ability that would allow it to be set up elsewhere on the battlefield. That objective cannot be moved while there are any entangled models contesting it.",
+            "usedBy": null,
+            "additionalRulesText": null
+          }
+        },
+        {
+          "type": "text",
+          "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/7e6e3ae4-1ab2-4db0-8c59-7137c42fd5c2",
+            "altText": null
+          }
+        },
+        {
+          "type": "image",
+          "image": {
+            "url": "https://dhss9aar8ocw.cloudfront.net/6e6f6ac2-255d-4362-984c-cbafab2025cb",
+            "altText": null
+          }
+        }
+      ]
+    }
+  ],
+  "battleTacticCards": [
+    {
+      "id": "4008d62f-4cdf-581f-ae55-f4872fee09e7",
+      "name": "Attuned to Ghyran",
+      "cardType": "BattleTacticCard",
+      "source": "aos-4e",
+      "lore": "The air of Neos is strangely febrile, as if the will of the realm crackles there. One could heed it, perhaps…",
+      "rulesText": null,
+      "tactics": [
+        {
+          "id": "b4d34ab1-f259-5e21-add4-fdb8f9f6f50e",
+          "name": "Fey Strikes",
+          "tacticType": "strike",
+          "lore": "Slip in and out of the melee like the cackling spites of the deep woods.",
+          "rulesText": "You complete this battle tactic at the end of your turn if all the following are true:\n• At least 2 friendly units moved as part of a **RETREAT** ability this turn. Those units are **lure** units.\n• At least 2 other friendly units charged this turn and at least 1 of those units ended the charge move in combat with an enemy unit from which any lure **units** retreated.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "0c1b0db5-5187-56df-811d-4603e97fee73",
+          "name": "Purification Rites",
+          "tacticType": "domination",
+          "lore": "New birth sometimes demands a matching price in death…",
+          "rulesText": "You complete this battle tactic at the end of your turn if there are no enemy units within friendly territory and no enemy units within neutral territory.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "f5e0726f-fdfe-579a-9d09-b23a449dd5ae",
+          "name": "Sacred Centrality",
+          "tacticType": "affray",
+          "lore": "Assemble at the heart of the field, as the druids once did around their holy henges.",
+          "rulesText": "You complete this battle tactic at the end of your turn if there are at least 2 friendly units within 3\" of the centre of the battlefield that are not in combat.",
+          "victoryPoints": 5
+        }
+      ]
+    },
+    {
+      "id": "a4c88c5d-97ec-5b3a-b977-936e49c3dfd8",
+      "name": "Intercept and Recover",
+      "cardType": "BattleTacticCard",
+      "source": "aos-4e",
+      "lore": "There are many who would thieve Neos’s life-giving relics. Recover them – either for noble purposes or in furtherance of darker goals…",
+      "rulesText": "•  If an ability would remove a unit that was carrying treasure from the battlefield and that unit is not set up again as part of the same ability (e.g. ‘Dark Apotheosis’ or ‘Red Ruin’), before removing that unit from the battlefield, your opponent must give the treasure it was carrying to another one of their units that does not have a Ghyranite treasure within 3\" of that unit. If this is not possible, that unit counts as having been destroyed for the purpose of this battle tactics card.\n\n• At the start of the battle, your opponent must pick 3 of their units on the battlefield to be carrying a Ghyranite Treasure. They cannot pick faction terrain features or **MANIFESTATIONS**. A unit can only carry 1 Ghyranite Treasure. If your opponent has fewer than 3 units on the battlefield, you automatically complete a number of these battle tactics, starting with the **Domination** battle tactic (followed by the **Strike** and then the **Affray**) until the number of remaining uncompleted battle tactics equals the number of enemy units on the battlefield.\n\n• If you went second in the previous battle round and choose to go first in the current battle round, your opponent can remove 1 Ghyranite Treasure from one of their units at the start of the battle round.",
+      "tactics": [
+        {
+          "id": "d8fcef35-3d48-5002-b853-ccaf2ea0ade5",
+          "name": "Stolen Seedpod",
+          "tacticType": "affray",
+          "lore": "Plucked from the branches of one of the towering trees of Neos, this seed contains a core of raw potential.",
+          "rulesText": "You complete this battle tactic at the end of your turn if at least 1 enemy unit carrying a Ghyranite Treasure has been destroyed this battle.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "2207d36c-84c3-59a1-a094-bf5faf85832d",
+          "name": "Ley Line Taproot",
+          "tacticType": "domination",
+          "lore": "Pulsing with the power of the ley lines, this root glows with the power to work wonders – or horrors.",
+          "rulesText": "You complete this battle tactic at the end of your turn if at least 3 enemy units carrying a Ghyranite Treasure have been destroyed this battle.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "93b2ba20-fb13-5312-a785-e7215f489109",
+          "name": "Contraband Aqua Ghyranis",
+          "tacticType": "strike",
+          "lore": "The Oakenbrow zealously guard Neos’s many springs of Aqua Ghyranis, but their gaze cannot be everywhere…",
+          "rulesText": "You complete this battle tactic at the end of your turn if at least 2 enemy units carrying a Ghyranite Treasure have been destroyed this battle.",
+          "victoryPoints": 5
+        }
+      ]
+    },
+    {
+      "id": "153a3121-5d6f-5fe1-bb68-299ed0538536",
+      "name": "Master The Paths",
+      "cardType": "BattleTacticCard",
+      "source": "aos-4e",
+      "lore": "The verdant innards of Neos resist the stamp of armies and conquerors. To slip along those paths takes woodsmen of great skill.",
+      "rulesText": null,
+      "tactics": [
+        {
+          "id": "e6e2ec96-1183-5101-87cb-4225e38938cc",
+          "name": "Envelop and Strangle",
+          "tacticType": "domination",
+          "lore": "Ensure no corner of the Neosian undergrowth is beyond your reach.",
+          "rulesText": "You complete this battle tactic at the end of your turn if at least 3 different friendly units are each wholly within 9\" of a different corner of the battlefield and only 1 of those corners is wholly within friendly territory. No more than 1 of those units can have been set up this turn.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "0f2fee68-d2da-5e0e-a43b-b28aaddf6ffe",
+          "name": "Seize The Paths",
+          "tacticType": "strike",
+          "lore": "Open tunnels through the foliage are a vital boon. Force the enemy from them.",
+          "rulesText": "You complete this battle tactic at the end of your turn if there are more friendly units in neutral territory than enemy units.\n\nIf there is no neutral territory in the battleplan you are playing, you complete this tactic at the end of your turn if there are no enemy units within friendly territory.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "dbe619ff-0678-55a0-b9be-f29a87bf5936",
+          "name": "Cut Off The Head",
+          "tacticType": "affray",
+          "lore": "Fall upon the leaders of the foe without warning.",
+          "rulesText": "You complete this battle tactic at the end of your turn if an enemy **HERO** has been destroyed this battle.",
+          "victoryPoints": 5
+        }
+      ]
+    },
+    {
+      "id": "8bb76b3c-d033-5904-afba-824ffb48ee3e",
+      "name": "Restless Energy",
+      "cardType": "BattleTacticCard",
+      "source": "aos-4e",
+      "lore": "Do not rest upon your laurels. Expand. Grow. Conquer.",
+      "rulesText": null,
+      "tactics": [
+        {
+          "id": "109eb79a-0372-509e-834e-d2b8875b1dd7",
+          "name": "Invasive Species",
+          "tacticType": "strike",
+          "lore": "Reach your vines and tendrils deep into the territory of the opposition.",
+          "rulesText": "You complete this battle tactic at the end of your turn if you control every objective that can be controlled within enemy territory. If there are no objectives within enemy territory, you complete this battle tactic at the end of your turn if you control every objective that was controlled by your opponent at the start of your turn.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "164750f2-ffdd-5066-ba45-8e27d67220aa",
+          "name": "All Roots Entwined",
+          "tacticType": "domination",
+          "lore": "The cycle will only achieve its true potential when it is brought under your rule.",
+          "rulesText": "You complete this battle tactic at the end of your turn if you control every objective that can be controlled on the battlefield.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "d29dbacd-2f52-58f9-b6d4-01e8bec063e8",
+          "name": "Water With Blood",
+          "tacticType": "affray",
+          "lore": "Sometimes, red must help the green to flourish.",
+          "rulesText": "You complete this battle tactic at the end of your turn if you control an objective that was controlled by your opponent at the start of your turn.",
+          "victoryPoints": 5
+        }
+      ]
+    },
+    {
+      "id": "351279d1-beb3-5c1e-ba59-6d22aa012cfc",
+      "name": "Scouting Force",
+      "cardType": "BattleTacticCard",
+      "source": "aos-4e",
+      "lore": "Focused tactics and small formations are key to triumph under the dense canopies of Neos.",
+      "rulesText": "At the start of the battle, pick each friendly non-**HERO INFANTRY** and non-**HERO CAVALRY** unit that was not set up in reserve using a Deploy ability to become a **scout** unit. You cannot complete these battle tactics with scout units that are in combat. Replacement units that replace scout units are also scout units.",
+      "tactics": [
+        {
+          "id": "b4285317-99bc-547b-a4ce-6aa7db16d350",
+          "name": "Bold Explorers",
+          "tacticType": "strike",
+          "lore": "Only the brave will plunge deep into the ever-seething heart of Neos.",
+          "rulesText": "You complete this battle tactic at the end of your turn if 3 or more objectives or non-**FACTION TERRAIN** terrain features that you control, in any combination, are being contested by any friendly scout units. Those objectives and terrain features must be within enemy territory.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "a55cc01c-5ed1-5a8d-8deb-5a584f0235e9",
+          "name": "Courageous Adventurers",
+          "tacticType": "domination",
+          "lore": "The depths of the forest hold many secrets. Make sure they are yours.",
+          "rulesText": "You complete this battle tactic at the end of your turn if a friendly scout unit that was not set up this turn is contesting a non-**FACTION TERRAIN** terrain feature that you control, that is wholly within enemy territory, and that is more than 6\" from friendly territory.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "f0dff4eb-04c7-59ed-9140-0a1f17a33bfe",
+          "name": "Raiding Party",
+          "tacticType": "affray",
+          "lore": "Ensure the foe knows you will brave their domains.",
+          "rulesText": "You complete this battle tactic at the end of your turn if there are 3 or more friendly scout units wholly outside friendly territory.",
+          "victoryPoints": 5
+        }
+      ]
+    },
+    {
+      "id": "9eac4c1c-d505-5d4b-9552-d9cd66f7bdf4",
+      "name": "Wrathful Cycles",
+      "cardType": "BattleTacticCard",
+      "source": "aos-4e",
+      "lore": "Even in joyous Neos, nature can change without warning. Embody its mercilessness as you turn the tide.",
+      "rulesText": null,
+      "tactics": [
+        {
+          "id": "7f9c2e18-a03c-5d90-8284-13935b4aab76",
+          "name": "Daring Resurgence",
+          "tacticType": "strike",
+          "lore": "Life always fights to endure. Draw upon that vitality now.",
+          "rulesText": "You complete this battle tactic at the end of your turn if you are the underdog this battle round, there is at least 1 friendly unit on the battlefield and at least half of the friendly units on the battlefield (rounding up) used a **FIGHT** ability this turn.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "66ac947a-fb6c-595b-9edf-7eb89c28b22e",
+          "name": "Master of Strategy",
+          "tacticType": "domination",
+          "lore": "Victory blooms from victory, growing greater by the moment.",
+          "rulesText": "You complete this battle tactic at the end of your turn if there is a different friendly unit wholly within each large quarter of the battlefield, you control more objectives than your opponent, and there are no enemy units contesting any objectives that you control.",
+          "victoryPoints": 5
+        },
+        {
+          "id": "b32c2a83-0092-5ba8-b1c9-9c8cba937fd3",
+          "name": "Defiant Surge",
+          "tacticType": "affray",
+          "lore": "Use the invigoration that floods you to overwhelm the enemy.",
+          "rulesText": "You complete this battle tactic at the end of your turn if you control more objectives than your opponent.",
+          "victoryPoints": 5
+        }
+      ]
+    }
+  ],
+  "sections": [
+    {
+      "id": "7930e6bb-a986-5e59-ae9a-def6bd030f48",
+      "name": "The Player's Code",
+      "containers": [
+        {
+          "id": "c3116b79-075e-5076-a172-e4c7bd005c27",
+          "title": "Cardinal Rules",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "bullets"
+            }
+          ]
+        },
+        {
+          "id": "10ab6d54-39de-57a1-806d-79ef226903e6",
+          "title": "Principles",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "bullets"
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "2145308c-1236-5db2-813d-d82d2a315ac4",
+      "name": "Matched Play Battlepack",
+      "containers": [
+        {
+          "id": "a04434a9-e2dc-58b5-8aa9-96938deec527",
+          "title": "1. Pick Your Armies",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Each player picks an army using the rules in Army Composition 2025-26 (Advanced Rules)."
+            }
+          ]
+        },
+        {
+          "id": "ef02afe0-a478-5a7b-83ac-26f910db0681",
+          "title": "2. Determine The Battleplan",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "One player rolls a dice to determine which battleplan table to use. On a 1-3, use battleplan table 1. On a 4-6, use battleplan table 2. The other player then rolls a dice to determine the battleplan. Alternatively, feel free to pick the battleplan you wish to play."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/a77d477a-259f-46df-ba7e-a0578e30ab80",
+                "altText": null
+              }
+            }
+          ]
+        },
+        {
+          "id": "619a5226-d7c8-585b-8c36-4fa4e36fcd93",
+          "title": "3. Set Up The Battlefield",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "header",
+              "text": "Attacker and Defender"
+            },
+            {
+              "type": "text",
+              "text": "The players roll off. The winner chooses which player is the **attacker** and which is the **defender**."
+            },
+            {
+              "type": "header",
+              "text": "Objectives and Terrain"
+            },
+            {
+              "type": "text",
+              "text": "This battlepack contains 6 special objectives called **Ghyranite objectives**: 2 **Oakenbrow** objectives, 2 **Gnarlroot** objectives, 1 **Winterleaf** objective and 1 **Heartwood** objective. The objective itself is the 40mm-diameter circle located in the centre, while the surrounding area extending 3\" from the objective is the **control zone**. To contest a Ghyranite objective, a unit must be within the control zone of that Ghyranite objective.\n\nThe defender sets up Ghyranite objectives in the locations indicated on the battlefield map. The objectives must be those indicated on the battlefield map; for example, if the map shows an Oakenbrow objective, the Oakenbrow objective must be set up in that location.\n\nThen, the defender sets up terrain features. We recommend 4 small and 4 medium terrain features. Each terrain feature must be set up more than 3\" from the battlefield edge, more than 3\" from all Ghyranite objectives and more than 6\" from all other terrain features. Alternatively, the battlefield can be set up as shown on the corresponding battlefield terrain layout map while maintaining the distance restrictions between the battlefield edge, objectives and other terrain features as detailed above."
+            },
+            {
+              "type": "header",
+              "text": "Territory"
+            },
+            {
+              "type": "text",
+              "text": "After Ghyranite objectives and terrain have been set up, the attacker picks which territory is their territory. The other territory is the defender’s territory. The players then resolve the deployment phase. The attacker begins deployment (Core Rules, 10.0)."
+            },
+            {
+              "type": "header",
+              "text": "Battle Length"
+            },
+            {
+              "type": "text",
+              "text": "Battles that use this battlepack last for 5 battle rounds."
+            },
+            {
+              "type": "header",
+              "text": "Glorious Victory"
+            },
+            {
+              "type": "text",
+              "text": "Each battleplan will describe how to score victory points. At the end of the battle, if one player has at least 5 victory points more than their opponent, they win a major victory. If one player has fewer than 5 more victory points than their opponent, they win a minor victory. If the players are tied on victory points, the player who completed the most battle tactics wins a minor victory. If the players are tied on victory points and completed the same number of battle tactics, the battle is a draw."
+            },
+            {
+              "type": "header",
+              "text": "Battle Tactics"
+            },
+            {
+              "type": "text",
+              "text": "If you are using this battlepack, you must pick battle tactics cards from this battlepack to add to your army roster during army composition.\n\nAt the start of the battle, you must reveal your choice of battle tactics cards to your opponent. If the battle tactics card instructs you to pick something, you must tell your opponent what you pick and vice versa."
+            }
+          ]
+        },
+        {
+          "id": "766ecb0c-18b5-5c5b-ba59-26bc92ee8e85",
+          "title": "Advanced Rules",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "In addition to the Core Rules and the Season Rules 2025- 26, this battlepack uses the following Advanced Rules:\n\n• Battle Tactics 2025-26\n• Commands 2025-26\n• Terrain 2025-26\n• Magic 2025-26\n• Army Composition 2025‑26\n• Command Models"
+            }
+          ]
+        },
+        {
+          "id": "84904ca9-a8ed-5431-bbb9-23737baef5ea",
+          "title": "Battlefield Size",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "The battleplans in this battlepack have been designed for 1000- or 2000-point battles and we recommend a 44\" × 60\" battlefield with 8 terrain features. However, some players prefer to use a 30\" × 44\" battlefield with 4 terrain features for 1000-point battles.\n\nIf you have agreed on a points limit outside these bounds, feel free to adjust the battlefield size and number of terrain features appropriately."
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "7064bd1e-8c0e-5981-843c-fb4544f13e6d",
+      "name": "Matched Play Publications 2025-26",
+      "containers": [
+        {
+          "id": "da61a9b8-3d40-5bd4-9128-a035d23aac0f",
+          "title": "Introduction",
+          "subtitle": null,
+          "containerType": "introduction",
+          "components": [
+            {
+              "type": "text",
+              "text": "As Warhammer Age of Sigmar continues to grow, naturally, we will continue to write rules for the game. However, when you are playing competitively, sometimes it’s hard to know which of these rules are ‘legal’ – in other words, which rules you can use in Matched Play battles. On this page, we’ve provided a handy at-a-glance list that shows you all the publications whose rules you are allowed to use in Matched Play battles."
+            }
+          ]
+        },
+        {
+          "id": "0ea982f2-2eda-5392-9f78-f662bf760d64",
+          "title": "Core",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "• *Warhammer Age of Sigmar Core Book*\n• *General’s Handbook 2025-26*\n• *Warhammer Age of Sigmar Faction Packs*\n• *Battle Profiles & Rules Updates*\n• Battletome publications, excluding Warhammer Legends rules"
+            }
+          ]
+        },
+        {
+          "id": "cd80f0aa-09f5-5b50-b8df-92d6dd55747c",
+          "title": "Battletomes",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Throughout this edition of Warhammer Age of Sigmar, we will be releasing battletomes for each faction. Battletomes contain additional and/or updated faction rules, which include battle traits, battle formations and enhancements. When a battletome is released, it will supersede the rules set out in the Faction Pack for that faction."
+            }
+          ]
+        },
+        {
+          "id": "402fa85e-f4fe-5d54-9f8b-fafcad397971",
+          "title": "Digital Updates",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "We sometimes release digital updates on warhammer-community.com. When we do, we will say whether that rules set is legal for use and, if so, in which types of battlepacks it can be used."
+            }
+          ]
+        },
+        {
+          "id": "c97e6839-e308-52a1-b4d5-78ca09c74281",
+          "title": "Battlescrolls",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Battlescrolls are rules updates that focus on balancing the game meta more actively. Sometimes they are simply useful summaries of corrections that also appear in the relevant errata documents. At other times, they appear as sets of entirely new rules that, while not compulsory, are highly recommended for use in Matched Play battles. The rules in battlescrolls will always be used at official Warhammer Age of Sigmar events."
+            }
+          ]
+        },
+        {
+          "id": "4d94b30a-d84d-512d-890f-81241cfbf912",
+          "title": "Errata",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Periodically, we release errata documents for our publications that correct any errors. These include things like outright mistakes, rules that didn’t quite work the way we intended them to, and rules that have had an unforeseen and undesirable impact on the game meta. The errata documents are considered to be part of the publications that they are correcting, so we don’t list them separately here."
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "bf2b741b-f184-5813-9556-b361886e86a7",
+      "name": "Season Rules 2025-26",
+      "containers": [
+        {
+          "id": "cf6305fd-b86a-59f3-b8ab-4b5e1ec39dd8",
+          "title": "Gyranite Objectives",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "The battleplans in the *General’s Handbook 2025-26* battlepack use the following **Ghyranite objective markers**:"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/10199dff-699f-4f1e-82bc-e35915a10402",
+                "altText": null
+              }
+            },
+            {
+              "type": "text",
+              "text": "Each Ghyranite objective marker comprises a 40mm-diameter round objective that is wholly within and surrounded by a **control zone**."
+            }
+          ]
+        },
+        {
+          "id": "523e9d38-9d1c-5546-9f19-b3d411112785",
+          "title": "Contesting Ghyranite Objectives",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "While a Ghyranite objective is within a model’s combat range, that **model** is contesting that objective. While any models in a unit are contesting a Ghyranite objective, that **unit** is contesting that Ghyranite objective."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/9bd92c3a-a429-436d-a343-dc94d5d9a469",
+                "altText": null
+              }
+            },
+            {
+              "type": "header",
+              "text": "Paired Objectives"
+            },
+            {
+              "type": "text",
+              "text": "Some battleplans will use more than one of the same type of Ghyranite objective. For example, they could include two **Oakenbrow** objectives and/or two **Gnarlroot** objectives. In these battleplans, the rules refer to two of the same type of Ghyranite objective as a **pair** or **paired**. When a rule requires a player to control a pair of objectives, the player has to control both objectives in that pair.\n\nWhen a player has to pick ‘a pair of objectives’, they can only pick a single pair of Ghyranite objectives of the same type. For example, that player could pick either both **Oakenbrow** objectives or both **Gnarlroot** objectives. They could not pick an **Oakenbrow** objective and a **Gnarlroot** objective, or both **Oakenbrow** objectives and both **Gnarlroot** objectives."
+            },
+            {
+              "type": "header",
+              "text": "Obscured Ghyranite Objectives"
+            },
+            {
+              "type": "text",
+              "text": "Some abilities can confer the ‘Obscuring’ terrain ability on a Ghyranite objective, even though it is not a terrain feature. In these cases, replace the words ‘within 1\" of this terrain feature’ in the ability with ‘wholly within this Ghyranite objective’s control zone’."
+            }
+          ]
+        },
+        {
+          "id": "4fde2f15-2c43-531f-a07d-5500b4414a71",
+          "title": "Regimented Forces",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "If a player has more regiments than their opponent at the start of the battle, then once per battle, that player can re-roll their priority roll after seeing the result of both players’ rolls but before determining priority for that battle round."
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "aa3e1772-57ae-50b3-be52-fb2dc2cfb0f8",
+      "name": "Battle Tactics 2025-26",
+      "containers": [
+        {
+          "id": "83ebdb6a-e8c8-5b51-9bd0-b2e024d45ee2",
+          "title": "1.0 Battle Tactics Overview",
+          "subtitle": null,
+          "containerType": "introduction",
+          "components": [
+            {
+              "type": "text",
+              "text": "During a battle, each player can score extra victory points by completing battle tactics from a **battle tactics card**. You can pick up to **2** battle tactics cards for your army during army composition, and the battle tactics cards you pick must be marked on your army roster.\n\nBefore deployment, you must tell your opponent which battle tactics cards you have picked for your army.\n\nEach battle tactics card has 3 battle tactics: 1 **Affray** battle tactic, 1 **Strike** battle tactic and 1 **Domination** battle tactic. You must complete the Affray battle tactic on that card before you can complete the Strike battle tactic on that card. Similarly, you must complete the Strike battle tactic on that card before you can complete the Domination battle tactic on that card.\n\nYou can complete **1 battle tactic on each of your battle tactics cards** at the end of each of your turns unless specified otherwise on that battle tactics card."
+            }
+          ]
+        },
+        {
+          "id": "c9a0d5e3-3ec8-5218-be99-f712ea68fdb8",
+          "title": "2.0 Seizing The Initiative",
+          "subtitle": null,
+          "containerType": "introduction",
+          "components": [
+            {
+              "type": "text",
+              "text": "If the player who went second in the previous battle round wins the priority roll and chooses to go first, unless their opponent is leading by 11 or more victory points, it is called **seizing the initiative**.\n\nWhen a player seizes the initiative, their opponent always counts as the underdog until that opponent seizes the initiative.\n\nA player who seizes the initiative cannot complete any battle tactics in that turn."
+            }
+          ]
+        },
+        {
+          "id": "c4ede84c-33e6-5b76-b082-af2720d1426d",
+          "title": "3.0 Completing Battle Tactics",
+          "subtitle": null,
+          "containerType": "introduction",
+          "components": [
+            {
+              "type": "text",
+              "text": "If, at the end of your turn, you have completed a battle tactic as described above, you score the number of victory points shown for that battle tactic."
+            }
+          ]
+        },
+        {
+          "id": "2894bb3d-dbde-5529-9a56-b2358bda857e",
+          "title": "Battle Tactics Card 1 - Master the Paths",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "battleTactic",
+              "battleTactic": "Cut Off The Head"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Seize The Paths"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Envelop and Strangle"
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "The verdant innards of Neos resist the stamp of armies and conquerors. To slip along those paths takes woodsmen of great skill"
+            }
+          ]
+        },
+        {
+          "id": "23731481-8105-572b-94b9-be1757da2a4e",
+          "title": "Battle Tactics Card 2 - Restless Energy",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "battleTactic",
+              "battleTactic": "Water With Blood"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Invasive Species"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "All Roots Entwined"
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Do not rest upon your laurels. Expand. Grow. Conquer."
+            }
+          ]
+        },
+        {
+          "id": "8bb67e15-0f2f-5932-80df-081070eb8135",
+          "title": "Battle Tactics Card 3 - Intercept and Recover",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "•  If you went second in the previous battle round and choose to go first in the current battle round, your opponent can remove 1 Ghyranite Treasure from one of their units at the start of the battle round.\n\n•  If an ability would remove a unit that was carrying treasure from the battlefield and that unit is not set up again as part of the same ability (e.g. ‘Dark Apotheosis’ or ‘Red Ruin’), before removing that unit from the battlefield, your opponent must give the treasure it was carrying to another one of their units that does not have a Ghyranite treasure within 3\" of that unit. If this is not possible, that unit counts as having been destroyed for the purpose of this battle tactics card.\n\n•  At the start of the battle, your opponent must pick 3 of their units on the battlefield to be carrying a Ghyranite Treasure. They cannot pick faction terrain features or **MANIFESTATIONS**. A unit can only carry 1 Ghyranite Treasure. If your opponent has fewer than 3 units on the battlefield, you automatically complete a number of these battle tactics, starting with the **Domination** battle tactic (followed by the **Strike** and then the **Affray**) until the number of remaining uncompleted battle tactics equals the number of enemy units on the battlefield."
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Stolen Seedpod"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Contraband Aqua Ghyranis"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Ley Line Taproot"
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "There are many who would thieve Neos’s life-giving relics. Recover them – either for noble purposes or in furtherance of darker goals…"
+            }
+          ]
+        },
+        {
+          "id": "9fab5333-b199-5181-8898-782365ce07f1",
+          "title": "Battle Tactics Card 4 - Wrathful Cycles",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "battleTactic",
+              "battleTactic": "Defiant Surge"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Daring Resurgence"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Master of Strategy"
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Even in joyous Neos, nature can change without warning. Embody its mercilessness as you turn the tide."
+            }
+          ]
+        },
+        {
+          "id": "d79f7e70-9960-5abe-b6d4-4ac9f8455129",
+          "title": "Battle Tactics Card 5 - Scouting Force",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "At the start of the battle, pick each friendly non-**HERO INFANTRY** and non-**HERO CAVALRY** unit that was not set up in reserve using a **DEPLOY** ability to become a **scout** unit. You cannot complete these battle tactics with scout units that are in combat. Replacement units that replace scout units are also scout units."
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Raiding Party"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Bold Explorers"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Courageous Adventurers"
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "Focused tactics and small formations are key to triumph under the dense canopies of Neos."
+            }
+          ]
+        },
+        {
+          "id": "f561ed5b-8c13-58ac-b33f-e9039b973c54",
+          "title": "Battle Tactics Card 6 - Attuned to Ghyran",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "battleTactic",
+              "battleTactic": "Sacred Centrality"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Fey Strikes"
+            },
+            {
+              "type": "battleTactic",
+              "battleTactic": "Purification Rites"
+            },
+            {
+              "type": "loreAccordion",
+              "title": "Lore",
+              "text": "The air of Neos is strangely febrile, as if the will of the realm crackles there. One could heed it, perhaps…"
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "0e0d1802-aaf0-5dc4-9fb0-b0fd3e963e5f",
+      "name": "Battleplan Maps",
+      "containers": [
+        {
+          "id": "aac49264-829a-57ea-9441-36a1319a0cd9",
+          "title": "Overview",
+          "subtitle": null,
+          "containerType": "introduction",
+          "components": [
+            {
+              "type": "text",
+              "text": "The battleplan maps show the player territories and the locations where terrain and objectives should be placed on the battlefield."
+            }
+          ]
+        },
+        {
+          "id": "9778c8b1-c11c-5ae1-ab2c-351bf4084bdd",
+          "title": "Player Territories",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "Each battleplan map shows two territories: one red (Attacker’s Territory) and one blue (Defender’s Territory)."
+            }
+          ]
+        },
+        {
+          "id": "dce3107f-6ac8-5c71-87d0-d2ea62b4e4a4",
+          "title": "Objectives Locations",
+          "subtitle": null,
+          "containerType": "standard",
+          "components": [
+            {
+              "type": "text",
+              "text": "The locations of Ghyranite objectives are indicated on the battleplan maps by the following icons."
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/62a5bc8a-6865-4673-b44a-75ac5d5ae372",
+                "altText": null
+              }
+            },
+            {
+              "type": "text",
+              "text": "Each icon represents the Ghyranite objective including its control zone. Where an objective icon is shown on the map, you must place the corresponding objective marker on the battlefield centred on the location of the objective icon shown on the map. For example, where the map shows an Oakenbrow objective icon, place an Oakenbrow objective on the battlefield in that location."
+            },
+            {
+              "type": "header",
+              "text": "Terrain Locations"
+            },
+            {
+              "type": "text",
+              "text": "The terrain location icons show where terrain features should be set up and what type of terrain should be placed in each terrain location. The following key shows which terrain features correspond to which icons:"
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/195567dd-1539-42cc-bade-edeebce01608",
+                "altText": null
+              }
+            },
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/d881b8be-65a8-4c37-8329-57128bd1f242",
+                "altText": null
+              }
+            },
+            {
+              "type": "accordion",
+              "title": "Battlefield Key",
+              "text": "1\\) Guardian Idol (S Obstacle)\n2\\)Bad Moon Loonshrine (M Faction Terrain)\n3\\) Heartwood Objective (Ghyranite Objective)\n4\\) Nexus Syphon (S Place of Power)\n5\\) Megadroth Remains (S Obstacle)\n6\\) Wyldwood (M Obscuring Terrain)\n7\\) Cleansing Aqualith (M Place of Power)\n8\\) Domicile Shell (S Obstacle)\n9\\) Gnawhole (S Faction Terrain)"
+            },
+            {
+              "type": "text",
+              "text": "**Designer’s Note:** *Faction terrain features do not appear on the battleplan maps because these are set up during deployment – the example battlefield below shows the battlefield just before units are deployed.*"
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "09ad25ca-be53-55cb-ba09-4c290baf7384",
+      "name": "Battleplans 2025-26",
+      "containers": [],
+      "sections": [
+        {
+          "id": "352527d9-16f3-5a80-b8e8-68f47351050d",
+          "name": "Passing Seasons",
+          "containers": [
+            {
+              "id": "5f9eae2d-0f58-5e1f-b8e3-09167de74498",
+              "title": "Passing Seasons",
+              "subtitle": "Battleplan 1 (Table 1)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: In battle rounds 2 and 4, if you are the **underdog**, you can use the ‘Burgeoning Rejuvenation’ ability. In battle rounds 3 and 5, while you are the **underdog**, your army has the ‘Powerful Resurgence’ ability."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "fa2c3731-2f13-5560-99ba-45409f37115a",
+                    "name": "Burgeoning Rejuvenation",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "defensive",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "Pick 1 of the following:\n\n• **Heal (D3)** every friendly unit contesting an **Oakenbrow** objective.\n•  For the rest of the battle round, while a friendly unit is contesting a **Gnarlroot**\n-  If it has a ward save, add 1 to ward rolls for that unit.\n-  If it does not have a ward save, it has **WARD (6+).**",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "8e429249-545a-52c2-b2f1-71daef680d30",
+                    "name": "Powerful Resurgence",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Passive",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "Add 1 to wound rolls for combat attacks made by friendly units while they are contesting a **Gnarlroot** objective.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• In battle rounds 1, 3 and 5, score 5 victory points for each **Gnarlroot** objective that you control.\n• In battle rounds 2 and 4, score 5 victory points for each **Oakenbrow** objective that you control."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/37123a64-820e-4fbf-b627-9f1cd06d24e8",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/bb92f734-4558-40c5-a691-76871aca3359",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "8c4f2b3c-8b45-5367-9604-130b12a47e19",
+          "name": "Paths of the Fey",
+          "containers": [
+            {
+              "id": "3990c108-3352-5e9e-8fe4-870076de9ded",
+              "title": "Paths of the Fey",
+              "subtitle": "Battleplan 2 (Table 1)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you must use the ‘The Spirit Paths Open’ ability. Both players can use the ‘Stumbling Forth’ ability."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "5f047493-fd5e-578e-9819-4a6500854b9f",
+                    "name": "The Spirit Paths Open",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": "Pick 2 objectives to be the targets.",
+                    "effect": "All units, excluding faction terrain and **MANIFESTATIONS**, within 6\" of any target objectives must be removed from the battlefield by their commander. Those units are **vanished**. Then, starting with you, players must take it in turns to set up each friendly **vanished** unit wholly within 3\" of either target objective and more than 3\" from all enemy units. Those units cannot use **MOVE** abilities in the first movement phase of the battle round. If it is impossible for a unit to be set up in this way, it is set up in reserve as a **lost** unit.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "f3321551-0cd6-5fa1-afff-ceb05ade26d0",
+                    "name": "Stumbling Forth",
+                    "phase": "movementPhase",
+                    "phaseDetails": "Your Movement Phase",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": "Pick a friendly **lost** unit (see above) to be the target.",
+                    "effect": "Set up the target on the battlefield, more than 9\" from all enemy units and wholly within 7\" of a battlefield edge.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/a534c383-30c4-4f92-a234-704f395210a2",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/651358e8-81e4-4010-8006-13d81f9e970e",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "721e7f73-1b07-5ef5-9c64-3e7e52951df7",
+          "name": "Roiling Roots",
+          "containers": [
+            {
+              "id": "7b3803ef-96a9-54dd-bbad-4778a4484304",
+              "title": "Roiling Roots",
+              "subtitle": "Battleplan 3 (Table 1)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you must use the ‘Tangling Tendrils’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "18f47b6c-ac1c-5672-aa00-36ed8cf16605",
+                    "name": "Tangling Tendrils",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "defensive",
+                    "cpCost": null,
+                    "declare": "Pick a pair of objectives to be the targets.",
+                    "effect": "For the rest of the battle round, units (friendly and enemy) have **STRIKE‑LAST** while they are contesting either target objective.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/ba01e007-dc2c-45f2-ac66-5b8ea21e1b58",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/adec1e47-684d-4cb9-bc97-43687a8ca672",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "5cc9942f-6b33-54bc-86d1-d4633d7ca0a5",
+          "name": "Cyclic Shifts",
+          "containers": [
+            {
+              "id": "7bf57dd5-58fe-524c-a0c3-8b55405c70b5",
+              "title": "Cyclic Shifts",
+              "subtitle": "Battleplan 4 (Table 1)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you can use the ‘Unpredictable Evolution’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "77d14343-b197-5731-bc47-5d649ea18b60",
+                    "name": "Unpredictable Evolution",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "control",
+                    "cpCost": null,
+                    "declare": "Pick a pair of objectives to be the targets.",
+                    "effect": "The target objectives are no longer controlled by either player (if they were) and they cannot be controlled this battle round.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/9a2026ae-ac22-4420-86ab-ee667ebfd1c0",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/97368535-7643-4f30-b7d1-b87ffd42eeac",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "21e89439-a598-5834-920d-6c1aa4a05915",
+          "name": "Surge of Slaughter",
+          "containers": [
+            {
+              "id": "f7291f61-091e-5f40-91dd-8e079a126aee",
+              "title": "Surge of Slaughter",
+              "subtitle": "Battleplan 5 (Table 1)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you can use the ‘Defence of the Realm’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "09600a01-f650-5ab9-be49-3499daa535a2",
+                    "name": "Defence of the Realm",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": "Pick a pair of objectives to be the targets.",
+                    "effect": "For the rest of the battle round, add 1 to the Rend characteristic of friendly units’ melee weapons while they are contesting either of the target objectives.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/b111de11-153f-4e5e-a184-19dc09bb5a41",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/03ec2826-07f1-4b86-9b44-d3451d6288c5",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "f223420a-700f-54ea-86a7-0d68cd0f8935",
+          "name": "Linked Ley Lines",
+          "containers": [
+            {
+              "id": "954d62da-cae2-5e3f-abcf-63444877f49d",
+              "title": "Linked Ley Lines",
+              "subtitle": "Battleplan 6 (Table 1)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: While you are the **underdog**, your army has the ‘Rooted in the Realm’ and ‘Full of Life’ abilities:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "7ef98963-80ba-59b4-9b91-4f1cd4e52d60",
+                    "name": "Rooted in the Realm",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Passive",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "Friendly units’ weapons have **Anti‑MANIFESTATION (+1 Rend)** while those units are a contesting an objective that is both controlled by you and on a **linked ley line** (see below).",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "1102de06-a351-5067-874d-e69fb7dc94fa",
+                    "name": "Full of Life",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Passive",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "Friendly **MANIFESTATIONS** have **STRIKE-FIRST**.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "A linked ley line is formed from the middle of one edge of the battlefield to the middle of the opposite edge while one player controls all the objectives on that line.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 3 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control any pairs of objectives.\n• Score 2 victory points if you control all of the objectives on a linked ley line."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/65b56453-3b41-4553-9780-e90b2905e84b",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/978b3154-5c4f-4c80-92ae-8510d0a3b62f",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "3cd2cf89-ccc0-5e84-bd71-36cc3ad24823",
+          "name": "Noxious Nexus",
+          "containers": [
+            {
+              "id": "eb895a93-0bda-5416-875f-00822510bbf0",
+              "title": "Noxious Nexus",
+              "subtitle": "Battleplan 1 (Table 2)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you can use the ‘Caustic Sap’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "355208fe-585b-5d97-8286-333eb30a62e1",
+                    "name": "Caustic Sap",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": "Pick an objective. Each unit contesting that objective is a target.",
+                    "effect": "Roll a D3 for each target. On a 2+, inflict an amount of mortal damage on the target equal to the roll. If you picked the **Heartwood** objective, roll a D6 for each target instead.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Objectives cannot be controlled in the first battle round.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control the **Oakenbrow** objective.\n• Score 3 victory points if you control the **Gnarlroot** objective.\n• Score 2 victory points if you control the **Heartwood** objective.\n\nIn addition, at the end of the battle, a player scores 10 victory points if they control the **Heartwood** objective."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/da81ad62-efc5-4012-83eb-3e9665215d5f",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/72381d13-c129-4781-93cc-0ee58827486b",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "71c73ce5-e208-504e-baea-0f728a454013",
+          "name": "The Liferoots",
+          "containers": [
+            {
+              "id": "d72e3b6f-f8ad-56df-b54a-d227b90c842c",
+              "title": "The Liferoots",
+              "subtitle": "Battleplan 2 (Table 2)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you can use the ‘Life Begets Life’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "b8fb6c36-649d-5dad-b463-f174cd4abacf",
+                    "name": "Life Begets Life",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "rallying",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that has all of its models within 1\" of a terrain feature to be the target.",
+                    "effect": "Return 1 slain model to the target unit.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores 1 **liferoot point** at the end of each of their turns for each non-**FACTION TERRAIN** terrain feature they control.\n\nEach player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control both objectives.\n• Score 2 victory points if you have more **liferoot points** than your opponent."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/73b44613-b55a-4a50-bd06-2ea3aabe891e",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/29d1eef8-7417-4f7b-bbb1-9675826815f6",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "bb0c3ca9-93f0-5073-a6d9-1ad80291ec5c",
+          "name": "Bountiful Equinox",
+          "containers": [
+            {
+              "id": "8c79a1f4-89d9-5035-aa6c-6787ffdf32a4",
+              "title": "Bountiful Equinox",
+              "subtitle": "Battleplan 3 (Table 2)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you can use the ‘Rejuvenating Bloom’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "a00c1ba4-b2d3-5f42-af8e-1f6b64759a46",
+                    "name": "Rejuvenating Bloom",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "defensive",
+                    "cpCost": null,
+                    "declare": "Pick an objective to be the target.",
+                    "effect": "**Heal (3)** each unit (friendly and enemy) contesting the target objective.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control at least 1 **Oakenbrow** , 1 **Gnarlroot** and 1 **Heartwood** objective."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/7ff7cff9-1ee4-46f0-b257-a961fe88f491",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/ee2b273b-6fc1-48e1-ba8a-2eecd60e56f9",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "82d4f8d8-72f1-576c-8811-8afe8af87528",
+          "name": "Lifecycle",
+          "containers": [
+            {
+              "id": "23e5dad4-31f8-5a31-98f2-382e9df8df1b",
+              "title": "Lifecycle",
+              "subtitle": "Battleplan 4 (Table 2)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: At the start of the second battle round, the **underdog** must use the ‘Lifecycle’ ability. If there is no **underdog**, the players roll off and the winner must use the ‘Lifecycle’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "11385df2-e964-5340-a091-625cca964d90",
+                    "name": "Lifecycle",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle, Start of Second Battle Round",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "Pick either the **Oakenbrow** or the **Gnarlroot** objective to be the primary objective. At the start of each subsequent battle round, the next objective in the cycle becomes the primary objective. The objectives before and after the primary objective in the cycle order (see below) are the secondary objectives.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "header",
+                  "text": "Cycle Order"
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/4fdba5fc-adbb-4bd4-9ddd-ceb607c38299",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 4 victory points if you control at least 1 objective.\n• Score 2 victory points if you control more objectives than your opponent.\n• Score 4 victory points if you control both the **Oakenbrow** and **Gnarlroot** objectives (first battle round only).\n• Score 2 victory points if you control the primary objective.\n• Score 1 victory point for each secondary objective that you control."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/982ded7a-4d2e-4f7d-b676-ae4baf371193",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/b9ceebf6-6210-4167-9ca8-6051fcb08751",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "0880b669-0418-5cbf-92c0-e716e1b3d24a",
+          "name": "Creeping Corruption",
+          "containers": [
+            {
+              "id": "49f38ad8-3fca-57f1-bc25-af1306843f5a",
+              "title": "Creeping Corruption",
+              "subtitle": "Battleplan 5 (Table 2)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you can use the ‘Pulsing Life Energies’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "1279662a-627c-55df-a80c-fed6a4aba128",
+                    "name": "Pulsing Life Energies",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick an objective you control and 1 other objective (whether you control it or not). Draw a line between the centres of those objectives. Then, choose **propagation** or **corruption**.",
+                    "effect": "Apply the appropriate effect:\n\n***Propagation:*** Add 1 to casting rolls, chanting rolls and banishment rolls for each unit crossed by the line for the rest of the battle round.\n\n***Corruption:*** Inflict D3 mortal damage on each unit crossed by the line.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/d7ea47c1-3251-4c7f-bc82-96f891c53981",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/4f6159a4-80db-49ca-8ea5-5ba069fb5c0f",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "f2fdc316-743d-52b9-b601-0e17928d3f74",
+          "name": "Grasp of Thorns",
+          "containers": [
+            {
+              "id": "579209db-7644-5c47-bbb9-78a8b7055cd0",
+              "title": "Grasp of Thorns",
+              "subtitle": "Battleplan 6 (Table 2)",
+              "containerType": "missionType",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**TWIST**: If you are the **underdog**, you can use the ‘Carnivorous Flora’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "e4d9eab0-f0e3-5411-a4de-4c0523333d6d",
+                    "name": "Carnivorous Flora",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Battle Round, Start of Battle Round",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick an objective to be **grasping**.",
+                    "effect": "Roll a dice for each unit contesting that objective. On a 3+, every model in that unit that is within the control zone of that objective is **entangled** for the rest of the battle round.\n\n**Entangled** models must stay within the control zone of the **grasping** objective for the rest of the battle round. While a unit has any **entangled** models, it cannot be removed from the battlefield by an ability that would allow it to be set up elsewhere on the battlefield. That objective cannot be moved while there are any entangled models contesting it.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Each player scores victory points at the end of each of their turns as follows:\n\n• Score 5 victory points if you control at least 1 objective.\n• Score 3 victory points if you control 2 or more objectives.\n• Score 2 victory points if you control more objectives than your opponent."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/7e6e3ae4-1ab2-4db0-8c59-7137c42fd5c2",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/6e6f6ac2-255d-4362-984c-cbafab2025cb",
+                    "altText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "b1ad3771-b324-5e55-bd62-3826adf6958c",
+      "name": "Addenda, Errata and FAQs",
+      "containers": [],
+      "sections": [
+        {
+          "id": "19e467b3-88b8-589a-af78-39a4efd4ac12",
+          "name": "Addenda",
+          "containers": [
+            {
+              "id": "9e10e9f4-8e4f-5687-b11a-b8f7418c619b",
+              "title": "Addenda",
+              "subtitle": null,
+              "containerType": "introduction",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The following rules updates add text in order to clarify ambiguities and/or avoid unintended interactions."
+                }
+              ]
+            },
+            {
+              "id": "2d2d65a0-0ce9-58ac-aa09-198c5bd58179",
+              "title": "Season Rules (2025-26)",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following rule:\n\n‘**REGIMENTED FORCES**\nIf a player has more regiments than their opponent at the start of the battle, then once per battle, that player can re-roll their priority roll after seeing the result of both players’ rolls but before determining priority for that battle round.'"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "37d38feb-6d24-5382-9f57-e1e8ce17bc5b",
+          "name": "Errata",
+          "containers": [
+            {
+              "id": "c2484f27-fb84-5402-a7bd-8fd7dc1ebe7b",
+              "title": "Errata",
+              "subtitle": null,
+              "containerType": "introduction",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The following rules updates correct errors in order to clarify ambiguities and/or avoid unintended interactions."
+                }
+              ]
+            },
+            {
+              "id": "3abcb7d3-fe26-539f-ae4e-85cb6186e225",
+              "title": "Battleplan: Liferoots",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the battleplan rules, replace ‘for each terrain feature they control’ with ‘for each non-**FACTION TERRAIN** terrain feature they control’."
+                }
+              ]
+            },
+            {
+              "id": "aa9c9429-8088-5edb-af6f-0c2ef2c99d29",
+              "title": "Battleplan: Linked Leylines",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the battleplan rules, change:\n‘A linked ley line is formed across the battlefield (long edge to long edge or short edge to short edge)’\nTo:\n‘A linked ley line is formed from the middle of one edge of the battlefield to the middle of the opposite edge.’"
+                }
+              ]
+            },
+            {
+              "id": "cf2c0742-a564-550e-8f61-c7407a2b6eea",
+              "title": "Battleplan: Paths of the Fey",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change the effect of ‘The Spirit Paths Open’ to:\n‘All units, excluding faction terrain and **MANIFESTATIONS**, within 6\" of any target objectives must be removed from the battlefield by their commander. Those units are **vanished**. Then, starting with you, players must take it in turns to set up each friendly **vanished** unit wholly within 3\" of either target objective and more than 3\" from all enemy units. Those units cannot use **MOVE** abilities in the first movement phase of the battle round. If it is impossible for a unit to be set up in this way, it is set up in reserve as a **lost** unit.’"
+                }
+              ]
+            },
+            {
+              "id": "b060c953-a7f4-5652-b4bd-41bbdab5379a",
+              "title": "Battleplan: Creeping Corruption",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change the effect of ‘Propagation’ in the ‘Pulsing Life Energies’ ability to:\n‘Add 1 to casting rolls, chanting rolls and banishment rolls for each unit crossed by the line for the rest of the battle round.’"
+                }
+              ]
+            },
+            {
+              "id": "6344cc6e-a60b-5a6e-aaca-224b009488b4",
+              "title": "Battleplan: Grasp of Thorns",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following to the end of ‘Carnivorous Flora’:\n\n‘That objective cannot be moved while there are any entangled models contesting it.’"
+                }
+              ]
+            },
+            {
+              "id": "37b90b58-31fa-59dd-8aed-7380b9f0a42e",
+              "title": "Battle Tactic Card 2: Restless Energy",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the Strike and Domination battle tactics, replace ‘control every objective’ with ‘control every objective that can be controlled’."
+                }
+              ]
+            },
+            {
+              "id": "5bd9cd30-cc21-516a-91d1-3b784e40e9a5",
+              "title": "Battle Tactics Card 3: Intercept and Recover",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following to the top of the battle tactics card:\n‘If an ability would remove a unit that was carrying treasure from the battlefield and that unit is not set up again as part of the same ability (e.g. ‘Dark Apotheosis’ or ‘Red Ruin’), before removing that unit from the battlefield, your opponent must give the treasure it was carrying to another one of their units that does not have a Ghyranite treasure within 3\" of that unit. If this is not possible, that unit counts as having been destroyed for the purpose of this battle tactics card.’"
+                }
+              ]
+            },
+            {
+              "id": "98b7a653-c0be-5e20-bc50-0de661abef35",
+              "title": "Battle Tactics Card 5: Scouting Force",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Replace: ‘At the start of the battle, every friendly non-**HERO INFANTRY** and non-**HERO CAVALRY** unit wholly within friendly territory becomes a **scout** unit.’\nwith:\n‘At the start of the battle, pick each friendly non-**HERO INFANTRY** and non-**HERO CAVALRY** unit that was not set up in reserve using a **DEPLOY** ability to become a **scout** unit.'"
+                },
+                {
+                  "type": "text",
+                  "text": "In the Strike: Bold Explorers battle tactic rule, replace ‘3 or more objectives or terrain features’ with ‘3 or more objectives or non-**FACTION TERRAIN** terrain features'."
+                },
+                {
+                  "type": "text",
+                  "text": "In the Domination: Courageous Adventurers battle tactic rule, replace ‘is contesting a terrain feature’ with ‘is contesting a non-**FACTION TERRAIN** terrain feature’."
+                }
+              ]
+            },
+            {
+              "id": "bbac97e2-293e-5012-86b4-3f27319db862",
+              "title": "Battle Tactics Card 6: Attuned to Ghyran",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change the Strike: Fey Strikes battle tactic rule to:\n‘You complete this battle tactic at the end of your turn if all the following are true:\n• At least 2 friendly units moved as part of a **RETREAT** ability this turn. Those units are **lure** units.\n• At least 2 other friendly units charged this turn and at least 1 of those units ended the charge move in combat with an enemy unit from which any lure **units** retreated.’"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "c9658cdc-5b2c-5624-ad20-65b3ab03a6af",
+          "name": "Frequently Asked Questions",
+          "containers": [
+            {
+              "id": "f4c1767c-956c-5eaa-910f-64e5e3bf8046",
+              "title": "Frequently Asked Questions",
+              "subtitle": null,
+              "containerType": "introduction",
+              "components": [
+                {
+                  "type": "boxedText",
+                  "text": "In this series of questions and answers, the rules-writing team respond to players’ queries and explain how the rules are intended to be used."
+                }
+              ]
+            },
+            {
+              "id": "47749ef8-84f5-5b2b-a0ed-6ae7b5613281",
+              "title": "1.0 Battle Tactics Overview",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Can I complete the same battle tactic multiple times in a battle?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No, unless specified otherwise."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If I have met the conditions to complete a battle tactic can I choose not to complete that tactic at the end of my turn?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A. No. If the conditions are fulfilled and you have not already scored a battle tactic from that card this turn, you must score that battle tactic."
+                }
+              ]
+            },
+            {
+              "id": "bb566e3e-e62f-5b20-97d8-67cec97479ef",
+              "title": "6.0 Attacking (Shooting and Combat) Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If a unit uses ‘All-out Attack’ in the shooting phase and the combat phase, do I subtract 2 from save rolls for that unit?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No. Persisting effects (see 28.1) count as the effects of passive abilities for their duration, so units cannot be affected by the same persisting effect more than once."
+                }
+              ]
+            },
+            {
+              "id": "c97040da-2b11-58c9-ba21-aa7a8270b95e",
+              "title": "1.2 Universal Terrain Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: While every model in a friendly non-**MONSTER** unit is within 1\" of an Obscuring terrain feature, are they visible to friendly units?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A. Yes. They are just not visible to enemy units outside of their combat range."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: When a **HERO** uses ‘Activate Place of Power’ and picks Tap the Ley Lines, can they use both the ‘Unbind’ ability and the ‘Banish Manifestation’ ability in the same phase?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No."
+                }
+              ]
+            },
+            {
+              "id": "8590809e-a4f0-52f5-936f-6565103f0f1c",
+              "title": "1.5 Faction Terrain",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If a hero is garrisoning a faction terrain feature, can it still be picked as the target of abilities other than attacks?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                }
+              ]
+            },
+            {
+              "id": "595b8e40-7112-55e4-bc28-9e2facfe2a1d",
+              "title": "2.2 Armies of Renown",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Can I use Scourge of Ghyran enhancements, lores and battle formations in an Army of Renown?*\n\nA: No."
+                }
+              ]
+            },
+            {
+              "id": "1a3885b8-a3c1-54d1-8f43-9939f0aae041",
+              "title": "Battleplan: Creeping Corruption",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: How does damage inflicted by ‘Pulsing Life Energies’ interact with The Shadow Queen’s ‘Iron Heart of Khaine’ ability?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Since the damage is inflicted in the Start of Battle Round timing window, before either player’s turn has started, ‘Iron Heart of Khaine’ would have no effect on those damage points. In addition, those damage points would not count towards the limit on damage allocation from ‘Iron Heart of Khaine’ in the next turn."
+                }
+              ]
+            },
+            {
+              "id": "ae10204b-47cf-5052-ac6a-6a857c1d558d",
+              "title": "Battleplan: Roiling Roots",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: In the Roiling Roots battleplan, if a unit that has **STRIKE-LAST** because it is contesting an objective that has been picked as the target of the ‘Tangling Tendrils’ ability, what happens if the models in that unit that are contesting that objective are slain?*\n\nA: The unit only has **STRIKE-LAST** while any models in that unit are contesting that objective. It loses the **STRIKE-LAST** effect immediately after all of the models that were contesting that objective have been slain and removed from the battlefield."
+                }
+              ]
+            },
+            {
+              "id": "f3435d86-3d27-5567-ac9c-107cdbc867b7",
+              "title": "Battle Tactics Card 3: Intercept and Recover",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If your opponent has picked the Intercept and Recover battle tactic card and they destroy 2 or 3 of your units that are carrying Ghyranite Treasure in the same turn, and then they choose to go first after going second in the previous battle round, can you remove a Ghyranite Treasure that has not been scored yet from a destroyed unit?*\n\nA: Yes."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If both players have the Intercept and Recover battle tactic card, what is the order in which players pick units to be carrying Ghyranite Treasures?*\n\nA: The attacker picks all their units first, then the defender picks all their units."
+                }
+              ]
+            },
+            {
+              "id": "30894f19-9ced-5125-a59f-338ed07b817c",
+              "title": "Scourge of Ghyran",
+              "subtitle": null,
+              "containerType": "standard",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Can I include Scourge of Ghyran units in an Army of Renown instead of their standard version?*\n\nA: Yes."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: Can I include Scourge of Ghyran units in a Regiment of Renown instead of their standard version?*\n\nA: No."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    }
+  ]
+}

--- a/aos/gdc/battlepacks/index.json
+++ b/aos/gdc/battlepacks/index.json
@@ -1,0 +1,20 @@
+{
+  "updated": "2026-07-04T16:16:49.873Z",
+  "compatibleDataVersion": 434,
+  "battlepacks": [
+    {
+      "id": "48f9fd56-bf1b-563e-9afd-801a9f8675b2",
+      "name": "General's Handbook 2024-25",
+      "file": "generals_handbook_2024_25.json",
+      "battleplans": 12,
+      "battleTacticCards": 0
+    },
+    {
+      "id": "035de91c-56f6-5063-9e9b-1ddd177db35e",
+      "name": "General's Handbook 2025-26",
+      "file": "generals_handbook_2025_26.json",
+      "battleplans": 12,
+      "battleTacticCards": 6
+    }
+  ]
+}


### PR DESCRIPTION
## What

First output of the new `readBattleplans.mjs` pipeline extractor (see the companion datasources-pipeline PR): `aos/gdc/battlepacks/` with one file per battlepack plus an index.

- `generals_handbook_2025_26.json` — 12 battleplans (twists with resolved abilities, VP scoring, battleplan card + deployment map image URLs), the six battle tactic cards with full rules text and all 18 tactics, season rules (Ghyranite objectives etc.), The Player's Code, matched play sequence, battleplan map key, addenda/errata/FAQs, and battlepack metadata (`battleTacticsCardLimit: 2`, army-builder cost flags).
- `generals_handbook_2024_25.json` — the 12 previous-season battleplans and section tree (no tactic cards; that system starts 2025-26).
- `index.json` — battlepack catalogue.

## Provenance

Generated from the archived `data-export-434-app-1.33.0.json` export (data v434), the newest export currently stored in the pipeline. When a newer export runs through the pipeline (data v446+ adds General's Handbook 2026-27), these files regenerate automatically and the 2026-27 battlepack file appears alongside.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcXK9xr3ssZj7su3QNwsA9)_