### PR TITLE
AoS: add rules data (Core Rules, Glossary 2026-27, Advanced Rules, FAQs)

### DIFF
--- a/aos/gdc/rules/advanced_rules.json
+++ b/aos/gdc/rules/advanced_rules.json
@@ -1,0 +1,1391 @@
+{
+  "id": "2f874ac8-bee6-53bd-888c-43fdcc47c639",
+  "name": "General's Handbook 2026-27: Advanced Rules",
+  "cardType": "AdvancedRules",
+  "source": "aos-4e",
+  "season": 2026,
+  "updated": "2026-07-05T15:43:06.738Z",
+  "compatibleDataVersion": 446,
+  "sections": [
+    {
+      "id": "b4c6b1d3-0286-5076-ad73-7554765a82e9",
+      "ref": null,
+      "name": "Advanced Rules 2026-27",
+      "containers": [
+        {
+          "id": "5c72d1f8-a026-5fb1-99cd-7b13a60a9a9a",
+          "ref": null,
+          "title": "Introduction",
+          "subtitle": null,
+          "containerType": "introduction",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The *General’s Handbook 2026-27* battlepack uses the following Advanced Rules modules:"
+            }
+          ]
+        },
+        {
+          "id": "2c448db7-1d0d-5e8f-a5b6-6b2427d452c1",
+          "ref": null,
+          "title": "Commands 2026-27",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "These rules explain how you can earn **command points** to use powerful **commands** that allow you to react to abilities and interact in your opponent’s turn. If you are not using the **Commands** rules, ignore any abilities that have the command point symbol in the corner."
+            }
+          ]
+        },
+        {
+          "id": "710ff0ed-0f63-541e-b07b-a91bb216c9f8",
+          "ref": null,
+          "title": "Terrain 2026-27",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "These rules go into more detail about how your models interact with terrain features, such as how they can take cover or even draw power from arcane nexuses."
+            }
+          ]
+        },
+        {
+          "id": "e6d952a0-1be3-5411-820e-a84fe2276367",
+          "ref": null,
+          "title": "Magic 2026-27",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If you’d like to wield unlimited mystical power by including **WIZARDS**, **PRIESTS** and **manifestations** in your battles, see **Magic**."
+            }
+          ]
+        },
+        {
+          "id": "a6cca042-68c7-535f-babc-d0a4f9387f1b",
+          "ref": null,
+          "title": "Army Composition 2026-27",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If you’re ready to build your own **army roster** and customise your army with **regiments**, **battle formations** and **enhancements**, see **Army Composition**."
+            }
+          ]
+        },
+        {
+          "id": "ba5ccb77-3132-5a38-96a0-cbcffaf10ef5",
+          "ref": null,
+          "title": "Command Models 2026-27",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Here you will find rules for special models called **champions**, **standard bearers** and **musicians**, which are found in many Warhammer Age of Sigmar units."
+            }
+          ]
+        },
+        {
+          "id": "c309d3d2-8775-5bae-9ceb-151e896af7c9",
+          "ref": null,
+          "title": "Battle Tactics 2026-27",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Add an additional tactical challenge to your games by including secondary objectives called **Battle Tactics**."
+            }
+          ]
+        },
+        {
+          "id": "cb23e84f-cbcd-5e7f-9f35-82524cb28b7c",
+          "ref": null,
+          "title": "Build your Own Battlepack",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "There are many, many ways to play Warhammer Age of Sigmar, from **Path to Glory** battlepacks, which focus on narrative-driven battles linked in an ongoing campaign, to **Spearhead** and **Matched Play** battlepacks, in which the emphasis is on balance and competitive play.\n\nIn addition to using official battlepacks, we’d encourage you to use the rules in this section as a toolbox, mixing and matching the elements within to build your own battleplan or battlepack to play with your friends.\n\nAre you excited to field your entire collection against your friends or to see which monster reigns supreme? Maybe you want to design your own battleplans and special rules, or perhaps you want to keep things simple in order to teach a younger sibling how to play. These rules provide an open framework that makes each of these things possible.\n\nHere are some ideas to get you started:\n\n• Instead of using the Advanced Rules for Army Composition, make an army based on your favourite Black Library story or based on a made‑up scenario that sounds exciting to you. For instance, how would 5 different Stormcast Eternals heroes fare against a pair of massive Chaos monsters?\n\n• Design your own battleplan by dividing portions of the battlefield into a territory for each player, placing objectives and thinking up a fun twist for the battle. Have fun and experiment with different ideas – why not try alternating placing objectives instead of having fixed locations, or try having two smaller battlefields connected by realmgates?\n\n• Learn the Advanced Rules by introducing each module into your battles one at a time – for instance, start by experimenting with Commands, then try adding Magic into your battles, and finally put them all together to outwit your opponent and score Battle Tactics."
+            }
+          ]
+        }
+      ],
+      "sections": []
+    },
+    {
+      "id": "c1cfad53-dedf-5e6a-958f-ec5a9294dc87",
+      "ref": null,
+      "name": "Commands 2026-27",
+      "containers": [],
+      "sections": [
+        {
+          "id": "63a9813a-7417-5e5e-ba46-bf0282033bba",
+          "ref": "1.0",
+          "name": "1.0 Commands Overview",
+          "containers": [
+            {
+              "id": "45f1e6c5-a658-5f0e-b0ea-e391fc075aa7",
+              "ref": null,
+              "title": "Commands Overview",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities, called commands, require that you spend one or more command points to use that ability. Any ability that has a command point cost (indicated in the top right corner of the ability) is a command."
+                }
+              ]
+            },
+            {
+              "id": "6fd9c5c8-5fca-5305-b4c5-f7332c578cc6",
+              "ref": "1.1",
+              "title": "1.1 Earning Command Points",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "At the start of each battle round, after determining the underdog, each player gains 4 command points. If there is an underdog, they gain 1 extra command point. At the end of the battle round, the players’ command points are reset to 0 (any that have not been used are lost)."
+                }
+              ]
+            },
+            {
+              "id": "c6f462b8-a84c-538f-8b52-342457032906",
+              "ref": "1.2",
+              "title": "1.2 Using Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Commands are used in a similar manner to any other ability. However, each unit can only use 1 command in each phase, each command can only be used 1 time by each army in each phase, and you must spend a number of command points equal to the command point cost to use a command."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "8caa7091-c64c-5105-89e9-7769f64fbb57",
+          "ref": "2.0",
+          "name": "2.0 Hero Phase Commands",
+          "containers": [
+            {
+              "id": "0eb728f3-a37c-5852-85af-3ae8e71cb66b",
+              "ref": null,
+              "title": "Hero Phase Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "bc2f2fdb-7d3c-5051-a28c-49f3bf82e3dc",
+                    "name": "Rally",
+                    "phase": "heroPhase",
+                    "phaseDetails": "Any Hero Phase",
+                    "icon": "rallying",
+                    "cpCost": 1,
+                    "declare": "Pick a friendly unit that is **not in combat** to use this ability.",
+                    "effect": "Make 6 **rally rolls** of D6. For each 4+, you receive 1 **rally point**. Rally points can be spent in the following ways:\n\n• For each rally point spent, **Heal (1)** that unit.\n• You can spend a number of rally points equal to the **Health** characteristic of that unit to **return** a slain model to that unit.\n\nYou can spend the rally points in any combination of the above. Unspent rally points are then lost.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "96bea915-0cc3-598f-973b-c65c16cd9620",
+                    "name": "Magical Intervention",
+                    "phase": "heroPhase",
+                    "phaseDetails": "Enemy Hero Phase",
+                    "icon": "special",
+                    "cpCost": 1,
+                    "declare": "Pick a friendly **WIZARD** or **PRIEST** to use this ability.",
+                    "effect": "That friendly unit can use a **SPELL**, **PRAYER** or **BANISH** ability (as appropriate) as if it were your hero phase. If you do so, subtract 1 from **casting rolls** or **chanting rolls** made as part of that ability.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "73118678-7989-5e59-a6ba-80de88f292b3",
+          "ref": "3.0",
+          "name": "3.0 Movement Phase Commands",
+          "containers": [
+            {
+              "id": "213bcd47-a419-5d9d-8076-ba4c1e2cf1fe",
+              "ref": null,
+              "title": "Movement Phase Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "e2d7414e-ae18-517e-9ca7-7701ba569d0f",
+                    "name": "Redeploy",
+                    "phase": "movementPhase",
+                    "phaseDetails": "Enemy Movement Phase",
+                    "icon": "movement",
+                    "cpCost": 1,
+                    "declare": "Pick a friendly unit that is **not in combat** to use this ability.",
+                    "effect": "Each model in that unit can move up to D6\". That move **cannot** pass through or end within the combat range of an enemy unit.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Move", "Run"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "7aa25842-b176-582c-921a-a3bdb50c6462",
+                    "name": "At the Double",
+                    "phase": "movementPhase",
+                    "phaseDetails": "Reaction: You declared a **RUN** ability",
+                    "icon": "movement",
+                    "cpCost": 1,
+                    "declare": null,
+                    "effect": "Do not make a **run roll** as part of that **RUN** ability. Instead, add 6\" to that unit’s **MOVE** characteristic to determine the distance each model in that unit can move as part of that **RUN** ability.",
+                    "usedBy": "&#x20;The unit using that **RUN** ability.",
+                    "additionalRulesText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "dba28f6e-5753-537e-9fc2-6229b4698254",
+          "ref": "4.0",
+          "name": "4.0 Shooting Phase Commands",
+          "containers": [
+            {
+              "id": "9a9d4e31-9987-5a06-bc1b-473475329462",
+              "ref": null,
+              "title": "Shooting Phase Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "9681bc84-c192-5ef2-81c2-10f58dcd91af",
+                    "name": "Covering Fire",
+                    "phase": "shootingPhase",
+                    "phaseDetails": "Enemy Shooting Phase",
+                    "icon": "shooting",
+                    "cpCost": 1,
+                    "declare": "Pick a friendly unit that did not use a **RUN** ability this turn and that is **not in combat** to use this ability, then pick the closest enemy unit (to that unit) that can be picked as the target of shooting attacks to be the target. You cannot pick **MANIFESTATIONS** or faction terrain features as the target of this ability.",
+                    "effect": "Resolve shooting attacks for the unit using this ability against the target. You must subtract 1 from the hit rolls for those attacks.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Attack", "Shoot"]
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "2d7772df-d95f-53bd-9c10-323c85cdae55",
+          "ref": "5.0",
+          "name": "5.0 Charge Phase Commands",
+          "containers": [
+            {
+              "id": "a2ad3b1d-23ea-581f-8abb-a04915445865",
+              "ref": null,
+              "title": "Charge Phase Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "62b47f21-db30-5f75-8931-1934002900c9",
+                    "name": "Counter-Charge",
+                    "phase": "chargePhase",
+                    "phaseDetails": "Enemy Charge Phase",
+                    "icon": "movement",
+                    "cpCost": 2,
+                    "declare": "Pick a friendly unit that is **not in combat** to use this ability.",
+                    "effect": "That unit can use a **CHARGE** ability as if it were your charge phase.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "97f72f6d-37d1-58e9-b76d-267ee07cfdcd",
+                    "name": "Forward to Victory",
+                    "phase": "chargePhase",
+                    "phaseDetails": "Reaction: You declared a Charge ability",
+                    "icon": "movement",
+                    "cpCost": 1,
+                    "declare": null,
+                    "effect": "You can re-roll the **charge roll**.",
+                    "usedBy": "The unit using that **CHARGE** ability.",
+                    "additionalRulesText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "59cc1993-afa4-510e-90af-49e9bb02a7f4",
+          "ref": "6.0",
+          "name": "6.0 Attacking (Shooting and Combat) Commands",
+          "containers": [
+            {
+              "id": "6b5401e5-6d77-5cf7-88e8-f6a5e0d46570",
+              "ref": null,
+              "title": "Attacking (Shooting and Combat) Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "d56b956f-5464-55ca-aca6-d5a407f6db3a",
+                    "name": "All-Out Attack",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Reaction: You declared an **ATTACK** ability",
+                    "icon": "offensive",
+                    "cpCost": 1,
+                    "declare": null,
+                    "effect": "Add 1 to **hit rolls** for attacks made as part of that **ATTACK** ability. This also affects weapons that have the **Companion** weapon ability. For the rest of the turn, subtract 1 from **save rolls** for the unit using this ability.",
+                    "usedBy": "The unit using that **ATTACK** ability.",
+                    "additionalRulesText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "19419402-f585-55d7-ac33-d2b96dcc782d",
+          "ref": "7.0",
+          "name": "7.0 Defensive Commands",
+          "containers": [
+            {
+              "id": "2f4ce5d0-d947-586c-94ef-9ba40a356c47",
+              "ref": null,
+              "title": "Defensive Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "5c3acbeb-553c-5fc5-9622-d2d959cd75c4",
+                    "name": "All-Out Defence",
+                    "phase": "defensive",
+                    "phaseDetails": "Reaction: Opponent declared an **ATTACK** ability",
+                    "icon": "defensive",
+                    "cpCost": 1,
+                    "declare": null,
+                    "effect": "Add 1 to **save rolls** for that unit until that **ATTACK** ability has been resolved.",
+                    "usedBy": "A unit targeted by that **ATTACK** ability.",
+                    "additionalRulesText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "47450393-3e18-5826-8f16-ec924d191645",
+          "ref": "8.0",
+          "name": "8.0 End of Turn Commands",
+          "containers": [
+            {
+              "id": "e144500a-d928-531d-937a-7fc0ac46f0e4",
+              "ref": null,
+              "title": "End of Turn Commands",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "873a95f6-a501-5a6f-8c3b-9a882529073d",
+                    "name": "Power Through",
+                    "phase": "endOfTurn",
+                    "phaseDetails": "End of Any Turn",
+                    "icon": "special",
+                    "cpCost": 1,
+                    "declare": "Pick a friendly unit that charged this turn to use this ability, then you must pick an enemy unit **in combat** with it to be the target. The target must have a lower **Health** characteristic than the unit using this ability.",
+                    "effect": "Inflict **D3 mortal damage** on the target. Then, the unit using this ability can move a distance up to its **Move** characteristic. It can pass through and end that move within the combat ranges of enemy units that were in combat with it at the start of the move, but not those of other enemy units. It does not have to end the move in combat.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Move"]
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "6503d7ec-15e6-54f9-9da3-18b217cff6d8",
+      "ref": null,
+      "name": "Terrain 2026-27",
+      "containers": [],
+      "sections": [
+        {
+          "id": "5f4e2d60-3f4f-5663-b633-a3ccfe0db08c",
+          "ref": "1.0",
+          "name": "1.0 Terrain Overview",
+          "containers": [
+            {
+              "id": "2a971125-5af3-5022-9810-6ff54b1cf544",
+              "ref": "1.0",
+              "title": "1.0 Terrain Overview",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Terrain features add interest and tactical challenges to the battlefield. The battleplan or battlepack you are using will explain how to set up terrain."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "The Citadel Terrain List, available at **warhammer-community.com**, includes a list of Warhammer Age of Sigmar terrain features and tells you which terrain abilities each of them has."
+                }
+              ]
+            },
+            {
+              "id": "09fdb84c-da69-54c8-a805-fe7860f4f0a3",
+              "ref": "1.1",
+              "title": "1.1 Wholly On Terrain and Behind Terrain",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "A model is **wholly on a terrain feature** if its base is on that terrain feature and no part of its base extends past the edge of that terrain feature. A unit is wholly on a terrain feature if every model in that unit is wholly on that terrain feature.\n\nWhen a unit is targeted by an attack, if it is impossible to draw a straight line from the closest point on the attacking model’s base to the closest point on the base of a model in the target unit that is in range without that line passing over that terrain feature, the target unit is considered to be **behind a terrain feature** for the attack made by that attacking model. Ignore parts of the terrain feature within the attacking unit’s combat range for the purposes of determining if the target is behind that terrain feature."
+                }
+              ]
+            },
+            {
+              "id": "087f7f69-ba16-5dde-aa4b-b0b00d7a72be",
+              "ref": "1.2",
+              "title": "1.2 Universal Terrain Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each terrain feature has one or more of the following passive abilities:"
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "**Cover:** Subtract 1 from hit rolls for attacks that target a unit that is behind or wholly on this terrain feature, unless that unit charged this turn or has the **FLY** keyword.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Impassable:** Models cannot move across, be set up on or end moves on any part of this terrain feature.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Obscuring:** While every model in a non-**MONSTER** non-**WAR MACHINE** unit that does not have the **FLY** keyword is within 1\" of this terrain feature, the following apply:\n\n• That unit is only visible to enemy units that are within its combat range.\n• The Range characteristic of that unit’s ranged weapons is halved (rounding down to the nearest inch).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Place of Power: HEROES** within 3\" of this terrain feature can use the ‘Activate Place of Power’ ability.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Unstable:** Models can move across but cannot be set up on or end any type of move on any part of this terrain feature that is more than 1\" tall.",
+                      "indent": 0
+                    }
+                  ]
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "d6c0d8ab-aa50-502b-9a90-bf46c9e0a4ac",
+                    "name": "Activate Place of Power",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Once Per Turn (Army), Start of Any Turn",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick a friendly **HERO** within 3\" of any **Places of Power** to use this ability.",
+                    "effect": "Roll a dice. On a 1, inflict D3 mortal damage on that **HERO**. On a 2+, pick 1 of the following effects:\n\n• *I**gnite Fury:*** Gain 2 **rage dice**, then increase your **fury level** by 2, to a maximum of 7.\n\n• ***Channel Wrath:*** If that **HERO** is a **WIZARD** or **PRIEST**, add 1 to casting rolls or chanting rolls for that **HERO** for the rest of the turn.\n\n• ***Dizzying Rage:*** For the rest of the turn, if that **HERO** is not a **WIZARD** or **PRIEST**, they can use the ‘Unbind’ or ‘Banish Manifestation’ ability as if they had **WIZARD (1)**.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core"]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "865841c2-548b-5645-aa2c-3a5e21945574",
+              "ref": "1.3",
+              "title": "1.3 Terrain Sizes",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "•  Terrain that fits into an area no larger than 7\" × 7\" is **small**.\n\n•  Terrain that is not small and fits into an area no larger than 7\" × 12\" is **medium**.\n\n•  Terrain that is too big to fit into an area 7\" × 12\" is **large**."
+                }
+              ]
+            },
+            {
+              "id": "b576b5d2-f97c-516e-a28a-12386bf00ce3",
+              "ref": "1.4",
+              "title": "1.4 Terrain Types",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each **terrain feature** in Warhammer Age of Sigmar is one of the following types:\n\n**• Obstacle**\n**• Obscuring Terrain**\n**• Area Terrain**\n**• Place of Power**\n**• Faction Terrain**\n\nBefore the battle begins, players must agree on which type applies to each terrain feature."
+                },
+                {
+                  "type": "accordion",
+                  "title": "1.4.1 Obstacles",
+                  "text": "**Examples:** Ruins, debris, statues, barricades\n**Terrain Abilities:** Cover, Unstable"
+                },
+                {
+                  "type": "accordion",
+                  "title": "1.4.2 Obscuring Terrain",
+                  "text": "**Examples:** Wyldwood, fortress wall\n**Terrain Abilities:** Cover, Obscuring, Unstable"
+                },
+                {
+                  "type": "accordion",
+                  "title": "1.4.3 Area Terrain",
+                  "text": "**Examples:** Hills, Stormvault Terrain\n**Abilities:** Cover"
+                },
+                {
+                  "type": "accordion",
+                  "title": "1.4.4 Places of Power",
+                  "text": "**Examples:** Realmgate, Cleansing Aqualith, Nexus Syphon\n**Abilities:** Cover, Place of Power, Unstable"
+                }
+              ]
+            },
+            {
+              "id": "7cc20ee4-aa90-5e8b-94a0-6dc4ee4be51d",
+              "ref": "1.5",
+              "title": "1.5 Faction Terrain",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some factions have special terrain features called **faction terrain features**. Faction terrain features have their own warscrolls. They are not considered to be units, with the following exceptions:\n\n•  In the combat phase, they are treated as if they were units for the purposes of movement, combat range and being in combat. Units can finish a charge move within ½\" of an enemy faction terrain feature as if it were a unit.\n•  They are affected by all enemy abilities as if they were units.\n•  They can be damaged in the same manner as units. However, when they are removed from play, they count as being **demolished** instead of slain or destroyed (this means that they do not count as destroyed units for the purposes of abilities, scoring battle tactics etc.).\n•  Enemy units can finish a charge move within 1/2\" of a terrain feature that is **garrisoned**. Faction terrain features cannot contest objectives even while they are garrisoned.\n•  If a terrain feature has any melee or ranged weapons, it can use the ‘Fight’ and ‘Shoot’ **CORE** abilities as if it were a unit.\n•  Terrain features that have a Move characteristic of 0\" (‘-’) cannot move (note that pile-in moves are a type of move).\n• Faction terrain features with a Move characteristic greater than ‘-’ are treated as if they were units in all phases for the purposes of movement, combat range, being in combat and setting up terrain features, other manifestations and other units.\n\nSome faction terrain features allow you to place a unit on them (this will be clearly specified in that terrain feature’s rules). When doing so, instead of measuring range or visibility to and from the unit that is on that terrain feature, measure to and from the terrain feature instead. Unless otherwise specified, units on a faction terrain feature cannot use **FIGHT** abilities. If a unit placed on a terrain feature is removed from it (e.g. if an ability removes them from the battlefield), that unit counts as having left that terrain feature and loses any special role or benefits it had as a result of being placed on it."
+                },
+                {
+                  "type": "accordion",
+                  "title": "1.5.1 Garrisoning Faction Terrain Features",
+                  "text": "Some faction terrain features allow you to place another unit on them using an ability on the terrain feature’s warscroll. While a faction terrain feature has another unit on it that was placed there in this way, that terrain feature is **garrisoned**.\n\nGarrisoned terrain features can use abilities and be affected by enemy abilities, but they cannot be affected by friendly abilities other than **CORE** abilities, abilities on their warscroll and abilities that specifically affect terrain features. Any time you would measure range or visibility to or from a unit that is on a garrisoned terrain feature (including if that unit is contesting an objective), measure to and from the terrain feature instead. Unless otherwise specified, units on a faction terrain feature are not eligible to use **FIGHT** abilities.\n\nUnits cannot move while they are garrisoned on a terrain feature."
+                }
+              ]
+            },
+            {
+              "id": "01c29643-c8a1-5e0f-8cb4-a20b7efc5371",
+              "ref": "1.6",
+              "title": "1.6 Charging Units on Terrain",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In some cases, it is not possible to reach an enemy unit using a **CHARGE** ability when they are wholly on a terrain feature (e.g. a unit on top of a tower) because the charging unit is unable to end their move mid-way up the terrain feature and there is not enough room for the models to be placed at the top. In these cases, the charging unit can end their charge within **½\" of that terrain feature** instead if this would result in the charging unit ending their move **in combat** with any enemy units wholly on a terrain feature."
+                }
+              ]
+            },
+            {
+              "id": "9996f274-b052-5975-b612-d09fd5b46e2d",
+              "ref": "1.7",
+              "title": "1.7 Scenery Pieces",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some terrain features, such as wyldwoods or collections of smaller timeworn ruins, are made up of multiple **scenery pieces**. Each scenery piece that makes up a part of the same terrain feature must be set up so that all of the scenery pieces fit into the area that corresponds to the terrain feature’s size (see 1.3). The full collection of scenery pieces is considered to be a single terrain feature."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/5cbc3fd7-71d2-42ec-84b9-2137ea04390e",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "This battlefield uses Citadel terrain, so the players were able to simply look up the terrain type of each terrain feature in the Citadel Terrain List.\n\n**1** Ruined Domicile (Obstacle)\n**2** Domicile Shell (Obstacle)\n**3** Guardian Idol (Obstacle)\n**4** Cleansing Aqualith (Place of Power)\n**5** Nexus Syphon (Place of Power)\n**6** Wyldwood (Obscuring Terrain)"
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/fe1e25c6-42a4-4cdf-8b2f-3a15e9c4646b",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "The second battlefield uses scratch-built terrain. Before setting up the terrain, both players discussed and agreed on the terrain type of each terrain feature they were using, as shown below.\n\n**1** Place of Power\n**2** Area Terrain\n**3** Obstacle\n**4** Obscuring Terrain"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "05eccca2-0370-50cd-9d58-fc5b6442dc4c",
+      "ref": null,
+      "name": "Magic 2026-27",
+      "containers": [],
+      "sections": [
+        {
+          "id": "d3017bc3-0696-5d01-8064-ac6034a0377f",
+          "ref": "1.0",
+          "name": "1.0 Wizards and Priests",
+          "containers": [
+            {
+              "id": "f1ff536b-8346-50e1-b4d3-70ddfd1a1f13",
+              "ref": "1.0",
+              "title": "1.0 Wizards and Priests",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**WIZARDS** are special units that can cast **spells**, and **PRIESTS** are special units that can chant **prayers**. Spells and prayers are powerful **abilities** that can have a dramatic impact on the battle."
+                }
+              ]
+            },
+            {
+              "id": "612aa280-8d73-54a9-8504-131af92e596c",
+              "ref": "1.1",
+              "title": "1.1 Power Level",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each **WIZARD** and **PRIEST** has a power level shown after the keyword, e.g. **WIZARD (2)**. A **WIZARD**’s casting power level determines how many Spell abilities they can use per phase. A **PRIEST**’s chanting power level determines how many **PRAYER** abilities they can use per phase."
+                },
+                {
+                  "type": "header",
+                  "text": "1.1.1 Multiple Power Levels"
+                },
+                {
+                  "type": "text",
+                  "text": "• If an ability references a unit’s power level and that unit has more than one power level, use whichever power level is higher.\n• If an ability modifies a unit’s power level and that unit has more than one power level, it modifies both."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "ea14657c-2cd0-55d2-8baa-096bde367dda",
+          "ref": "2.0",
+          "name": "2.0 Spells",
+          "containers": [
+            {
+              "id": "79074bc6-3bd9-5b00-8b69-806ca8192052",
+              "ref": "2.0",
+              "title": "2.0 Spells",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The declare step of each spell will tell you to make a **casting roll** of **2D6**. If the roll does **not** equal or exceed the spell’s **casting value** (at the top-right corner of the spell), the spell fails and its effect is not resolved. If the unmodified casting roll includes **2 or more rolls of 1**, the spell is **miscast**: the spell fails, its effect is not resolved, **D3 mortal damage** is inflicted on the **WIZARD** that used it, and that **WIZARD** cannot use any more spells in that phase.\n\nEnemy reactions can only be used if the **casting roll** equals or exceeds the spell’s **casting value**. So long as the spell is not **unbound** (see 4.0), then it is **successfully cast**: resolve its **effect**."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "7ab45de6-d0f8-5e73-982f-142ff29ecf31",
+          "ref": "3.0",
+          "name": "3.0 Prayers",
+          "containers": [
+            {
+              "id": "4b269407-ff08-5985-8e14-8162f9bd718f",
+              "ref": "3.0",
+              "title": "3.0 Prayers",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The declare step of each prayer will tell you to make a **chanting roll** of **D6**. On an unmodified chanting roll of **1**, the prayer fails, its effect is not resolved and you must **remove D3 ritual points** from the **PRIEST** using the prayer. Otherwise, pick one of the following:\n\n•  Give a number of **ritual points** to the **PRIEST** equal to the chanting roll (ritual points can be accumulated over multiple turns).\n•  You can add the **PRIEST**’s ritual points to the chanting roll. If the chanting roll equals or exceeds the prayer’s **chanting value** (at the top-right corner of the prayer), it is **answered**: resolve the **effect** of the prayer, then reset the **PRIEST**’s ritual points total to 0.\n\nAll **PRIESTS** know the following prayer:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "134f8b39-605b-599a-99d4-dab27dacd7cf",
+                    "name": "Sacred Rites",
+                    "phase": "heroPhase",
+                    "phaseDetails": "Your Hero Phase",
+                    "icon": "special",
+                    "cpCost": 2,
+                    "declare": "Pick a friendly **PRIEST** to use this ability, then make a **chanting roll** of D6. On an unmodified chanting roll of 1, remove 1 ritual point from that **PRIEST** instead of D3.",
+                    "effect": "Give a number of ritual points to the **PRIEST** equal to the unmodified chanting roll and do not reset the **PRIEST**'s ritual points total to 0.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Prayer", "Unlimited"]
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "3172d4d3-185a-5a4d-a8aa-6fc5ee473aac",
+          "ref": "4.0",
+          "name": "4.0 Unbinding Spells",
+          "containers": [
+            {
+              "id": "c56d6244-2fdd-58af-b5ee-9d9ce274a909",
+              "ref": "4.0",
+              "title": "4.0 Unbinding Spells",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each **WIZARD** can use the ‘Unbind’ reaction a number of times per phase equal to their **power level**. This is an exception to The Rules of One (Core Rules, 5.3)."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "2fdb89e2-f84d-5c8a-94dd-0828433290cb",
+                    "name": "Unbind",
+                    "phase": "heroPhase",
+                    "phaseDetails": "Reaction: Opponent declared a **SPELL** ability",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "Make an **unbinding roll** of 2D6. If the roll exceeds the **casting roll** for the spell, then the spell is unbound and its effect is not resolved. This reaction cannot be used more than once per **casting roll**.",
+                    "usedBy": "A friendly **WIZARD** within 30\" of the enemy **WIZARD** casting the spell.",
+                    "additionalRulesText": null,
+                    "keywords": ["Unbind"]
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "4cdd57db-ad52-549f-b5fb-962a82764229",
+          "ref": "5.0",
+          "name": "5.0 Jealous Mages and Fickle Gods",
+          "containers": [
+            {
+              "id": "b63b0b49-072a-55da-8c29-92979bdad8c2",
+              "ref": "5.0",
+              "title": "5.0 Jealous Mages and Fickle Gods",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "No more than 1 friendly **WIZARD** can cast the same spell per turn, unless that spell has the **UNLIMITED** keyword. Likewise, no more than 1 friendly **PRIEST** can chant the same prayer per turn, unless that prayer has the **UNLIMITED** keyword. Keep in mind that each unit can still only use any given spell or prayer ability once per phase (see The Rules of One, Core Rules, 5.3)."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "667a21ba-1c41-557b-b809-cf4b6d641726",
+          "ref": "6.0",
+          "name": "6.0 Known Spells and Prayers",
+          "containers": [
+            {
+              "id": "8a43f4cf-bdfe-5139-865a-e9d5f935df71",
+              "ref": "6.0",
+              "title": "6.0 Known Spells and Prayers",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**WIZARDS** and **PRIESTS** can only use spells or prayers that they know. Each **WIZARD** and **PRIEST** knows any spells or prayers on its warscroll, plus all of the spells and prayers in the spell lores, manifestation lores and prayer lores you take for your army."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "ee18ad40-eeef-5822-910e-18cdaa24d7d9",
+          "ref": "7.0",
+          "name": "7.0 Manifestations",
+          "containers": [
+            {
+              "id": "0383c46a-1b56-5ba7-8576-bccdfc28863b",
+              "ref": "7.0",
+              "title": "7.0 Manifestations",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "There are two types of **manifestation: endless spells**, which can be summoned by **WIZARDS**, and **invocations**, which can be summoned by **PRIESTS**. Each manifestation has its own **warscroll**, and the **spell** or **prayer** that allows that manifestation to be summoned will be found in the appropriate **manifestation lore**. No more than 1 friendly **WIZARD** or **PRIEST** can attempt to summon the same manifestation per turn, and a friendly **WIZARD** or **PRIEST** cannot attempt to summon a friendly manifestation that was removed from play in the same turn.\n\nManifestations are not units but can be interacted with in similar ways, as explained next:"
+                },
+                {
+                  "type": "header",
+                  "text": "All Manifestations"
+                },
+                {
+                  "type": "bullets"
+                },
+                {
+                  "type": "header",
+                  "text": "Manifestations With a Move Characteristic of '-'"
+                },
+                {
+                  "type": "bullets"
+                },
+                {
+                  "type": "header",
+                  "text": "Manifestations With a Move Characteristic Greater Than '-'"
+                },
+                {
+                  "type": "bullets"
+                }
+              ]
+            },
+            {
+              "id": "f8e8cee2-9b85-5df3-a308-9d1d3fed7e48",
+              "ref": "7.1",
+              "title": "7.1 Severed Connection",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "If the unit that summoned a manifestation is destroyed, that manifestation is removed from the battlefield."
+                }
+              ]
+            },
+            {
+              "id": "6366506f-1460-567d-a6ed-4aec9c82c2da",
+              "ref": "7.2",
+              "title": "7.2 Banishing Manifestations",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Instead of using a **SPELL** or **PRAYER** ability (including when using the ‘Magical Intervention’ ability), each **WIZARD** and **PRIEST** can use the ‘Banish Manifestation’ ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "60b70dc0-a9fa-56f0-85c1-dfde645112e8",
+                    "name": "Banish Manifestation",
+                    "phase": "heroPhase",
+                    "phaseDetails": "Your Hero Phase",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick a friendly **WIZARD** or **PRIEST** to use this ability, pick a **MANIFESTATION** within 30\" of them that was not summoned this turn to be the target, then make a banishment roll of 2D6. Add 1 to the **banishment roll** for each additional enemy **MANIFESTATION** on the battlefield after the first. You cannot pick the same **MANIFESTATION** to be the target of this ability more than once per turn.",
+                    "effect": "If the **banishment roll** equals or exceeds the banishment value listed on the **MANIFESTATION**’s warscroll, it is banished and removed from play.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Banish"]
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "ac83d341-7925-5877-aac9-a3dd6e604001",
+      "ref": null,
+      "name": "Army Composition 2026-27",
+      "containers": [
+        {
+          "id": "6c228f4a-f066-5a9c-b06e-8c1a3595bd25",
+          "ref": null,
+          "title": "Army Composition Overview",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "image",
+              "image": {
+                "url": "https://dhss9aar8ocw.cloudfront.net/8af17b77-0daf-458f-900b-b20fca05a6d0",
+                "altText": null
+              }
+            }
+          ]
+        }
+      ],
+      "sections": [
+        {
+          "id": "4118e8f5-1987-52fe-bb9c-33e2894f6706",
+          "ref": "1.0",
+          "name": "1.0 Getting Started",
+          "containers": [
+            {
+              "id": "a5519423-fb04-5c04-86a6-0089cd9a8696",
+              "ref": "1.1",
+              "title": "1.1 Army Roster",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "These rules will explain how to create an **army roster** to prepare for a battle. You can find a blank army roster in the Generals Handbook 2025-26, or go to **warhammer‑community.com** to download a printable copy."
+                }
+              ]
+            },
+            {
+              "id": "f2ae90db-cc14-51d6-b9c7-88e0879c6e5c",
+              "ref": "1.2",
+              "title": "1.2 Points Limit",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Before you start filling your roster, you and your opponent must agree on a **points limit** for the battle. You can agree on any points limit, but most players use a limit of 1000 points, 2000 points or somewhere in between. If a unit, Regiment of Renown, faction terrain feature, enhancement or lore has a points value, you must spend that number of points to include it on your army roster. The total points value of the options you have picked in your army must not exceed the agreed points limit of the battle. No more than half of your points can be spent on a single unit."
+                },
+                {
+                  "type": "accordion",
+                  "title": "1.2.1 Underspending",
+                  "text": "In many cases, the total points cost of your army will not add up to the exact points limit, but you might not have enough points left to add something else. If the points cost of your army is **50 or more points lower** than the points limit of the battle, you gain **1 extra command point at the start of the first battle round**."
+                }
+              ]
+            },
+            {
+              "id": "3a2f94ce-bbbe-5c2a-a43c-792404c56fec",
+              "ref": "1.3",
+              "title": "1.3 Battle Profiles",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The information you’ll need when building your army roster is found in each unit’s **battle profile**. The battle profiles for all units are also available online at warhammer-community.com."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "5cff716f-a256-5939-8291-96c3e2160772",
+          "ref": "2.0",
+          "name": "2.0 Factions",
+          "containers": [
+            {
+              "id": "f17e0b77-bf2f-5f58-a96a-e316464f9783",
+              "ref": "2.0",
+              "title": "2.0 Factions",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The first thing you need to do when building your army roster is to pick your **faction** (e.g. Stormcast Eternals or Skaven).\n\nEach faction has its own warscrolls, battle profiles and faction rules. These can be found in various publications but most commonly in the faction’s **battletome**."
+                }
+              ]
+            },
+            {
+              "id": "919f5949-f4bd-5927-93bd-b64db493ff90",
+              "ref": "2.1",
+              "title": "2.1 Battle Formations",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Many factions contain one or more **battle formations**. Each battle formation grants unique benefits to your army. The **faction rules** for your faction will explain any battle formation options."
+                }
+              ]
+            },
+            {
+              "id": "b9760617-f458-5784-b4ca-0b39406f0910",
+              "ref": "2.2",
+              "title": "2.2 Armies of Renown",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some factions have access to rules for themed armies called **Armies of Renown**. If you choose to use an Army of Renown, the rules for that Army of Renown replace the normal faction rules for that army."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "0d183d5d-48e2-5086-9309-0c278863a0ef",
+          "ref": "3.0",
+          "name": "3.0 Adding Units",
+          "containers": [
+            {
+              "id": "bd02f7d1-4e83-5d2f-960b-960ed3c83862",
+              "ref": "3.1",
+              "title": "3.1 Regiments",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Armies are made up of one or more **regiments**, each of which is led by a Hero. You must have **at least 1** regiment in your army, and you can include a **maximum of 5** regiments. To add a regiment, pick **1** **HERO** from your faction, then pick up to **3** non‑**HERO** units to accompany them.\n\nEach **HERO’**&#x73; battle profile lists which units can be added to their regiment, and each non-**HERO** unit’s battle profile lists any relevant keywords it has. The battle profiles of some **HEROES** may say that they can be added to the regiment of another **HERO** in place of a non-**HERO** unit in that regiment."
+                },
+                {
+                  "type": "header",
+                  "text": "3.1.1 Regimented Forces"
+                },
+                {
+                  "type": "text",
+                  "text": "If a player has more regiments than their opponent at the start of the battle, then once per battle, that player can re-roll their priority roll after seeing the result of both players’ rolls but before determining priority for that battle round."
+                }
+              ]
+            },
+            {
+              "id": "eaabfaeb-ded4-5912-a56b-62bc9e250f8b",
+              "ref": "3.2",
+              "title": "3.2 The General",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "You must pick 1 **HERO** in your army that is leading a regiment to be your general. If any units in your army have the **WARMASTER** keyword, you must pick one of those units to be your general and they must lead a regiment. Your general’s **regiment** can include up to **4** non‑**HERO** units in addition to your general."
+                }
+              ]
+            },
+            {
+              "id": "17f36ba7-2b9c-5623-8f87-bf2c62b4c5d2",
+              "ref": "3.3",
+              "title": "3.3 Reinforced Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "When you add a unit to your army roster, you can add it as a **reinforced unit**. A reinforced unit has **twice as many models** as its minimum unit size and costs **twice as many points**. If a unit has a minimum unit size of 1, it cannot be reinforced. In addition, some units with a unit size of more than 1 can not be reinforced. This will be noted on their battle profile."
+                }
+              ]
+            },
+            {
+              "id": "ea07fa95-21d4-5d1a-9b86-3f51ede6d0f1",
+              "ref": "3.4",
+              "title": "3.4 Unique Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "You cannot include the same **UNIQUE** unit more than once in your army. **UNIQUE** units cannot be reinforced."
+                }
+              ]
+            },
+            {
+              "id": "db0ced70-3c13-50ba-9154-a12debd084ce",
+              "ref": "3.5",
+              "title": "3.5 Regiments of Renown",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In addition to creating your own regiments, you can also spend points to include 1 **Regiment of Renown**. Regiments of Renown are pre‑built regiments, each with their own special abilities. The rules for each Regiment of Renown will specify which factions can include it. A unit in a Regiment of Renown cannot be your general even if it is a **WARMASTER**.\n\n• You cannot include more than one Regiment of Renown in your army unless otherwise specified in the notes column of that regiment’s battle profile.\n\n• Units in a Regiment of Renown cannot use (but can be picked as the target of, if otherwise eligible) any faction rules from the faction they are allied into, including enhancements and lores, unless they have a keyword that matches that faction’s name.\n\n• If an ability allows you to set up a replacement unit (see Core Rules 24.2) for a unit from a Regiment of Renown, that unit also counts as being part of the Regiment of Renown."
+                }
+              ]
+            },
+            {
+              "id": "81845f4b-5886-5e23-af3e-811322b1496c",
+              "ref": "3.6",
+              "title": "3.6 Auxiliary Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "**Auxiliary units** allow you to take any units from your faction without the constraints of regiments, at the cost of potentially giving your opponent an advantage. You can add any number of units to the auxiliary units section of your army roster. However, the player with the fewest auxiliary units on their roster gains **1 extra command point at the start of each battle round** (if the players have the same number of auxiliary units, neither player receives an extra command point). **HEROES** that have compulsory regiment options cannot be taken as auxiliary units.\n\nEach auxiliary unit after the first that is added to your roster will incur a cumulative surcharge of 20 points. For example, the second auxiliary unit will cost +20 points, the third will cost +40 points, the fourth will cost +60 points and so on."
+                }
+              ]
+            },
+            {
+              "id": "1db483e5-60d9-58aa-af3b-88a3c8aa9e8b",
+              "ref": "3.7",
+              "title": "3.7 Faction Terrain Features",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "If your faction has a **faction terrain feature**, or a set of faction terrain features, you can pick 1 to include on your army roster."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "edf23cd6-cd25-5dce-af88-d4d529fcd535",
+          "ref": "4.0",
+          "name": "4.0 Finishing Touches",
+          "containers": [
+            {
+              "id": "6425203d-5a5f-51fb-a0a2-ddf5a721e0f9",
+              "ref": "4.1",
+              "title": "4.1 Enhancements",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each set of faction rules include a number of **enhancements** that can be given to units, e.g. **heroic traits** and **artefacts of power**. You can take **1 enhancement** from **each** enhancement table in your **faction rules**. Each enhancement table lists which units are eligible to be given that enhancement. **UNIQUE** units cannot be given enhancements.\n\nWhile some abilities allow you to take extra enhancements, the same unit can never have more than 1 enhancement of the same type, and you can never include the same enhancement in your army more than once. Enhancements cannot be given to Regiment of Renown units unless they have a keyword that matches that faction’s name."
+                }
+              ]
+            },
+            {
+              "id": "7c4e3fc4-dfef-5f4b-b87c-64b619150219",
+              "ref": "4.2",
+              "title": "4.2 Lores",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "You can pick 1 **spell lore** available to your faction. If you do, **all** **WIZARDS** in your army with the same faction keyword as your general know **all** spells from that lore.\n\nYou can pick 1 prayer lore available to your faction. If you do, **all** **PRIESTS** in your army with the same faction keyword as your general know **all** prayers from that lore.\n\nYou can pick 1 **manifestation lore** available to your faction. If you do, **all WIZARDS** in your army know **all** spells from that lore, and **all** **PRIESTS** in your army know **all** prayers from that lore."
+                }
+              ]
+            },
+            {
+              "id": "cd994e54-9321-5c39-941e-0c4fde03a2b0",
+              "ref": "4.3",
+              "title": "4.3 Battle Tactics Cards",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "You can pick up to 2 battle tactics cards from the Battle Tactics 2026‑27 module for your army. Make a note of these battle tactics in the appropriate section on your army roster."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "09eb2764-7476-5840-8e6a-d5411d2139f2",
+      "ref": null,
+      "name": "Command Models 2026-27",
+      "containers": [],
+      "sections": [
+        {
+          "id": "c295a3be-21a4-5f96-96c5-f4973b0267d1",
+          "ref": "1.0",
+          "name": "1.0 Champions",
+          "containers": [
+            {
+              "id": "7e837323-b402-5a6c-b7b6-f9d2c297d5c8",
+              "ref": null,
+              "title": "Champions",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Units with the **CHAMPION** keyword have one or more **champion** models. If there is a number after the **CHAMPION** keyword, that number indicates the proportion of models in that unit that can be champions. In any other case, 1 model in the unit can be a champion. Units with the **CHAMPION** keyword have the following passive ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "1047ccf7-5ad8-5f3e-8eb3-5adf72ac1fe4",
+                    "name": "Champion",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Passive",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "Add 1 to the **Attacks** characteristic of weapons used by champions in this unit. If this unit is a **BEAST**, this ability affects this unit’s **Companion** weapons.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "boxedText",
+                  "text": "If a unit had **CHAMPION (1/10)** on its keywords bar, then 1 model in that unit could be a champion for every 10 models in the unit."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "a2379000-2759-51f2-899d-0ed523f5e8c5",
+          "ref": "2.0",
+          "name": "2.0 Musicians",
+          "containers": [
+            {
+              "id": "2e748d0e-c254-5142-a69d-d61ed29c55e6",
+              "ref": null,
+              "title": "Musicians",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Units with the **MUSICIAN** keyword have one or more **musician** models. The number after the **MUSICIAN** keyword indicates the proportion of models in that unit that can be musicians. Units with the **MUSICIAN** keyword have the following passive ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "afad6429-1a0e-5514-841f-dcd4583f8f53",
+                    "name": "Musician",
+                    "phase": "heroPhase",
+                    "phaseDetails": "Passive",
+                    "icon": "rallying",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "While this unit contains any musicians, if it uses the ‘Rally’ command, you can make one additional **rally roll** of D6.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "boxedText",
+                  "text": "Let your opponent know which models in a unit are champions, musicians and standard bearers if it’s not already clear from the miniatures."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "f9a8062f-daa2-50bd-86ef-9ee858ddf586",
+          "ref": "3.0",
+          "name": "3.0 Standard Bearers",
+          "containers": [
+            {
+              "id": "08487c6d-bd80-5ec3-8f19-fdcb3577d33e",
+              "ref": null,
+              "title": "Standard Bearers",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Units with the **STANDARD BEARER** keyword have one or more **standard bearer** models. The number after the **STANDARD BEARER** keyword indicates the proportion of models in that unit that can be standard bearers. Units with the **STANDARD BEARER** keyword have the following passive ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "ea5723db-b93d-5b11-b801-f6ab9f84af03",
+                    "name": "Standard Bearer",
+                    "phase": "endOfTurn",
+                    "phaseDetails": "Passive",
+                    "icon": "control",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "While this unit contains any standard bearers, add 1 to this unit’s **control score**.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    }
+  ]
+}

--- a/aos/gdc/rules/core_rules.json
+++ b/aos/gdc/rules/core_rules.json
@@ -1,0 +1,3232 @@
+{
+  "id": "bcfb42b3-335c-59f2-883c-ae27b4fa2231",
+  "name": "Core Rules",
+  "cardType": "CoreRules",
+  "source": "aos-4e",
+  "updated": "2026-07-05T15:43:04.135Z",
+  "compatibleDataVersion": 446,
+  "groups": [
+    {
+      "id": "91d64303-707e-5b8b-9471-aeee22d09085",
+      "ref": null,
+      "name": "Core Rules 1.0 - 7.0",
+      "containers": [],
+      "sections": [
+        {
+          "id": "9513ba8c-c506-53d1-b6a3-6f4e3925356b",
+          "ref": "1.0",
+          "name": "1.0 Core Concepts",
+          "containers": [
+            {
+              "id": "9e53a525-146f-5f7c-9006-233cca1ef242",
+              "ref": null,
+              "title": "The Most Important Rule",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "While you’re playing Warhammer Age of Sigmar, you might encounter a rules situation that you aren’t sure how to resolve. If you’re new to the game, we recommend discussing with your opponent and agreeing on a fair and reasonable solution so you can get on with the game as quickly as possible. Otherwise, the **Special Rules** section includes detailed instructions on how to resolve these situations."
+                }
+              ]
+            },
+            {
+              "id": "27a2a486-2d00-52b5-91f8-892e8b61e933",
+              "ref": null,
+              "title": "Rules Updates",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "We are committed to supporting Warhammer Age of Sigmar rules via regular free updates based on community feedback. Please check **warhammer-community.com** to download the latest updates and FAQs."
+                }
+              ]
+            },
+            {
+              "id": "ccaa8065-905e-5cca-9dac-806e350962c5",
+              "ref": null,
+              "title": "Core Concepts",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Battles in Warhammer Age of Sigmar are fought on a surface that is referred to as the **battlefield**. Each battle uses a scenario called a **battleplan**, which will explain how to set up the battlefield and how to determine the winner.\n\nEach player is the **commander** of an **army**. Each army belongs to a **faction** and is made up of groups of **models** called **units**. Models and units in your army are referred to as **friendly** models and units, and models and units in your opponent’s army are referred to as **enemy** models and units."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "4112066c-70bb-59e2-ba40-27228fa447c7",
+          "ref": "2.0",
+          "name": "2.0 Tools of War",
+          "containers": [
+            {
+              "id": "8e2ee2d6-0d49-5eee-80c8-3bc528768cda",
+              "ref": null,
+              "title": "Tools of War",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "To fight a battle, you will need:\n\n• A tape measure\n• Some dice\n• A surface to play on (the battlefield)\n• 2 armies of Citadel Miniatures"
+                }
+              ]
+            },
+            {
+              "id": "d4cba552-bbe6-5f42-b589-ca55de3b717a",
+              "ref": "2.1",
+              "title": "2.1 Measuring Distances",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Distances in Warhammer Age of Sigmar are measured in **inches** (\"), between the closest points on the bases of the models you’re measuring to and from. You can measure distances whenever you wish. When measuring the distance between units, always measure the distance between the closest points on the bases of the closest models in each unit. If a model does not have a base, measure to and from the closest point on the model instead."
+                }
+              ]
+            },
+            {
+              "id": "5a792715-9d62-578b-bb30-f550d2e0e2df",
+              "ref": "2.1.1",
+              "title": "2.1.1 Within and Wholly Within",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "A **model** is **within** a certain distance of something (e.g. another unit, a territory or an objective) if any part of its base is within that distance.\n\nA **model** is **wholly within** a certain distance of something if every part of its base is within that distance.\n\nA **unit** is **within** a certain distance of something if any part of the base of any model in the unit is within that distance. A **unit** is **wholly** **within** a certain distance of something if every part of the bases of all of the models in the unit is within that distance."
+                }
+              ]
+            },
+            {
+              "id": "db21634c-1c25-50a6-9375-eb4def32cacf",
+              "ref": "2.2",
+              "title": "2.2 Dice",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Warhammer Age of Sigmar uses six-sided dice, often abbreviated to **D6**."
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "Some rules refer to ‘2D6’, ‘3D6’ and so on – in such cases, roll a number of dice equal to the number before ‘D6’ and add the results together.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "A roll of ‘2+’ means a roll of 2 or more, a roll of ‘3+’ means a roll of 3 or more, and so on.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "If a rule requires you to roll a **D3**, roll a dice and halve the total, rounding up. For D3 rolls, a roll of ‘2+’ means a result of 2 or more after halving the total and rounding up.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "Effects that allow you to modify a dice roll are called **modifiers**.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "Some rules allow you to **re-roll** a dice roll, which means you get to roll some or all of the dice again. You cannot re-roll a dice more than once, and re-rolls happen before modifiers to the roll (if any) are applied.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "If you are instructed to **roll off**, each player should roll a dice. Whichever player has a higher roll wins the roll-off. If the result is a tie, each player should roll off again until there is a clear winner, unless otherwise specified.",
+                      "indent": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "ef78dbac-4eae-5b0d-a823-97e050f0a298",
+          "ref": "3.0",
+          "name": "3.0 Factions",
+          "containers": [
+            {
+              "id": "fac5a523-af2f-58ff-8860-798d38737137",
+              "ref": null,
+              "title": "Factions",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each army belongs to a **faction**, e.g. Stormcast Eternals or Skaven.\n\nEach faction has a set of **faction rules**, which include **battle traits**, **battle formations**, **enhancements** and **lores**. These can be found in various publications but most commonly in the faction’s **battletome**."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "feca06f7-f680-547b-9dc6-c1bd8be41710",
+          "ref": "4.0",
+          "name": "4.0 Warscrolls",
+          "containers": [
+            {
+              "id": "3d6a51d9-80e3-5b52-99a5-6595c3df08ee",
+              "ref": null,
+              "title": "Warscrolls",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The rules for each unit are contained on a **warscroll**:"
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/7a212d8c-82a0-414d-8796-3126e4f5f757",
+                    "altText": "An example warscroll. At the top of the left-hand column of the warscroll are the unit's characteristics: Move, Save, Control and Health. Beneath that is a short description of the unit. On the right is shown the name of the unit, and beneath that is a table that lists the weapons that the unit is armed with, along with their respective characteristics. Beneath the weapon table are the unit's abilities; each of these is contained in its own little box. Some units only have one ability; others have more. Finally, running along the bottom of the warscroll is the keywords bar. This is a list of words that are used to group units that share common traits or to indicate that certain special rules apply to the unit."
+                  }
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "1. The **MOVE** characteristic determines how quickly the unit can move across the battlefield (see 15.0).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "2. The **HEALTH** characteristic determines how many damage points can be allocated to a unit before a model in the unit is slain (see 18.2).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "3. The **CONTROL** characteristic determines how well each model in the unit can contest objectives (see 32.2).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "4. The **SAVE** Characteristic determines how well armoured the unit is. This characteristic is the roll you need to equal or exceed to save a model from harm, so a lower value is better (see 17.0).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "5. The **UNIT TYPE**.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "6. The **KEYWORDS** that the unit has (see 5.1).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "7. The **WEAPONS** the unit is armed with. Weapons are either **melee weapons**, used to make **combat attacks**, or **ranged weapons**, used to make **shooting attacks**. Each weapon has its own characteristics (see 16.0).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "8. Any special **ABILITIES** the unit can use (see 5.0).",
+                      "indent": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "5793bd5b-2052-5084-8397-659e77bdd823",
+          "ref": "5.0",
+          "name": "5.0 Abilities",
+          "containers": [
+            {
+              "id": "106afa40-7b99-5672-85eb-0c54366e64bb",
+              "ref": null,
+              "title": "Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The vast majority of things that units can do in Warhammer Age of Sigmar are called **abilities**. This is an example of an ability:"
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/6e5902c8-11d4-45d3-8708-eb281114cfc1",
+                    "altText": "An example ability. Abilities are contained in their own box. The bar at the top tells you when the ability can be used. Beneath that, in the main part of the box, is the name of the ability, a small passage of text that puts the ability into context to help you imagine what is happening on the battlefield when it is being used. Beneath that are the Declare instructions (if any), and beneath that is the Effect of the ability – in other words, what the ability actually does in the game. Beneath the effect is a keywords bar. Ability keywords are used to group abilities of a similar type."
+                  }
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "1. **Timing**",
+                      "indent": 0
+                    },
+                    {
+                      "text": "2. **Name and Description**",
+                      "indent": 0
+                    },
+                    {
+                      "text": "3. **Declare Instructions**",
+                      "indent": 0
+                    },
+                    {
+                      "text": "4. **Effect**",
+                      "indent": 0
+                    },
+                    {
+                      "text": "5. **Keywords**",
+                      "indent": 0
+                    }
+                  ]
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/894e4f94-7170-4edf-92c0-c086214d4359",
+                    "altText": "This key shows the different ability icons and their names. The Movement icon is a small arrow, the Offensive icon is a crossed axe and sword, the Defensive icon is a shield bearing the twin-tailed comet symbol, the Shooting icon is a bow and arrow, the Rallying icon is a flag, the Special icon is a twelve-pointed halo, and the Control icon is a solid circle."
+                  }
+                }
+              ]
+            },
+            {
+              "id": "695be0a5-0a9a-55ce-8177-923de16b6b5c",
+              "ref": "5.1",
+              "title": "5.1 Keywords",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities have one or more **keywords** listed at the bottom of the ability on their **keywords bar**, e.g. the ‘Shoot’ ability shown above has the **CORE**, **ATTACK** and **SHOOT** keywords. Units also have a keywords bar on their warscroll.\n\nKeywords let you know which abilities can be used or which units can be picked as targets for an ability. For example, the ‘Charge’ ability can only be used by a unit if it did not use an ability with the **RUN** or **RETREAT** keyword earlier in the turn. The singular and plural forms of a keyword are synonymous for rules purposes."
+                }
+              ]
+            },
+            {
+              "id": "ca9d568a-6a55-5a15-9a53-f9fe2f6d8cfb",
+              "ref": "5.2",
+              "title": "5.2 Using Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The **timing** of an ability tells you when it can be used. When using an ability, follow these steps:\n\n1. Declare the Ability: Tell your opponent which ability is being used. If the ability has **Declare** instructions, resolve them at this step.\n2. Use Reactions: Starting with the player using the ability, the players alternate using any abilities with an appropriate **Reaction** timing. Players can choose to pass instead of using a reaction, but once both players consecutively pass, no further reactions to that ability can be used.\n3. Resolve the Effect: Follow the instructions in the **Effect** part of the ability."
+                }
+              ]
+            },
+            {
+              "id": "904a8e30-8137-5002-9190-759042aed77e",
+              "ref": "5.3",
+              "title": "5.3 The Rules of One",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "A unit cannot use more than 1 **CORE** ability per phase (see 14.0).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "A unit cannot use the **same ability** more than once per phase, unless specified otherwise.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "A unit cannot be affected by the same **passive ability** more than once at the same time. For example, if a unit is within range of two different terrain features that have the ‘Cover’ passive ability, the effect only applies to it once.",
+                      "indent": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "5bd028a8-99bf-51a1-ab34-5bb02ec04d24",
+              "ref": "5.4",
+              "title": "5.4 Passive Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Abilities that have the **Passive** timing are called passive abilities. **Passive abilities** are not declared. The effects of passive abilities always apply if the conditions of the ability are met, and they must be applied if it is possible to do so."
+                }
+              ]
+            },
+            {
+              "id": "f4c6bfdb-db3e-56a7-91cf-cf27b1c5443c",
+              "ref": null,
+              "title": "Abilities Example",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "textBold",
+                  "text": "Ben and Jes are fighting a battle, and Ben’s Rat Ogors have charged into Jes’s Liberators. It is Ben’s turn to pick a unit to fight. The following example shows how abilities are used, but don’t worry too much about the specific abilities, as they will be explained later in the rules."
+                },
+                {
+                  "type": "text",
+                  "text": "1. Ben uses the ‘Fight’ ability. The first step is to resolve any Declare instructions for the ability. In this case, Ben picks his unit of Rat Ogors to use the ability, then they make a pile-in move. Finally, Ben picks Jes’s Liberators unit as the target of all the Rat Ogors’ attacks."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "af29ec0a-b3df-56a6-a7c1-3f356530d3f1",
+                    "name": "Fight",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Any Combat Phase",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that is **in combat** or that **charged** this turn to use this ability. That unit can make a **pile-in move** (see 15.3). Then, if that unit is **in combat**, you must pick one or more enemy units as the target(s) of that unit’s attacks (see 16.0).",
+                    "effect": "Resolve **combat attacks** against the target unit(s).",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Attack", "Fight"]
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/ac6ce57b-1dd0-4c6b-bdf5-6da435fc8170",
+                    "altText": "A unit of three Skaven Rat Ogors is piling in towards a unit of five Stormcast Eternals Liberators. Two arrows indicate that two of the Rat Ogor models made a pile-in move to get into combat with the Liberators, while the third Rat Ogor has not moved because it was already in combat. The starting positions of the Rat Ogors that moved are indicated by fainter images."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "2. After declaring the ability, Ben has the first opportunity to use any **reactions**. As ‘Fight’ has the **ATTACK** keyword, Ben is able to use the ‘All-out Attack’ ability to improve his Rat Ogors’ attacks.\n\nAfter Ben uses ‘All-out Attack’, Jes uses the ‘All-out Defence’ ability to try to protect his Liberators against the upcoming onslaught. Ben then passes on using any further reactions, then Jes does the same."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "de88d680-3642-531b-8d1b-f4aadd21dcbb",
+                    "name": "All-out Attack",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Reaction: You declared an ATTACK ability",
+                    "icon": "offensive",
+                    "cpCost": 1,
+                    "declare": null,
+                    "effect": "Add 1 to **hit rolls** for attacks made as part of that **ATTACK** ability. This also affects weapons that have the **Companion** weapon ability.",
+                    "usedBy": "The unit using that **ATTACK** ability.",
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "09f59d7e-3584-56bc-9213-4424e22653ff",
+                    "name": "All-out Defence",
+                    "phase": "defensive",
+                    "phaseDetails": "Reaction: Opponent declared an ATTACK ability",
+                    "icon": "defensive",
+                    "cpCost": 1,
+                    "declare": null,
+                    "effect": "Add 1 to **save rolls** for that unit in this phase.",
+                    "usedBy": "A unit targeted by that **ATTACK** ability.",
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "‘All-out Attack’ and ‘All-out Defence’ are examples of **Advanced Rules**, which are used in certain battlepacks."
+                },
+                {
+                  "type": "text",
+                  "text": "3. Now that the Declare instructions have been resolved and both players have had a chance to use reactions, Ben can resolve the effect of the ability, resulting in 2 Liberators being slain (see 18.3)."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "af29ec0a-b3df-56a6-a7c1-3f356530d3f1",
+                    "name": "Fight",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Any Combat Phase",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that is **in combat** or that **charged** this turn to use this ability. That unit can make a **pile-in move** (see 15.3). Then, if that unit is **in combat**, you must pick one or more enemy units as the target(s) of that unit’s attacks (see 16.0).",
+                    "effect": "Resolve **combat attacks** against the target unit(s).",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Attack", "Fight"]
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/9f8ce4a9-7eb0-4298-9e0d-2907249fd5ed",
+                    "altText": "The two slain Liberators are indicated by icons in the form of haloed skulls set over the images of the slain models."
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "fc0b9d8a-5e94-58e6-bc08-2f001eb7a84f",
+          "ref": "6.0",
+          "name": "6.0 Visibility",
+          "containers": [
+            {
+              "id": "e2a2255a-a5ca-5838-b695-d0be7d73c8ba",
+              "ref": null,
+              "title": "Visibility",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "A target model is visible to another model (which we’ll call the ‘observing model’) if you can draw a straight line through the air (whether horizontal, diagonal or vertical) from any point on the observing model to any point on the target model that does not intersect any objects except for other models in the observing model’s unit. A target unit is visible to an observing unit if at least 1 model in the target unit is visible to at least 1 model in the observing unit. A model is always considered to be visible to itself."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/61556fdc-0fe3-4c50-bf60-584b765457e2",
+                    "altText": "A Stormcast Eternal Liberator partially obscured by a wall."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "Even though only half of this Liberator can be seen, he counts as being visible. A model is visible no matter how much of the model is blocked from sight or how little of it is visible; if any part of the model can be seen, it is visible."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/e2603d4e-f5a6-46e3-a732-89dec981fae0",
+                    "altText": null
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "An observing model's visibility can be blocked by enemy models. The Plaguebearer in this shot is not visible to the Liberator because it is hidden by the Great Unclean One."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/be9ee61a-836d-4bf0-90cc-ab52b7ac9124",
+                    "altText": "Three Liberators viewed from behind. One of them is a little further back than the other two."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "The Liberator at the back of this unit can see through their fellows. Models don’t block the visibility of other models in their unit – it is assumed that they fight in such a way as to not obstruct one another’s attacks."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ If any part of another model can be seen by an observing model, both the target model and its unit are **visible** to that observing model."
+                },
+                {
+                  "type": "text",
+                  "text": "In some cases, it might not be immediately clear whether a model is visible. If so, stoop down to get a look from behind the observing model. If any part of the other model is visible, even if it is just the tip of a spear, then that model is visible for rules purposes."
+                },
+                {
+                  "type": "text",
+                  "text": "If a rule or ability requires a target to be both within a given range of and visible to the unit using that ability, or to a model in that unit, both conditions must be met by the same model in the target. You could not, for instance, target a unit where one model is within range but not visible and another model is not in range but is visible."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "d8ca5469-9a4a-5873-adc5-39453ab83747",
+          "ref": "7.0",
+          "name": "7.0 Combat Range",
+          "containers": [
+            {
+              "id": "40c7d160-61a3-5f05-8c3e-c66eb7b10890",
+              "ref": null,
+              "title": "Combat Range",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each model has a **combat range** that extends 3\" horizontally from its base and any distance vertically from that circle to form a cylinder. The combat range of a unit extends 3\" horizontally and any distance vertically from every model in that unit. Units from opposing armies that are within each other’s combat range and that are **visible** to each other are **in combat** with each other. When a unit that is not in combat enters the combat range of a visible enemy unit, it **moves into combat**.\n\nA model is considered to be in combat with an enemy unit if that unit is within the model’s combat range and visible to it."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ A unit’s combat range extends 3\" out from every model in that unit.\n\n◆ If any enemy models are within a unit’s combat range and visible to it, that unit is in combat."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/42995b24-a75a-46b7-8726-8b8ad9203187",
+                    "altText": "A blue overlay is set over a Liberator, stretching out 3 inches from the left and right of the model's base and stretching all the way up to the top of the image. This indicates the combat range of the model."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "A model’s combat range extends 3\" horizontally outwards from it in all directions and an infinite distance vertically. Note that this is measured from the edge of its base, not the centre."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/f8869d9a-0bcb-4477-9ee1-f09050463594",
+                    "altText": "Two Rat Ogors, a Liberator and a wall. One Rat Ogor and the Liberator are on one side of the wall; the other Rat Ogor is on the opposite side of the wall. A large blue circle centred over the Liberator partially overlaps both the Rat Ogors and the wall."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "Even though both Rat Ogors are within the combat range of the Liberator, the Rat Ogor behind the wall is not visible to the Liberator and is therefore not in combat."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/2d2ffbe1-8d3c-4451-8a7d-43db8512b75c",
+                    "altText": "Five large blue circles centred over each model in a unit of five Liberators have merged to indicate the combat range of the unit as a whole."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "A unit’s combat range extends 3\" horizontally and any distance vertically from all models in the unit. As you can see, this forms a sort of ‘cloud’."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/b5ad61b9-e387-4802-a8bc-74b691655575",
+                    "altText": "A unit of five Liberators, a unit of three Rat Ogors and a unit consisting of a single Clawlord. The blue area indicating the Liberators' combat range is overlapping the Clawlord and two of the three Rat Ogors."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "A unit is in combat with a visible enemy unit if any of its models are within the combat range of that enemy unit. Even though 1 Rat Ogor is not within the Liberators’ combat range, its unit is still in combat."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "8460ff70-3bd9-5a9f-a9cc-07121caac77a",
+      "ref": null,
+      "name": "Setting up for Battle 8.0 - 10.1",
+      "containers": [],
+      "sections": [
+        {
+          "id": "c837769d-b9b2-5343-876f-30bd3923b647",
+          "ref": "8.0",
+          "name": "8.0 The Armies",
+          "containers": [
+            {
+              "id": "03e572fe-c956-5b3a-b388-77e1f148a474",
+              "ref": null,
+              "title": "The Armies",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Before starting a battle, both players will need an **army**. Some battlepacks use pre-made armies, while others include rules on how to fill your army roster."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "Unless specified otherwise in the battlepack or battleplan:\n\n◆ Set up objectives.\n◆ Set up terrain.\n◆ Determine territories.\n◆ Deploy armies.\n◆ The player who lost the roll-off to choose territories decides who begins deployment"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "75e1f840-2459-57c2-b40a-58af418a1217",
+          "ref": "9.0",
+          "name": "9.0 Battleplans",
+          "containers": [
+            {
+              "id": "797cb04a-a477-5a06-963e-e7c4c5025d86",
+              "ref": null,
+              "title": "Battleplans",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Before any battle, you’ll need to pick a **battleplan**. A variety of battleplans are available in each **battlepack**, and additional battleplans are available in other publications. Each battleplan is a scenario to play – it outlines **territories**, **objectives** and **victory conditions**, in addition to any special rules that apply to that battle."
+                }
+              ]
+            },
+            {
+              "id": "52ca1ace-3ca7-5ff8-a9ea-87894a4dc620",
+              "ref": "9.1",
+              "title": "9.1 Battlefield Map",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each battleplan includes a **battlefield map** that is divided into **quarters**. The map will show the locations of any **objectives** and the players’ **territories**. Each battlepack or battleplan will indicate the recommended battlefield size based on the size of game you are playing."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/fbd5b179-78b5-46fe-89dd-6fb0fd1425c7",
+                    "altText": "A rectangular diagram of a battlefield is shown. At the top of the rectangle, stretching all the way from left to right, there is a blue strip captioned 'Defender's Territory'. At the bottom, there is a red strip captioned 'Attacker's territory'. Between these two strips, there is a wider grey strip that has no caption. On the horizontal centre line of the battlefield, there are two golden circles. The battlefield is symmetrical."
+                  }
+                }
+              ]
+            },
+            {
+              "id": "bc7c053a-a43f-5392-82c3-15feee6a8be3",
+              "ref": "9.1.1",
+              "title": "9.1.1 Setting up Objectives and Terrain Features",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Many battlefields have key locations called **objectives**, and almost all battlefields have **terrain features** such as buildings, ruins and woods. Unless otherwise specified, players should first set up objective markers at the locations indicated by a gold circles on the deployment map, then set up terrain features in a mutually agreeable manner. Many battlepacks and battleplans include further instructions for setting up terrain."
+                }
+              ]
+            },
+            {
+              "id": "06300b64-9c3a-5b43-b272-6ce5aafe37a1",
+              "ref": "9.1.2",
+              "title": "9.1.2 Territories",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Unless otherwise specified in the battlepack or battleplan, after terrain has been set up, the players should roll off. The winner decides which territory belongs to which player. Their opponent decides which player begins deployment."
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "A unit is **within** a territory if any part of the base of any model in the unit is within that territory.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "A unit is **wholly within** a territory if every part of the base of every model in the unit is within that territory.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "The area of the battlefield that is neither player’s territory is **neutral territory**.",
+                      "indent": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "652c2174-5a4a-5c11-89d9-2e0310f482ad",
+          "ref": "10.0",
+          "name": "10.0 The Deployment Phase",
+          "containers": [
+            {
+              "id": "6b1c4f94-5c4d-5775-a2c1-a812b83cce31",
+              "ref": null,
+              "title": "The Deployment Phase",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Once the battlefield is ready, the players must **deploy** their armies. This is done in a special phase called the **deployment phase**. The deployment phase happens once per battle, before the start of the first battle round (see 12.0)."
+                },
+                {
+                  "type": "textBold",
+                  "text": "Step 1 - Deploy Faction Terrain Features"
+                },
+                {
+                  "type": "text",
+                  "text": "Some factions have **faction terrain features**, which have their own warscrolls and are set up using **DEPLOY TERRAIN** abilities. The player who begins deployment must use **DEPLOY TERRAIN** abilities first, followed by their opponent."
+                },
+                {
+                  "type": "textBold",
+                  "text": "Step 2 - Deploy Armies"
+                },
+                {
+                  "type": "text",
+                  "text": "Unless otherwise specified in the battleplan, the players alternate using **DEPLOY** abilities to deploy their units, starting with the player who begins deployment. Once one player has no more **DEPLOY** abilities to use, their opponent must continue to use **DEPLOY** abilities until they also have no more to use."
+                },
+                {
+                  "type": "textBold",
+                  "text": "Step 3 - Use Deployment Phase Abilities"
+                },
+                {
+                  "type": "text",
+                  "text": "After both players have finished deploying their units, the player who begins deployment can use any Deployment Phase abilities that are **not DEPLOY** or **DEPLOY TERRAIN** abilities, in the order of their choosing, then their opponent can do the same."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆Player who begins deployment can use any **DEPLOY TERRAIN** abilities, followed by their opponent.\n◆ Players alternate using **DEPLOY** abilities.\n◆ Player who begins deployment must use any other Deployment Phase abilities, then their opponent can do so."
+                }
+              ]
+            },
+            {
+              "id": "7c1f1db6-aaff-5d24-8b80-3c0887ecbabd",
+              "ref": "10.1",
+              "title": "10.1 Universal Deployment Phase Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "22ebbb45-9e10-532b-a182-7c9b6767f8e1",
+                    "name": "Deploy Unit",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Deployment Phase",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick a **unit** from your army roster that has not been **deployed** to be the target.",
+                    "effect": "Set up the target unit wholly within friendly territory and more than 9\" from enemy territory. After you have done so, it has been **deployed**.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Deploy"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "8e90ebdf-af7a-5458-bd5e-1020820f1570",
+                    "name": "Deploy Faction Terrain",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Deployment Phase",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick a friendly **faction terrain feature** that has not been **deployed** to be the target.",
+                    "effect": "Set up the target faction terrain feature wholly within friendly territory, more than 3\" from all objectives and other terrain features. After you have done so, it has been **deployed**.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Deploy Terrain"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "c0d4f8c2-c50d-5665-b904-8b7c65824cd9",
+                    "name": "Deploy Regiment",
+                    "phase": "startOfTurn",
+                    "phaseDetails": "Deployment Phase",
+                    "icon": "special",
+                    "cpCost": null,
+                    "declare": "Pick a **regiment** from your army roster to be the target. No units in that regiment can have already been **deployed**.",
+                    "effect": "Keep using **DEPLOY** abilities without alternating until all units in that regiment have been **deployed**. You cannot pick units that are not in that regiment as the target of any of those **DEPLOY** abilities.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Deploy"]
+                  }
+                },
+                {
+                  "type": "boxedText",
+                  "text": "A **regiment** is a collection of units. It is one of the main building blocks of an army (see ‘Army Composition’ in the Advanced Rules).\n\nSome factions have special **DEPLOY** abilities, such as the ‘Scions of the Storm’ ability of the Stormcast Eternals."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "e34923be-d0c8-546b-ba1f-d65c450a9db1",
+      "ref": null,
+      "name": "The Battle 11.0 - 14.4",
+      "containers": [],
+      "sections": [
+        {
+          "id": "31213d9a-c524-5d35-a49b-d2cfc255c724",
+          "ref": "11.0",
+          "name": "11.0 Battle Sequence",
+          "containers": [
+            {
+              "id": "43175dac-f32a-53ae-a177-40f9e93db3a5",
+              "ref": null,
+              "title": "Battle Sequence",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each battle lasts a number of **battle rounds**, specified in the battleplan. During each battle round, each player will take a **turn**. Each turn is broken down into multiple **phases** (see 13.0)."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ The battle lasts a fixed number of **battle rounds**.\n◆ Each battle round contains 2 **turns**.\n◆ The player whose turn is taking place is the **active player**.\n◆ Each turn contains 7 **phases**.\n◆ In each phase, the active player uses abilities first, then their opponent does the same."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "6da2ad82-dc45-5e4b-8ee5-d4d3190a54fe",
+          "ref": "12.0",
+          "name": "12.0 Start of Battle Round",
+          "containers": [
+            {
+              "id": "685f9912-9920-58c6-9e89-f6839eb49230",
+              "ref": null,
+              "title": "Start of Battle Round",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "At the start of each battle round, follow these steps:\n\n1. **Determine the Active Player**: If it is the **first** battle round, the player who finished setting up their army first decides who will take the first turn (unless otherwise specified in the battlepack or battleplan).&#x20;\n\nIf it is **not** the first battle round, the players make a roll-off called the **priority roll** and the winner decides who will take the first turn. If the roll-off is a **tie**, the player who took the first turn in the **previous** battle round decides who will take the first turn in the **current** battle round.&#x20;\n\nWhen it is a player’s turn, regardless of whether they take the first or second turn, they are referred to as the **active player**.\n\n2. **Determine the Underdog**: Whichever player has the fewest victory points is the **underdog** for the battle round. If the players are tied (e.g. in the first battle round), then there is no underdog, unless otherwise specified.\n\n3. **Start of Battle Round Abilities**: The active player can use any Start of Battle Round abilities first, then their opponent can do the same."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "86de5026-12fe-575d-a721-edd723bf3f0d",
+          "ref": "13.0",
+          "name": "13.0 Turn Phases",
+          "containers": [
+            {
+              "id": "b9d0af76-669b-5c99-8447-60e6548d1ffc",
+              "ref": null,
+              "title": "Turn Phases",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Each player’s turn is broken down into 7 **phases**, as shown on the left. In each phase, the active player can use any abilities with the ‘**Your (…) Phase**’ or ‘**Any (…) Phase**’ timing in the order of their choosing. For example, in the **Movement Phase**, the active player could use abilities with the Your Movement Phase or Any Movement Phase timing.\n\nOnce the active player has finished using abilities, their opponent can then use any abilities with an ‘**Enemy (…) Phase**’ or ‘**Any (…) Phase**’ timing, in the order of their choosing."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/b87fa2d2-22e3-4964-9d22-7417dda8b542",
+                    "altText": "A small diagram showing the colours that are associated with the different phases: black for the start of turn, gold for the hero phase, grey for the movement phase, blue for the shooting phase, orange for the charge phase, red for the combat phase, and purple for the end of turn."
+                  }
+                }
+              ]
+            },
+            {
+              "id": "c28ebd39-dfac-541b-8778-579a7733d0e6",
+              "ref": "13.1",
+              "title": "13.1 Fight Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Abilities with the **FIGHT** keyword follow a different sequence to other abilities. When the players are using Combat Phase abilities as described in 13.0, they cannot use **FIGHT** abilities.\n\nAfter the players have finished using Combat Phase abilities that are **not FIGHT** abilities, they must alternate picking 1 eligible unit to use a **FIGHT** ability, starting with the active player. Each unit in combat **must** use a **FIGHT** ability if it is able to.\n\nOnce a player has no more units that are eligible to use a **FIGHT** ability, the other player continues to pick units that are eligible to use a **FIGHT** ability, one after another, until there are no more units that are eligible to use a **FIGHT** ability."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/b86f02b6-134b-42e6-aabd-6262cef7a346",
+                    "altText": "Step one: the active player uses all their combat phase abilities that are not Fight abilities. Step two: their opponent does the same. Step three: the players alternate using Fight abilities, one at a time, starting with the active player."
+                  }
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ The active player uses Combat Phase abilities that are **not FIGHT** abilities, then the opponent does the same.\n◆ Players alternate picking a unit to use a **FIGHT** ability, starting with the active player.\n◆ Each unit **must** use a **FIGHT** ability if it is able to."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "e2bbf7cb-88b5-50eb-828d-b705f226f7ea",
+          "ref": "14.0",
+          "name": "14.0 Universal Core Abilities",
+          "containers": [
+            {
+              "id": "3acb6dd3-d3d3-5f56-90b3-b513edc556c2",
+              "ref": null,
+              "title": "Universal Core Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The following **CORE** abilities can be used by any unit. Remember that each unit can use a maximum of 1 **CORE** ability per phase (see 5.3)."
+                }
+              ]
+            },
+            {
+              "id": "2df50aca-5929-5329-84ce-02255e30def7",
+              "ref": "14.1",
+              "title": "14.1 Movement Phase",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "1ba45a35-4256-58ed-8f43-67892d3a74a2",
+                    "name": "Normal Move",
+                    "phase": "movementPhase",
+                    "phaseDetails": "Your Movement Phase",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that is **not in combat** to use this ability.",
+                    "effect": "That unit can move a distance up to its **Move** characteristic. That unit **cannot** move into combat during any part of that move.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Move"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "7fb56162-79c4-5f20-a133-1c7ea9c236f8",
+                    "name": "Run",
+                    "phase": "movementPhase",
+                    "phaseDetails": "Your Movement Phase",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that is **not in combat** to use this ability.",
+                    "effect": "Make a **run roll** of D6. That unit can move a distance up to its **Move** characteristic added to the **run roll**. That unit **cannot** move into combat during any part of that move.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Run", "Move"]
+                  }
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "a1c84295-1cff-5474-bc6b-59056dcfb441",
+                    "name": "Retreat",
+                    "phase": "movementPhase",
+                    "phaseDetails": "Your Movement Phase",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that is **in combat** to use this ability.",
+                    "effect": "Inflict **D3 mortal damage** on that unit. That unit can move a distance up to its **Move** characteristic. That unit **can** move through the combat ranges of any enemy units but **cannot** end that move within an enemy unit’s combat range.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Retreat", "Move"]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "23ecdf48-0eb5-5459-816d-8f5800386388",
+              "ref": "14.2",
+              "title": "14.2 Shooting Phase",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "967f5cff-f776-5984-bf1c-f47e21da9ceb",
+                    "name": "Shoot",
+                    "phase": "shootingPhase",
+                    "phaseDetails": "Your Shooting Phase",
+                    "icon": "shooting",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that has not used a **RUN** or **RETREAT** ability this turn to use this ability. Then, pick one or more enemy units as the target(s) of that unit’s attacks (see 16.0).",
+                    "effect": "Resolve **shooting attacks** against the target unit(s).",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Attack", "Shoot"]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "a17a4fe4-5eca-5b5c-9d2f-3903c2488ed4",
+              "ref": "14.3",
+              "title": "14.3 Charge Phase",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "601a3b2a-f98e-57fb-9731-8acbcd724183",
+                    "name": "Charge",
+                    "phase": "chargePhase",
+                    "phaseDetails": "Your Charge Phase",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that is **not in combat** and has not used a **RUN** or **RETREAT** ability this turn to use this ability. Then, make a **charge roll** of 2D6.",
+                    "effect": "That unit can move a distance up to the value of the **charge** **roll**. That unit **can** move through the combat ranges of any enemy units and **must** end that move within ½\" of a visible enemy unit. If it does so, the unit using this ability has **charged**.",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Charge", "Move"]
+                  }
+                }
+              ]
+            },
+            {
+              "id": "d8bef19d-e9ad-5586-a14c-ffe0b8a7549b",
+              "ref": "14.4",
+              "title": "14.4 Combat Phase",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "af29ec0a-b3df-56a6-a7c1-3f356530d3f1",
+                    "name": "Fight",
+                    "phase": "combatPhase",
+                    "phaseDetails": "Any Combat Phase",
+                    "icon": "offensive",
+                    "cpCost": null,
+                    "declare": "Pick a friendly unit that is **in combat** or that **charged** this turn to use this ability. That unit can make a **pile-in move** (see 15.3). Then, if that unit is **in combat**, you must pick one or more enemy units as the target(s) of that unit’s attacks (see 16.0).",
+                    "effect": "Resolve **combat attacks** against the target unit(s).",
+                    "usedBy": null,
+                    "additionalRulesText": null,
+                    "keywords": ["Core", "Attack", "Fight"]
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "3d99c11e-0b51-5cf1-8ef4-6a04cfba5a9e",
+      "ref": null,
+      "name": "Movement 15.0 - 15.5",
+      "containers": [],
+      "sections": [
+        {
+          "id": "c9e59695-152a-52ad-89c9-2f24e2bdeada",
+          "ref": "15.0",
+          "name": "15.0 Movement",
+          "containers": [
+            {
+              "id": "c7ba5eb6-0cfc-531a-81a5-78c3eddb4cfc",
+              "ref": null,
+              "title": "Movement",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities allow a unit to move. When a unit moves, each model in that unit can move, one at a time, in the order chosen by that unit’s commander.\n\nWhen a model moves, it can pivot and change direction as often as you like, but no part of that model’s base can move a greater total distance than the maximum allowed by the ability used. Models cannot move beyond the edge of the battlefield or through other models, and they can never end a move standing on top of another model (the base counts as part of the model).\n\nA model’s base is assumed to remain parallel with the battlefield as it moves. If a model ends its move on an uneven surface, it must be able to stand up by itself with its base as close to parallel with the battlefield as possible (in other words, models cannot lie flat on the battlefield or lean against terrain to stop them from falling over)."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/a6fa4d4d-693e-4cca-9e31-1076031a5982",
+                    "altText": "A unit of five Liberators with their combat range marked in blue, a Skaven Grey Seer, and a wall. The diagram shows the Grey Seer using the 'Normal Move' ability to move around the wall. Importantly, at no point does the Grey Seer's move encroach on the blue area indicating the Liberators' combat range."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "This Grey Seer is using the ‘Normal Move’ ability to change its position on the battlefield. No part of that move can be within the combat range of the Liberators, so the Grey Seer has to stay outside the area marked in blue."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ When moving a unit, move any number of models in that unit.\n◆ Each model can turn and pivot, but no part of its base can move farther than the maximum distance.\n◆ Units can move any distance up to the maximum specified in the ability.\n◆ Units must end their move in coherency."
+                }
+              ]
+            },
+            {
+              "id": "f9c305ce-889c-5347-bc4b-53cea38e5882",
+              "ref": "15.1",
+              "title": "15.1 Coherency",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Any time a unit is **set up** or **ends a move**, it must be in a single group. A unit is considered to be in a coherent group if each model in that unit is within **coherency range**, measured horizontally, of **at least 1 other model** in that unit (ignore differences in height between the two models).\n\nFor the majority of units, **coherency range is ½\"**, though some units (particularly those with large models with overhanging parts) have a longer coherency range noted on their warscroll for ease of play. While there are **7 or more** models in a unit, that unit is considered to be in a coherent group if each model in that unit is within coherency range of **at least 2 other models** in that unit.\n\nIf it is not possible for a unit to end a move in a single coherent group, that move cannot be made."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ After finishing a move, a unit must be in a single group.\n◆ Coherency range is ½\" horizontally.\n◆ Each model must be within coherency range of a different model from the same unit.\n◆ While a unit has 7+ models, each model must be in coherency with 2 other models in the unit."
+                }
+              ]
+            },
+            {
+              "id": "bdd2cad7-b043-5498-b5ae-1c7c02cd05e9",
+              "ref": "15.2",
+              "title": "15.2 Moving Across Terrain",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "When a model moves, it can move over **terrain features** but not through them. A model can be moved over terrain features that are **1\" or less in** **height** as if they were not there. A model can be moved vertically in order to **climb up or down** any terrain features that are taller than 1\", counting the vertical distance as part of its move. Models cannot end a move mid-climb."
+                }
+              ]
+            },
+            {
+              "id": "1b6ca6e4-c236-5756-ad83-aa71db9f3ec1",
+              "ref": "15.2.1",
+              "title": "15.2.1 Jumping Down",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "When a model that is on a terrain feature moves, it can **jump down** from the edge of the terrain feature to land on a lower part of the same or a different terrain feature or to land on the battlefield. To do so, you must trace the path of the model’s move to the edge of the terrain feature. Then, that model can jump down any distance, but doing so immediately ends their move. Models cannot end any kind of move mid-jump – if it is not possible to end the move as a result, that move cannot be made."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/bf28d0a3-a741-47ac-bc6a-f87869f254c3",
+                    "altText": "A Liberator moving over a small piece of terrain. There is a white line that leads from the Liberator's starting position, flows over the terrain feature, and then ends at the model's final position. This indicates that the model is presumed to stay in contact with the terrain feature as it climbs over it."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "As a model moves across terrain, its base is assumed to stay in contact with the terrain feature and parallel to the battlefield. Models can climb up or down terrain. They can jump down too, but this ends their move."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ Models can move freely over terrain features 1\" or less in height.\n◆ Models can climb up and down terrain features, and they can jump down from a higher ledge.\n◆ Models cannot end a move mid-climb or mid-jump."
+                }
+              ]
+            },
+            {
+              "id": "8c6e64d8-b267-5fab-8db8-2f64ca65af53",
+              "ref": "15.3",
+              "title": "15.3 Pile-in Moves",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities, such as **Fight** abilities, allow a unit to make a short move called a **pile-in move** to get into a better position for combat. To do so:\n\n**If your unit is in combat**: Pick an enemy unit your unit is **in combat** with to be the **target** of the pile-in move. Each model in your unit can move up to 3\". That move can pass through the combat ranges of any enemy units, but each model must end that move **no further from** the **target** unit. At the end of the move, your unit must still be in combat with all units that it was in combat with at the start of the move.\n\n**If your unit is not in combat**: Each model in your unit can move 3\" in any direction. Th at move can pass through and end within the combat ranges of any enemy units."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ Pile in: move up to 3\".\n◆ If in combat, the unit must end the move closer, or at least as close, to the target enemy unit."
+                }
+              ]
+            },
+            {
+              "id": "a86cb229-825f-52eb-b844-c8cd917181fc",
+              "ref": "15.4",
+              "title": "15.4 Flying",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Units with the **FLY** keyword have the following passive ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "1561b798-9dd3-59de-aa38-b4cbb1888a7b",
+                    "name": "Fly",
+                    "phase": "movementPhase",
+                    "phaseDetails": "Passive",
+                    "icon": "movement",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "As this unit moves, it ignores other models, terrain features and the combat ranges of enemy units. It cannot end its move in combat unless specified in the ability that allowed it to move. Ignore any vertical distance moved for this unit.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "When moving flying units, move them horizontally in any direction, ignoring intervening models and terrain, and place them where you wish, so long as they are allowed to end their move on that spot. Note that some units have the **FLY** keyword even if that unit can’t really fly. This often represents units that bounce, bound or skitter across the battlefield so adeptly that they might as well be flying!"
+                }
+              ]
+            },
+            {
+              "id": "5f3921b9-76d6-5e58-b9ca-e4d273f506b2",
+              "ref": "15.5",
+              "title": "15.5 Overhanging Models",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some models overhang their base. When moving models, overhanging parts should be treated as if they do not exist when determining where a model could be placed. Where possible, a model should be rotated to allow for another model to end a move in proximity to it. When rotating a model this way, the base must occupy the same position – a circular base may be rotated any amount, while an oval base may only be rotated 180°. Otherwise, mark down the location of where the model should end its move (such as with an empty base of the same size) and place the model to the side. Return the model to the table as soon as it is physically possible to do so."
+                }
+              ]
+            },
+            {
+              "id": "6b328c24-3aae-5836-911b-feed9920eeac",
+              "ref": "15.6",
+              "title": "15.6 Charge Moves",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some rules reference a unit finishing or ending a charge move. This is considered to occur when a **CHARGE MOVE** ability that unit used resolves and the unit has charged as part of that ability."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "ece0c9b1-c491-5ea9-9887-6fa3cfa422ed",
+      "ref": null,
+      "name": "Attacking 16.0 - 18.4",
+      "containers": [],
+      "sections": [
+        {
+          "id": "b8140dbe-ca17-5606-a15e-303bb67f4386",
+          "ref": "16.0",
+          "name": "16.0 Picking Targets",
+          "containers": [
+            {
+              "id": "52cd4add-5d86-51ac-8ff6-974a8c4eb067",
+              "ref": null,
+              "title": "Picking Targets",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "When declaring an **ATTACK** ability for a unit, you must pick the target unit(s) for its **attacks**. The number of attacks each model can make is equal to the **Attacks** characteristic of the **weapons** it is using. In most cases, models attack with every weapon on their warscroll (melee weapons for combat attacks, ranged weapons for shooting attacks), though some warscrolls specify that certain models in the unit are armed with special weapons or that the unit must pick between multiple weapons when it attacks.\n\nIf the unit is **in combat**, it can only target units that are in combat with it. If a model has more than one attack, you can split the attacks between eligible targets as you wish."
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "**Combat attacks** are made with **melee weapons**. The target unit(s) must be within the **combat range** of the attacking model and **visible** to it. The model must attack with all of the melee weapons it is armed with.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Shooting attacks** are made with **ranged weapons**. The target unit(s) must be within a distance equal to the **Range** characteristic of the weapon being used and **visible** to the attacking model. Models **cannot** make shooting attacks if their unit is **in combat**, unless otherwise specified (see 20.0 Weapon Abilities).",
+                      "indent": 0
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "text": "◆ Pick targets for **all** attacks when declaring an **ATTACK** ability.\n◆ If a unit is **in combat**, it can only attack units it is **in combat** with and that are **visible** to it.\n◆ If making a **combat attack**, the target must be within the attacking model’s **combat range**.\n◆ If making a **shooting attack**, the target must be **visible** and within the weapon’s **Range**.\n◆ A unit cannot make **shooting attacks** if it is **in combat**, unless otherwise specified."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "be293eec-591a-5199-8bb0-548222415698",
+          "ref": "17.0",
+          "name": "17.0 The Attack Sequence",
+          "containers": [
+            {
+              "id": "07965d0f-2c44-5c8c-95d4-096603223d75",
+              "ref": null,
+              "title": "The Attack Sequence",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Resolve steps 1-4 below for each attack made against a target unit, one attack at a time. If you picked more than one target unit for the **ATTACK** ability, resolve all the attacks made against one unit before moving on to the next, in an order of your choosing. Once you are familiar with the attack sequence, see ‘Fast Dice Rolling’ (see 17.3) if you want to speed up play.\n\n**1. Hit Roll**: Roll a dice. If the roll equals or exceeds the attacking weapon’s **Hit** characteristic, the attack scores a **successful hit**: move on to the next step. If not, the attack **fails** and the attack sequence ends. Unmodified hit rolls of 1 always fail. If an unmodified hit roll for an attack made with a weapon is a **6**, that attack is a **critical hit**.\n\n**2. Wound Roll**: Roll a dice. If the roll equals or exceeds the attacking weapon’s **Wound** characteristic, the attack **successfully wounds**: move on to the next step. If not, the attack **fails** and the attack sequence ends. Unmodified wound rolls of 1 always fail.\n\n**3. Save Roll**: The commander of the **target** unit rolls a dice, subtracting the attacking weapon’s **Rend** characteristic from the roll. Unmodified save rolls of 1 always fail. If the roll equals or exceeds the **Save** characteristic of the target unit, the attack **fails** and the attack sequence ends. If not, it is a **successful attack**: move on to the next step.\n\n**4. Determine Damage**: Th e attack **inflicts** a number of **damage points** on the unit equal to the **Damage** characteristic of the weapon. Inflicted damage points are added to a temporary **damage pool** for the target unit.\n\nAfter completing these steps for all of the attacks made as part of that **ATTACK** ability, the attacks for that ability are **resolved** and you can move on to the **damage sequence** (see 18.0)."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "Critical hits have no effect on their own but often trigger additional effects (see 20.0 Weapon Abilities)."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "Keep track of the number of damage points in the damage pools of target units. Placing dice next to those units is a handy way of doing this."
+                }
+              ]
+            },
+            {
+              "id": "bf07d96a-9a39-5bfa-8766-ed5376b92ceb",
+              "ref": "17.1",
+              "title": "17.1 Attack Modifiers and Caps",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Modifiers to **hit rolls**, **wound rolls** and **save rolls** are **capped** to prevent overwhelming combinations of abilities. When making a **hit roll** or a **wound roll**, add up all positive and negative modifiers that apply to the roll, then cap the result at a **maximum of +1** (if positive) or a **minimum of -1** (if negative). When making a **save roll**, add up all the positive and negative modifiers that apply to the roll, then cap the result at a **maximum of** **+1**. Note that, unlike **hit rolls** and **wound rolls**, there is **no cap** on the amount that can be **subtracted** from **save rolls**."
+                }
+              ]
+            },
+            {
+              "id": "a79ee167-cb19-5bfe-b77f-c35bdef18be2",
+              "ref": "17.2",
+              "title": "17.2 Mortal Damage",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities inflict **mortal damage**. If an ability inflicts mortal damage on a unit, add that number of damage points to the unit’s damage pool for that ability (see 18.2 Allocating Damage)."
+                }
+              ]
+            },
+            {
+              "id": "81f61eae-e8f2-5d5b-b229-61edcf03097c",
+              "ref": "17.3",
+              "title": "17.3 Fast Dice Rolling",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In order to speed up play, it is often possible to make several attacks at once. If you choose to do so, all of the attacks must have the same **Hit, Wound, Rend and Damage** characteristics, the same **weapon abilities** (if any – see 20.0), and they must target the same enemy unit. If this is the case, make all of the hit rolls at the same time, then all of the wound rolls and finally all of the save rolls. Then, add up all the damage points inflicted on the target unit and move on to the damage sequence (see 18.0).\n\nIf the attack sequence ends for an attack made while fast dice rolling, it doesn’t stop the attack sequence for all the attacks, just that specific attack."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "17b4f743-fa25-5418-aac9-028d58a69210",
+          "ref": "18.0",
+          "name": "18.0 The Damage Sequence",
+          "containers": [
+            {
+              "id": "2fd37637-3ab1-5d2f-a695-27b0f6f43c63",
+              "ref": null,
+              "title": "The Damage Sequence",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "After resolving the effect of any ability that inflicts damage points on a unit, follow the steps below. If the ability inflicted damage points on more than one unit, follow the steps below for each of those units, one at a time. Each commander allocates damage points to their own units, in the order of their choosing, starting with the active player.\n\n**1. Resolve ward saves** for all damage points in the target unit’s damage pool, if applicable (see 17.0).\n\n**2. Allocate the damage points** in the unit’s damage pool and remove slain models (see 18.3)."
+                }
+              ]
+            },
+            {
+              "id": "1e6cb468-93b5-50a5-9494-e95d799c36fd",
+              "ref": "18.1",
+              "title": "18.1 Ward Saves",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Units with the **WARD** keyword have the ‘Ward Save’ passive ability. The number after the **WARD** keyword indicates the **ward value** for the ward save. If a unit had **WARD** **(5+)**, for example, its ward value would be 5. If a unit has more than one ward save, only the ward save with the lowest value applies to it; the other has no effect."
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "b09bea3a-5842-57ad-a96b-b297b9c7c092",
+                    "name": "Ward Save",
+                    "phase": "defensive",
+                    "phaseDetails": "Passive",
+                    "icon": "defensive",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "In step 1 of the damage sequence (see 18.0), make a **ward roll** of D6 for each **damage point** in this unit’s **damage pool**. If the roll equals or exceeds this unit’s **ward value**, remove that damage point from the damage pool.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                }
+              ]
+            },
+            {
+              "id": "fc24b06d-c094-56d2-b421-7fef76101812",
+              "ref": "18.2",
+              "title": "18.2 Allocating Damage",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "After resolving the effect of any ability that inflicts damage points (whether via attacks, mortal damage or both), you must **allocate** the damage points.\n\nWhen **allocating** damage points to a unit, the damage points in its damage pool are allocated to it one at a time. Each time the number of damage points allocated to the unit equals the **Health** characteristic of that unit, 1 model in that unit is **slain** (and removed from play) and the number of damage points allocated to that unit is reset to 0. Keep allocating damage points until there are none left in the damage pool.\n\nIf the number of damage points allocated to a unit is not enough to slay a model, keep track of the number of damage points currently allocated to the unit (most players place a dice or markers next to the unit). While a unit has any damage points allocated to it, it is **damaged**."
+                }
+              ]
+            },
+            {
+              "id": "c61c422f-36ac-5caa-b5d2-9238d426b50c",
+              "ref": "18.3",
+              "title": "18.3 Slain Models",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The commander of a unit must pick which model(s) in the unit are slain. However, after each slain model is removed, the unit must be in a single coherent group (see 15.1). If this is not possible, continue to remove models, one at a time, until the unit is in a single coherent group.\n\nYou must remove the fewest models possible to make the unit a single coherent group."
+                }
+              ]
+            },
+            {
+              "id": "de975328-1322-555e-84ae-d64607b3dc80",
+              "ref": "18.4",
+              "title": "18.4 Destroyed Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "When the last model in a unit is slain, the unit is **destroyed** and all remaining damage points inflicted on that unit have no effect. Similarly, if something causes a unit to be destroyed, all models in the unit are slain and removed from play."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "78681557-ca91-50db-b86c-58b6132ef204",
+          "ref": null,
+          "name": "Attacking Diagram",
+          "containers": [
+            {
+              "id": "1ff59933-7899-5f61-930c-1b93b1c47930",
+              "ref": null,
+              "title": "Attacking Diagram",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/a25431c4-38f6-41e2-8c6c-c817a0b0505e",
+                    "altText": "A flow chart that shows the steps of the attack sequence and the damage sequence."
+                  }
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ Attacker makes a **hit roll** of D6. If the roll equals or beats the weapon’s **Hit** characteristic, it is a **successful hit**.\n◆ Attacker makes a **wound roll** of D6. If the roll equals or beats the weapon’s **Wound** characteristic, it is a **successful wound**.\n◆ Defender makes a **save roll** of D6. Subtract the attacking weapon’s **Rend** characteristic from the roll. If the result is less than the defending unit’s **Save** characteristic, it is a **successful attack**.\n◆ **Inflict** an amount of **damage** on the target equal to the attacking weapon’s **Damage** characteristic.\n◆ Resolve ward saves.\n◆ Allocate damage points.\n◆ Unmodified **hit rolls**, **wound rolls** and **save rolls** of 1 always fail."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "f5acb53a-e611-57f6-80ae-bfd00b99953e",
+          "ref": null,
+          "name": "Attacking Example",
+          "containers": [
+            {
+              "id": "f37aee6e-a16d-54b8-98d6-a1fc6a901b4f",
+              "ref": null,
+              "title": "Attacking Example",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "textBold",
+                  "text": "Erik’s Stormcast Eternals are facing off against Emma’s Skaven in a close game of Spearhead. Erik’s Liberators have charged (see 14.3), and in the declare step of the ‘Fight’ ability, they have piled in towards Emma’s Clawlord (see 15.3) and targeted that unit with all of their attacks (see 16.0). In this example we’ll be using fast dice rolling to speed up play."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/9983f29d-b710-423a-8956-7d873521fba3",
+                    "altText": "A unit of five Liberators in combat with a Skaven Clawlord on Gnaw-beast. Four of the Liberators are picked out with green borders to indicate that those are the models that are armed with Warhammers."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Erik’s 4 Liberators armed with Warhammers attack first. They can each make 2 attacks (as a Warhammer has an **Attacks** characteristic of 2), and Erik needs to make **hit rolls** equal to or higher than their **Hit** characteristic of 3+. The Liberators score 5 successful hits out of 8 attacks."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/803a6fba-20f8-4cad-bf02-d48661e40cab",
+                    "altText": "Erik's hit rolls on 8 dice. Erik rolled two fives, a four, two threes, two twos and a one. There are green check marks next to each of the rolls that are three or higher. The rest have red crosses next to them."
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/f54b9f0e-4013-43e9-afb7-a58d4ae20caa",
+                    "altText": "A weapon table showing the weapon profile for the Liberators' Warhammers. The characteristics of a Warhammer are as follows: Attacks 2, Hit 3+, Wound 3+, Rend 1, Damage 1. It also has the Crit (Mortal) ability, shown at the end of the row. The Hit characteristic has a soft glow around it."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Erik then makes a **wound roll** for each of the 5 hits. The Warhammers have a **Wound** characteristic of 3+. The Liberators successfully wound with 3 of their attacks."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/63bf497c-f83c-42ad-88af-7571128ad04a",
+                    "altText": "Erik's wound rolls on 5 dice. Erik rolled a six, two fours, a two and a one. There are green check marks next to each of the rolls that are three or higher. The rest have red crosses next to them."
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/75e89613-92b9-431b-9ba3-8726dbe9a61c",
+                    "altText": "Emma's save rolls on three dice. Emma rolled a five, a four and a one. The five has a green check mark; the other two have red crosses."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Emma makes a **save roll** for each of the 3 successful wounds. Her Clawlord has a **Save** characteristic of 4+, but the Warhammers have a **Rend** characteristic of 1, so Emma must subtract 1 from each roll, meaning she now needs to roll a 5 or more.\n\nThe Clawlord successfully saves 1 of the 3 attacks, resulting in 2 damage points being added to his **damage pool** (1 for each Warhammer, as they have a **Damage** characteristic of 1)."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/5beee394-c102-42c6-b84b-90c7875dd3a2",
+                    "altText": "This time, only the Clawlord has a green border around it to indicate that Emma is making save rolls for it. Beneath it, there is a red circle showing the number two. This indicates the number of damage points in the Clawlord's damage pool after the save rolls were made."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Erik repeats this process with the remaining Liberator in the unit, who wields a mighty Grandhammer. He scores 2 hits, one of which is a **critical hit** of 6. Th is result triggers the Grandhammer’s **Crit (Mortal)** weapon ability, which inflicts 2 mortal damage (see 17.2), directly adding 2 damage points to the damage pool."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/02113bdf-45df-4a5e-b53b-00c42526da2a",
+                    "altText": "The hit rolls and the wound roll that Erik made for the Grandhammer. The hit rolls show a six and a three; the wound roll shows a four. There is a little green star next to the six to indicate that this roll triggered the Grandhammer's Crit (Mortal) ability."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Erik then makes a wound roll for the other hit, which **successfully wounds**."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/34ab5251-2744-4c1a-a8dd-9083ddaff686",
+                    "altText": "The image of the Liberators and the Clawlord is shown again. This time, the green border appears around the Liberator who is armed with the Grandhammer. The red circle showing the Clawlord's damage pool now shows the number four."
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/42dc0299-7330-4246-9522-fcf3a9b32cbe",
+                    "altText": "A weapon table showing the weapon profile for the Liberators' Grandhammer. The characteristics of the Grandhammer are as follows: Attacks 2, Hit 3+, Wound 2+, Rend 1, Damage 2. It also has the Crit (Mortal) ability, shown at the end of the row. The Damage characteristic has a soft glow around it."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "Emma makes a **save roll** for the successful wound, and again must subtract 1 from the roll due to the Grandhammer’s **Rend** characteristic of 1. Unfortunately, her **save roll** is unsuccessful, resulting in another 2 **damage points** being added to the **damage** pool, as the Grandhammer has a Damage characteristic of 2.\n\nThe Liberators’ attacks are **resolved**, so Emma must move on to the damage sequence."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/aac26d84-a822-4874-9f45-a4ab23243dd0",
+                    "altText": "Emma's save roll for the Grandhammer attack that did not automatically wound the Clawlord. The dice shows a three with a red cross, indicating that Emma did not roll high enough to save against the attack."
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/d5f44137-2446-4ec1-8bad-7dd388744fb8",
+                    "altText": "The Clawlord now has six damage points in its damage pool, shown by the number in the red circle beneath it."
+                  }
+                },
+                {
+                  "type": "text",
+                  "text": "The Clawlord is in grave peril, with 6 damage points in the damage pool (and only 7 **Health**!). Fortunately, he has **WARD (6+)**, which gives him one last chance to avoid the damage. Emma makes a **ward roll** for each of the 6 damage points in the damage pool, and 2 of those rolls are sixes, meaning 2 damage points are removed from the damage pool.\n\nThe remaining 4 damage points are **allocated** to the Clawlord. Emma places a dice next to the Clawlord to keep track of the number of damage points that are currently allocated to that unit.\n\nThe Clawlord is now **damaged** – luckily for Emma, this allows her Clawlord to use his ‘Cornered Rat’ ability to exact revenge on the dastardly Liberators…"
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/cf31f2ac-6c9c-47d9-8302-4fb069316d80",
+                    "altText": "Emma's ward rolls for her Clawlord. From left to right, the dice show a one, a three, a six, a four, a five, and a six. The two sixes have green check marks; the others have red crosses."
+                  }
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/134ed873-5220-4875-bbfe-41a96de583c7",
+                    "altText": "A red dice has been placed next to the Clawlord. This indicates the number of damage points allocated to the Clawlord after all the Liberators' attacks have been resolved."
+                  }
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "217dafc1-1364-5177-b586-e3e6ae61551b",
+      "ref": null,
+      "name": "Special Rules 19.0 - 30.0",
+      "containers": [],
+      "sections": [
+        {
+          "id": "49340171-c158-588a-adb5-f1b1a259abae",
+          "ref": "19.0",
+          "name": "19.0 STRIKE-FIRST and STRIKE-LAST",
+          "containers": [
+            {
+              "id": "64544ca7-6dc7-5bc4-9f2f-825d6739c0c1",
+              "ref": null,
+              "title": "STRIKE-FIRST and STRIKE-LAST",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "If there are any **STRIKE-FIRST** units **in combat** after any non-**FIGHT** Combat Phase abilities have been used, other units cannot be picked to use a **FIGHT** ability until those units have been picked to use a **FIGHT** ability. After all those **STRIKE-FIRST** units have fought, the active player picks the next unit to fight.\n\nIf there are any **STRIKE-LAST** units **in combat**, they cannot be picked to use a **FIGHT** ability if there are any units **in combat** that do not have **STRIKE-LAST** and have not yet used a **FIGHT** ability.\n\nIf a unit has **STRIKE-FIRST** and **STRIKE-LAST**, treat it as if it had neither."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "There may be situations when a unit that has **STRIKE-FIRST** is not in combat at the start of the phase, but because of moves such as pile-in moves, it is ‘pulled into combat’ later in the phase. In such cases, **STRIKE-FIRST** has no effect on that unit because it was not in combat at the start of the phase.\n\nAbilities that allow a unit to use a **FIGHT** ability immediately after another unit do not override the **STRIKE-FIRST** or **STRIKE-LAST** constraints, so you could not pick a unit with **STRIKE-LAST** to fight immediately after a unit with **STRIKE-FIRST**."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "c76ea371-bf9d-53c9-a442-c5d5b59f8f6c",
+          "ref": "20.0",
+          "name": "20.0 Weapon Abilities",
+          "containers": [
+            {
+              "id": "8cc9e28d-835d-51a1-809d-01122d6ec04e",
+              "ref": null,
+              "title": "Weapon Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some weapons have one or more of the passive **weapon abilities** below. If a weapon has multiple weapon abilities that apply on a critical hit, before the attack sequence starts, the commander of the attacking model must pick 1 of those abilities to use."
+                },
+                {
+                  "type": "header",
+                  "text": "Universal Weapon Abilities"
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "**Anti-X (+1 Rend):** Add 1 to this weapon’s **Rend** characteristic if the target has the keyword after ‘**Anti**-’ or fulfils the condition after ‘**Anti-’**. Multiples of this ability are cumulative. For example, if a weapon has both **Anti-charge (+1 Rend)** and **Anti-HERO (+1 Rend)**, then add 2 to the **Rend** characteristic of the weapon for attacks that target a **HERO** that **charged** in the same turn.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Charge (+1 Damage):** Add 1 to this weapon’s **Damage** characteristic if the attacking unit **charged** this turn.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Companion:** Unless otherwise specified, attacks made by this weapon are not affected by friendly abilities that modify hit rolls, wound rolls or weapon characteristics, except for those that apply negative modifiers (e.g. ‘Covering Fire’).",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Crit (2 Hits):** If an attack made with this weapon scores a **critical hit**, that attack scores 2 hits on the target unit instead of 1. Make a **wound roll** for each hit.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Crit (Auto-wound)**: If an attack made with this weapon scores a **critical hit**, that attack automatically wounds the target. Make a **save roll** as normal.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Crit (Mortal):** If an attack made with this weapon scores a **critical hit**, that attack inflicts **mortal damage** on the target unit equal to the **Damage** characteristic of that weapon and the attack sequence ends.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "**Shoot in Combat:** This weapon can be used to make shooting attacks even if the attacking unit is in combat.",
+                      "indent": 0
+                    }
+                  ]
+                },
+                {
+                  "type": "boxedText",
+                  "text": "The **Companion** weapon ability restricts things like mounts from benefiting from most effects that augment a unit’s capabilities."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "aa3dc255-ad19-59a7-8ed4-dbda189aa89f",
+          "ref": "21.0",
+          "name": "21.0 Healing",
+          "containers": [
+            {
+              "id": "ba715549-e11f-56ab-8884-e14ba160020d",
+              "ref": null,
+              "title": "Healing",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities allow you to **heal** a unit. To heal a unit, remove a number of damage points from the unit equal to the number in brackets after ‘**Heal**’, e.g. **Heal (2)**."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "b4ddab67-bd43-5207-b28f-baf3cf006e8b",
+          "ref": "22.0",
+          "name": "22.0 Returning and Adding Models",
+          "containers": [
+            {
+              "id": "a39743ff-98d9-570c-8fcb-3a048c414a04",
+              "ref": null,
+              "title": "Returning and Adding Models",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities allow you to **return** slain models to a unit or **add** new models to a unit. In either case, set up those models, one at a time within coherency range (see 15.1) of the model(s) in that unit that were not returned or added this phase. If that unit has 7 or more models (including the model being set up), it must be set up within coherency range of at least 2 other models in that unit that were not returned or added this phase. The new models can only be set up in combat with an enemy unit if their unit is already in combat with that enemy unit."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ Returned models must be set up in **coherency** with the models in their unit that were not returned as part of that ability.\n◆ Returned models can only be set up **in combat** with an enemy unit if their unit is already in combat with it."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "52084d2b-a043-57af-9c84-7c15eabad9cf",
+          "ref": "23.0",
+          "name": "23.0 Tokens",
+          "containers": [
+            {
+              "id": "139eeaf5-f782-5a75-b4b4-328de3d1cc32",
+              "ref": null,
+              "title": "Tokens",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Tokens are not considered to be models for rules purposes and can be ignored or moved out of the way for purposes of visibility, coherency or abilities. They cannot be picked as the target of abilities. Their purpose is to indicate persisting effects on units they are placed next to. Each time a unit with a token finishes a move or is set up, place the token next to the unit."
+                },
+                {
+                  "type": "image",
+                  "image": {
+                    "url": "https://dhss9aar8ocw.cloudfront.net/b0ef4f24-7219-4753-b931-590bd1668fab",
+                    "altText": "This Gryph-crow is a token."
+                  }
+                },
+                {
+                  "type": "textItalic",
+                  "text": "This Gryph-crow is a token."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "23f9591e-24aa-5ef5-9352-12ebb632ea64",
+          "ref": "24.0",
+          "name": "24.0 Setting up Units",
+          "containers": [
+            {
+              "id": "be496c15-50c9-5a95-8f57-f7217501c79c",
+              "ref": null,
+              "title": "Setting up Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities allow you to set up a unit on the battlefield. When doing so, you must set up all models in that unit. If this is impossible, you cannot use that ability. A unit set up on the battlefield in a phase other than the deployment phase cannot use **MOVE** abilities in the movement phase of the same turn."
+                }
+              ]
+            },
+            {
+              "id": "57e5f829-96e6-5992-b82d-4c6035b91e32",
+              "ref": "24.1",
+              "title": "24.1 Reserve Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities allow you to set up units **in reserve**. These units are placed to one side instead of being set up on the battlefield. At the start of the fourth battle round, units that were set up in reserve using a **DEPLOY** ability and that are still in reserve are destroyed."
+                }
+              ]
+            },
+            {
+              "id": "674ebc52-0d95-55cc-b6af-a1023300c973",
+              "ref": "24.2",
+              "title": "24.2 Replacement Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities allow you to set up a **replacement unit**. When setting up that unit, it should have the same warscroll type, weapon options and number of models as the original unit, unless otherwise specified in the ability. Many of these abilities specify the proportion of models in the replacement unit (e.g. half the number of models from the original unit). In these cases, you can pick which models from the original unit are set up.\n\nThe replacement unit is otherwise treated as a new unit; any keywords or abilities the original unit gained during the battle, and any persisting effects that applied to it, do not apply to the replacement unit. Each unit can only be replaced once, and you cannot replace replacement units.\n\nIf the original unit was reinforced and the replacement unit has more than half the number of models from the original unit, the replacement unit is considered to be reinforced."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "Because a replacement unit is treated as a completely new unit, it could, for instance, use a **Once Per Battle** ability on its warscroll even if the unit it replaced used that ability earlier in the battle."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "dddaa373-6324-5888-a211-83a9c3e0dae4",
+          "ref": "25.0",
+          "name": "25.0 Guarded Heroes",
+          "containers": [
+            {
+              "id": "ef6c1e28-c6af-5fd6-86d8-edb9e91df6d9",
+              "ref": null,
+              "title": "Guarded Heroes",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "All **HEROES** that are not **MONSTERS** or **WAR MACHINES** have the ‘Guarded Hero’ passive ability:"
+                },
+                {
+                  "type": "ability",
+                  "ability": {
+                    "id": "fc52eb62-dc64-5943-85e2-447eff2652e9",
+                    "name": "Guarded Hero",
+                    "phase": "shootingPhase",
+                    "phaseDetails": "Passive",
+                    "icon": "defensive",
+                    "cpCost": null,
+                    "declare": null,
+                    "effect": "If this **HERO** is within the combat range of a friendly unit that is **not** a **HERO**:\n\n• Subtract 1 from **hit rolls** for **shooting attacks** that target this **HERO**.\n• If this **HERO** is **INFANTRY**, they cannot be picked as the target of **shooting attacks** made by models more than 12\" from them.",
+                    "usedBy": null,
+                    "additionalRulesText": null
+                  }
+                },
+                {
+                  "type": "boxedText",
+                  "text": "Understandably, **MONSTERS** and **WAR MACHINES** don’t benefit from the ‘Guarded Hero’ ability. These units are very conspicuous targets even if they are surrounded by their fellows!"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "68e823f3-9099-59f1-8674-36a11cc26832",
+          "ref": "26.0",
+          "name": "26.0 Random Characteristics",
+          "containers": [
+            {
+              "id": "b80bb2c8-7a01-5bae-86a8-10395db3bfbc",
+              "ref": null,
+              "title": "Random Characteristics",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some warscrolls show a **random characteristic roll** instead of a fixed value. When this is the case, the value of the characteristic is generated by the commander of the unit in question each time an ability requires that characteristic.\n\nIn the case of random weapon characteristics, generate a **random Attacks** characteristic for each model in the attacking unit each time you declare an **ATTACK** ability, and generate a **random Damage** characteristic each time you inflict damage with that weapon (roll once for each attack)."
+                },
+                {
+                  "type": "boxedText",
+                  "text": "◆ When using a **random characteristic**, generate it each time it is needed for an ability.\n◆ When using **random Damage**, generate it for each attack made."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "a1c3f6f9-fde8-53cf-8f5e-a720dc91095b",
+          "ref": "27.0",
+          "name": "27.0 Modifier Order",
+          "containers": [
+            {
+              "id": "3cc6bf44-1dfe-504d-a5e2-acef5db6be8f",
+              "ref": null,
+              "title": "Modifier Order",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The effects of some abilities modify a characteristic or roll. Unless stated otherwise, a characteristic or roll cannot be modified to less than 1. The exception to this is Rend, which can be modified to a minimum of 0 (‘-’).\n\nIf a characteristic uses a **random characteristic roll** (see 26.0 Random Characteristics), apply characteristic modifiers **after** that characteristic has been generated.\n\nIf a characteristic or roll is halved or would be modified to a value that is not a whole number, **round it down** to the nearest whole number.\n\nApply characteristic modifiers in the following order:\n\n**1.** Modifiers that **set** a characteristic to a fixed value.\n**2.** Modifiers that **multiply** or **divide** a characteristic.\n**3.** Modifiers that **add to** or **subtract from** a characteristic. If there are multiple modifiers of the same type (e.g. that set a characteristic), apply them in the Order of Effects (see 30.0).\n\nThe effects of some abilities (e.g. ‘An Excess of Depravity’) allow you to replace a roll with a fixed value. When doing so, you must replace the roll before rolling the dice for it."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "25171f95-7de3-5966-ae84-c37206836053",
+          "ref": "28.0",
+          "name": "28.0 Advanced Ability Rules",
+          "containers": [
+            {
+              "id": "70ce6e18-e584-5d21-a7d5-916559049cf5",
+              "ref": null,
+              "title": "Advanced Ability Rules",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "Unless stated otherwise, units using or picked as part of an ability must be on the battlefield.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "If an effect states that a unit **can** do something, its commander can choose whether to resolve that part of the effect or not.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "If an effect states that a unit **must** do something, its commander has no choice and must resolve that part of the effect. If this is impossible, no part of the effect is applied but the ability is still considered to have been used.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "When ‘this unit’ appears in ability text (most often on warscrolls), it means the unit that is using the ability.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "If an ability affects more than one unit, the player who used the ability can choose the order in which units are affected by it.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "When resolving an effect, if you need to roll a dice for multiple affected units, roll and resolve the effect for one unit before moving on to the next.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "If an ability instructs you to pick more than 1 unit, each unit you pick must be a different unit unless stated otherwise.",
+                      "indent": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "76049c2a-61d6-53d8-b7cf-9d6594fd05ac",
+              "ref": "28.1",
+              "title": "28.1 Persisting Effects",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some abilities have effects that aren’t immediately resolved (e.g. ‘add 1 to save rolls for this unit for the rest of the turn’ or ‘this unit has **WARD (5+)** for the rest of the turn’). These effects count as the effects of passive abilities (see 5.4) for their duration."
+                }
+              ]
+            },
+            {
+              "id": "5172d48e-fffb-54b7-bdcb-7eb39dd5fd2e",
+              "ref": "28.2",
+              "title": "28.2 'Once per' Timings",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The timing part of some abilities says **Once Per Phase, Once Per Turn** or **Once Per Battle**. If the ability is used by a unit, it can be used a maximum of one time in that phase, turn or battle by each unit that can use the ability. If the ability is used by a player, it can be used a maximum of one time in that timing window by that player.\n\nSome abilities that are used by units say **Once Per Phase (Army),** **Once Per Turn (Army)** or **Once Per Battle (Army)**. These abilities can be used a maximum of one time in that phase, turn or battle regardless of the number of units in the army that can use the ability."
+                }
+              ]
+            },
+            {
+              "id": "2bfdd37a-761c-51af-8246-09536908f095",
+              "ref": null,
+              "title": "Who is Using the Ability?",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Most abilities are found on warscrolls, but many appear elsewhere – the best examples being the Universal Core Abilities (see 14.0).\n\nWhile abilities on warscrolls are always used by the unit whose warscroll it is, some abilities that do not appear on warscrolls will tell you explicitly to pick a unit to use the ability. In both cases, it should be clear which unit is using the ability.\n\nSome abilities that do not appear on warscrolls, most commonly enhancements (see Army Composition, 4.1), are given to certain units in your army. In such cases, the unit to which the enhancement was given is the one using the ability.\n\nAbilities that neither appear on a warscroll nor tell you to pick a unit to use the ability are used by you, the player. Finally, for the purposes of the rules in this section, when a rule refers to a player using an ability, this includes abilities used by units in that player’s army."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "5311f10b-c97d-564d-a9db-538422a353d6",
+          "ref": "29.0",
+          "name": "29.0 Contradictory Rules",
+          "containers": [
+            {
+              "id": "1ac47d05-74d7-57b0-8a08-fdb12dae24f2",
+              "ref": null,
+              "title": "Contradictory Rules",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "If two or more rules contradict, if one of those rules states that something **cannot** do something, this takes precedence over rules that state it **can** or **must** do that thing, unless the second rule specifically overrides the restriction of the first. For example, while the ‘Normal Move’ ability states you cannot move into combat during that move, the ‘Fly’ ability specifies to ignore the combat ranges of enemy models during a move.\n\nExcepting the above, the effect of the most recently used ability takes precedence."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "3d2b7c2f-a578-5321-b9c1-71f69ab44aeb",
+          "ref": "30.0",
+          "name": "30.0 Order of Effects",
+          "containers": [
+            {
+              "id": "92bf5d3e-774c-53e6-b1bc-477d97785f54",
+              "ref": null,
+              "title": "Order of Effects",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The effects of passive abilities are considered to be applied more recently than the effects of other abilities and rules. The effects of the active player’s passive abilities are considered to be applied more recently than the effects of their opponent’s passive abilities, whose passive abilities are considered to be applied more recently than the effects of neutral passive abilities (e.g. passive abilities on a terrain feature that is in neither player’s army). The active player chooses the order in which neutral passive effects are applied.\n\nSome abilities have a delayed effect (e.g. ‘each time a friendly unit uses a **FIGHT** ability, after that ability has been resolved, **Heal (D3)** that unit’). If more than one of these effects would be resolved at the same time, the active player resolves the delayed effects of their abilities first, in an order of their choosing, then their opponent does the same."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "0da8de8b-b98a-541b-9ff0-674f710a8b3e",
+      "ref": null,
+      "name": "End of Turn 31.0 - 33.0",
+      "containers": [],
+      "sections": [
+        {
+          "id": "f4c300a5-6156-5124-b236-1b34bd8c38c9",
+          "ref": "31.0",
+          "name": "31.0 End of Turn Overview",
+          "containers": [
+            {
+              "id": "3812239b-3ff6-55e3-8731-d371f404bf3d",
+              "ref": null,
+              "title": "End of Turn Overview",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "At the end of each turn, follow these steps:\n\n**1.** The active player can use any abilities with the End of Your Turn or End of Any Turn timing, in the order of their choosing, then their opponent can use any abilities with the End of Enemy Turn or End of Any Turn timing, in the order of their choosing.\n\n**2.** Determine which player **controls** each objective (if any).\n\n**3.** The active player scores **victory points** as described in the battleplan."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "0e90c876-4fd9-50a4-9e7d-b54b0a03e560",
+          "ref": "32.0",
+          "name": "32.0 Objectives",
+          "containers": [
+            {
+              "id": "fbdf4fca-b06e-57c2-9f99-cf46501d163b",
+              "ref": null,
+              "title": "Objectives",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Many battleplans award victory points for controlling **objectives**, which are represented by **objective markers**. Unless otherwise specified, objective markers are round and 40mm wide. Models can move over and end their moves on objective markers. If an objective marker is on the border between territories, it is within all those territories but wholly within none of them. Objective markers don’t block visibility."
+                },
+                {
+                  "type": "bullets",
+                  "bullets": [
+                    {
+                      "text": "An objective marker is a 40mm round marker.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "A model **contests** an objective if the objective marker is within its combat range.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "A player **gains control** of an objective if the sum of the **Control** characteristics of friendly models contesting that objective is higher than that of enemy models.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "Check if you gain control of objectives at the start of the first battle round and at the end of each turn.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "An objective remains in your control until your opponent gains control of it.",
+                      "indent": 0
+                    },
+                    {
+                      "text": "Terrain features are controlled in the same way as objective markers but do not remain in your control if no friendly models are contesting them.",
+                      "indent": 0
+                    }
+                  ]
+                },
+                {
+                  "type": "boxedText",
+                  "text": "Sometimes objective markers get accidentally nudged while you are moving models around. This is perfectly fine – just remember to put them back in their proper positions when determining objective control."
+                }
+              ]
+            },
+            {
+              "id": "633faf64-f43d-5256-910d-b65236bb365a",
+              "ref": "32.1",
+              "title": "32.1 Contesting Objectives",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Unless otherwise specified, if an objective is within a model’s combat range, that model is **contesting** that objective. If any models in a unit are contesting an objective, that unit is contesting that objective.\n\nEach unit can only count as contesting a single objective for the purposes of determining objective control (see 32.2). Before determining objective control, for each of their units contesting two or more objectives, the active player must pick one of those objectives for it to contest. Then, their opponent does the same."
+                },
+                {
+                  "type": "text",
+                  "text": "**Designer’s Note:** *For purposes other than determining objective control, a unit can contest more than one objective.*"
+                }
+              ]
+            },
+            {
+              "id": "43cf8d0e-fa74-53c3-834d-4da4e6b07cd8",
+              "ref": "32.2",
+              "title": "32.2 Objective Control",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the **deployment phase** after all Deployment Phase abilities have been used and at the **end of each turn**, follow this sequence for **each objective** in an order chosen by the active player:\n\n1. Starting with the active player, each player determines the control score of each of their units that is contesting that objective. A unit’s **control score** is the combined **Control** characteristics of all the models in that unit that are contesting the objective. Some abilities modify a unit’s control score, but it cannot be reduced to less than 1.\n\n2. Each player adds up the control scores of all of their units contesting that objective. This is their **army control score** for that objective.\n\n3. The players compare their army control scores for that objective. If one player’s score is higher, that player **gains control** of that objective. Once a player gains control of an objective, it **remains under their control** until their opponent gains control of it."
+                }
+              ]
+            },
+            {
+              "id": "31260cfd-4e63-5780-aab2-0fe9cbf870cd",
+              "ref": "32.3",
+              "title": "32.3 Terrain Control",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some battleplans require you to gain control of terrain features. Terrain features are contested and controlled in the same way as objectives, but terrain features **do not remain in your control** if your units are no longer contesting them. For the purposes of determining objective control and terrain feature control, each unit can contest 1 objective and 1 terrain feature at the same time.\n\n**Designer’s Note:** *For purposes other than determining terrain feature control, a unit can contest more than one terrain feature.*"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "1ace6d41-6fea-5525-afc4-d5acda6b1629",
+          "ref": "33.0",
+          "name": "33.0 End of Battle Round",
+          "containers": [
+            {
+              "id": "b64a8dd4-fbe2-5b59-aaf0-f00838276a8b",
+              "ref": null,
+              "title": "End of Battle Round",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": null,
+              "components": [
+                {
+                  "type": "text",
+                  "text": "At the end of each battle round, the active player can use any End of Battle Round abilities, then their opponent can do the same. Each battleplan will specify the number of battle rounds that should be fought. If you have completed the number of battle rounds specified in your battleplan, the battle has ended, and you should follow the rules included in that battleplan to determine the winner."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    },
+    {
+      "id": "535447a4-04e6-5087-b58c-9be3d5ca523f",
+      "ref": null,
+      "name": "Addenda, Errata and FAQs",
+      "containers": [],
+      "sections": [
+        {
+          "id": "be6570c7-7620-5398-a0dd-e7f5e18e3bf1",
+          "ref": null,
+          "name": "Addenda",
+          "containers": [
+            {
+              "id": "b164b492-12e7-541f-9585-4d34646a9032",
+              "ref": null,
+              "title": "Addenda",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The following rules updates add text in order to clarify ambiguities and/or avoid unintended interactions."
+                }
+              ]
+            },
+            {
+              "id": "91c198f5-04af-5ba6-8bd5-f7ee2634e4ae",
+              "ref": "2.2",
+              "title": "2.2 Dice",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n\n‘• Some rules allow you to **re-roll** a dice roll, which means you get to roll some or all of the dice again. You cannot re-roll a dice more than once, and re-rolls happen before modifiers to the roll (if any) are applied.’"
+                }
+              ]
+            },
+            {
+              "id": "75c1215b-0885-5cfc-ab03-6b3f6d4d3155",
+              "ref": "7.0",
+              "title": "7.0 Combat Range",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n\n‘A model is considered to be in combat with an enemy unit if that unit is within the model’s combat range and visible to it.’"
+                }
+              ]
+            },
+            {
+              "id": "c9cf3e5c-93bb-5bc7-908e-c5bb10bebdb5",
+              "ref": "15.6",
+              "title": "15.6 Charge Moves",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n‘Some rules reference a unit finishing or ending a charge move. This is considered to occur when a **CHARGE MOVE** ability that unit used resolves and the unit has charged as part of that ability.’"
+                }
+              ]
+            },
+            {
+              "id": "47f98666-56fc-59b4-94cd-82d76f816660",
+              "ref": "18.3",
+              "title": "18.3 Slain models",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n\n‘You must remove the fewest models possible to make the unit a single coherent group.’"
+                }
+              ]
+            },
+            {
+              "id": "0ec7043b-935c-52cc-819f-015950cdab73",
+              "ref": "24.2",
+              "title": "24.2 Replacement Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n‘If the original unit was reinforced and the replacement unit has more than half the number of models from the original unit, the replacement unit is considered to be reinforced.'"
+                }
+              ]
+            },
+            {
+              "id": "4fc81b42-511d-55d4-9358-2d950f4d1a07",
+              "ref": "27.0",
+              "title": "27.0 Modifier Order",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n‘The effects of some abilities (e.g. ‘An Excess of Depravity’) allow you to replace a roll with a fixed value. When doing so, you must replace the roll before rolling the dice for it.’"
+                }
+              ]
+            },
+            {
+              "id": "5ba31ba6-5468-550a-a294-5f487084ff91",
+              "ref": "30.0",
+              "title": "30.0 Order of Effects",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "addenda",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n\n‘Some abilities have a delayed effect (e.g. ‘each time a friendly unit uses a **FIGHT** ability, after that ability has been resolved, **Heal (D3)** that unit’). If more than one of these effects would be resolved at the same time, the active player resolves the delayed effects of their abilities first, in an order of their choosing, then their opponent does the same.’"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "9c58daaa-7c40-539a-96b6-8078ac850231",
+          "ref": null,
+          "name": "Errata",
+          "containers": [
+            {
+              "id": "1b9eed08-9a7d-559d-8159-10c78d994993",
+              "ref": null,
+              "title": "Errata",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "The following rules updates correct errors in order to clarify ambiguities and/or avoid unintended interactions."
+                }
+              ]
+            },
+            {
+              "id": "e6451cae-f5ff-519a-a06f-1354431c34cc",
+              "ref": "5.2",
+              "title": "5.2 Using Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change point 2 (Use Reactions) to:\n\n‘Starting with the player using the ability, the players alternate using any abilities with an appropriate **Reaction** timing. Players can choose to pass instead of using a reaction, but once both players consecutively pass, no further reactions to that ability can be used.’"
+                }
+              ]
+            },
+            {
+              "id": "1f1775fe-cf5e-57ca-a865-323243f0da22",
+              "ref": "6.0",
+              "title": "6.0 Visibility",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Add the following:\n\n‘If a rule or ability requires a target to be both within a given range of and visible to the unit using that ability, or to a model in that unit, both conditions must be met by the same model in the target. You could not, for instance, target a unit where one model is within range but not visible and another model is not in range but is visible.’"
+                }
+              ]
+            },
+            {
+              "id": "82f678e3-b8c7-513c-bf02-6f7866b5ae37",
+              "ref": "14.4",
+              "title": "14.4 Combat Phase",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the declare step of the ‘Fight’ ability, change ‘**pile-in move** (see 15.4)’ to ‘**pile-in move** (see 15.3)’."
+                }
+              ]
+            },
+            {
+              "id": "c5e5febd-6cf3-51d7-b636-d9ce0b27cbed",
+              "ref": "15.5",
+              "title": "15.5 Overhanging Models",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Some models overhang their base. When moving models, overhanging parts should be treated as if they do not exist when determining where a model could be placed. Where possible, a model should be rotated to allow for another model to end a move in proximity to it. When rotating a model this way, the base must occupy the same position – a circular base may be rotated any amount, while an oval base may only be rotated 180°. Otherwise, mark down the location of where the model should end its move (such as with an empty base of the same size) and place the model to the side. Return the model to the table as soon as it is physically possible to do so.'"
+                }
+              ]
+            },
+            {
+              "id": "0cefeae5-945f-5b7b-9a4a-e95ae93d1f10",
+              "ref": "19.0",
+              "title": "19.0 STRIKE-FIRST and STRIKE-LAST",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the first sentence, replace ‘at the start of the phase’ with ‘after any non-**FIGHT** Combat Phase abilities have been used’."
+                }
+              ]
+            },
+            {
+              "id": "f861cd7b-062f-58bf-bcf1-9fd1261b62e9",
+              "ref": "20.0",
+              "title": "20.0 Weapon Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change the **Companion** weapon ability to:\n\n‘Unless otherwise specified, attacks made by this weapon are not affected by friendly abilities that modify hit rolls, wound rolls or weapon characteristics, except for those that apply negative modifiers (e.g. ‘Covering Fire’).'"
+                }
+              ]
+            },
+            {
+              "id": "da884d5e-e5d6-52d2-ab72-901bb2c6ed64",
+              "ref": "22.0",
+              "title": "22.0 Returning and Adding Models",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Replace:\n‘In either case, set up those models, one at a time, in coherency (see 15.1) with the model(s) in that unit that were not returned or added this phase.’\nwith:\n‘In either case, set up those models, one at a time within coherency range (see 15.1) of the model(s) in that unit that were not returned or added this phase. If that unit has 7 or more models (including the model being set up), it must be set up within coherency range of at least 2 other models in that unit that were not returned or added this phase.’"
+                }
+              ]
+            },
+            {
+              "id": "11d7ac14-7fb5-5d72-9278-221a2905a7fb",
+              "ref": "25.0",
+              "title": "25.0 Guarded Hero",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In the effect of ‘Guarded Hero’, replace:\n‘If this **HERO** is **INFANTRY**, they cannot be picked as the target of shooting attacks made by units more than 12\" from them.’\n\nwith:\n‘If this **HERO** is **INFANTRY**, they cannot be picked as the target of shooting attacks made by models more than 12\" from them.’"
+                }
+              ]
+            },
+            {
+              "id": "fe455ee9-72e2-54e6-818f-138755aaed1d",
+              "ref": "32.1",
+              "title": "32.1 Contesting Objectives",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change the second paragraph to:\n\n‘Each unit can only count as contesting a single objective for the purposes of determining objective control (see 32.2). Before determining objective control, for each of their units contesting two or more objectives, the active player must pick one of those objectives for it to contest. Then, their opponent does the same.\n\n**Designer’s Note:** *For purposes other than determining objective control, a unit can contest more than one objective*.’"
+                }
+              ]
+            },
+            {
+              "id": "429bb16d-b3bf-564b-bfff-1f3e3cabbd25",
+              "ref": "32.2",
+              "title": "32.2 Objective Control",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change the first sentence to:\n‘In the **deployment phase** after all Deployment Phase abilities have been used and at the **end of each turn**, follow this sequence for **each objective** in an order chosen by the active player:’"
+                }
+              ]
+            },
+            {
+              "id": "feb2c81a-5a1b-515f-acd7-c9409b1ba944",
+              "ref": "32.3",
+              "title": "32.3 Terrain Control",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "errata",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Change the text to:\n‘Some battleplans require you to gain control of terrain features. Terrain features are contested and controlled in the same way as objectives, but terrain features **do not remain in your control** if your units are no longer contesting them. For the purposes of determining objective control and terrain feature control, each unit can contest 1 objective and 1 terrain feature at the same time.\n\n**Designer’s Note:** *For purposes other than determining terrain feature control, a unit can contest more than one terrain feature.*’"
+                }
+              ]
+            }
+          ],
+          "sections": []
+        },
+        {
+          "id": "69a9751f-f482-570a-a480-37cf3405b0fc",
+          "ref": null,
+          "name": "Frequently Asked Questions",
+          "containers": [
+            {
+              "id": "7129c857-1d0a-5fda-9da5-4cef2af3647c",
+              "ref": null,
+              "title": "Frequently Asked Questions",
+              "subtitle": null,
+              "containerType": "introduction",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "In this series of questions and answers, the rules-writing team respond to players’ queries and explain how the rules are intended to be used."
+                }
+              ]
+            },
+            {
+              "id": "53db9bb4-932a-5de9-a400-2191ee37e155",
+              "ref": "2.2",
+              "title": "2.2 Dice",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If an ability allows me to re-roll one dice from an XD6 roll (e.g. the Blades of the Hollow King ‘Aurelias’ ability), could I then use a different ability to re-roll the entire XD6 roll?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No."
+                }
+              ]
+            },
+            {
+              "id": "bd115e1c-6161-52ca-8fda-5bd13523de1b",
+              "ref": "4.0",
+              "title": "4.0 Warscrolls",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: How should I resolve an ability that refers to an enemy’s Control characteristic (e.g. Ushoran’s ‘Shroudcage Fragment’) if the target does not have a Control characteristic (e.g. a manifestation)?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: The target is treated as having a Control characteristic of 0."
+                }
+              ]
+            },
+            {
+              "id": "b03328b7-25e5-5970-8735-f445d8b7635e",
+              "ref": "5.0",
+              "title": "5.0 Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *Some abilities (e.g. ‘All-out Attack’) have a red timing bar. Can these abilities only be used in the combat phase?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No. The words in the timing bar or, in the case of reactions and passive abilities, the specific wording of the ability will let you know exactly when you can use it; the colour is just there as a play aid. If a phase is not specified, the colour indicates the most common phase it is used in or, if it is used in multiple phases equally, the timing bar is black."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: Some abilities have a green timing bar. What does this mean?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: The green timing bar is used to indicate defensive abilities, many of which can be used in multiple phases."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q:* *Are non-passive abilities such as ‘Burning Wyrdflame’ optional to use?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes. You must apply the effects of passive abilities and abilities that state that they must be used if it is possible to do so, but all other abilities are optional to use."
+                }
+              ]
+            },
+            {
+              "id": "8c0ee668-0df7-54a8-b0da-2eff42d3060c",
+              "ref": "5.1",
+              "title": "5.1 Keywords",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Q: *In ‘Pick a friendly non-**HERO LEGION OF THE FIRST PRINCE DAEMON INFANTRY** or **CAVALRY** unit that has been destroyed to be the target’ (and similar wordings with multiple keywords), does ‘**CAVALRY** unit’ mean just that (i.e. with no other keywords) or does it mean ‘ friendly non-**HERO LEGION OF THE FIRST PRINCE DAEMON CAVALRY UNIT**’?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: It means ‘friendly non-**HERO LEGION OF THE FIRST PRINCE DAEMON CAVALRY** unit’."
+                },
+                {
+                  "type": "text",
+                  "text": "Q: *Where an ability references multiple keywords but has ‘non-’ at the start of the sequence of keywords(for example, the Skaven Brood Terror’s Lend a Claw ability which targets ‘non-**SKRYRE MOULDER**’ units’), does this mean the target must not have any of the keywords listed (in this example, the target couldn’t have **SKRYRE** or **MOULDER** keywords), or does it mean the target cannot have the first keyword but must have the second (in this example, it cannot have **SKRYRE** but must have **MOULDER**)?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: The ‘non-’ only relates to the keyword it is directly attached to. Therefore, in the example given, the target cannot have the **SKRYRE** keyword but must have the **MOULDER** keyword. If the intent were to exclude both keywords, then it would be expressed as ‘non-**SKRYRE** non-**MOULDER**'."
+                }
+              ]
+            },
+            {
+              "id": "6989ce43-8fa9-537f-bdfd-ad3166a7c85e",
+              "ref": "5.2",
+              "title": "5.2 Using Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *When resolving the effect of an ability that refers to a Save characteristic of 3+ or better (e.g. the ‘Cloying Quagmire’ spell), what does ‘or better’ mean?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: It means any Save characteristic with a lower value than 3+, such as 2+, that better protects against incoming damage."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If an ability allows another friendly unit to be picked to use a **FIGHT** ability immediately after a friendly unit has used a **FIGHT** ability (for example, the Crypt Haunter Courtier’s ‘Knightly Exemplar’ ability), does the second unit being activated have to meet the requirements of the Declare step of the **FIGHT** ability it is using?*\n\nA: Yes. So, for example, if the second unit being activated was using the ‘Fight’ ability, it would need to be in combat or have charged in the same turn."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If an ability references a qualifier that multiple objects are tied for (e.g. two terrain features are equally close to an Awakened Wyldwood that is using the ‘Ever Growing’ ability), what happens?*\nA: The player who used the ability chooses which object to affect."
+                }
+              ]
+            },
+            {
+              "id": "143e1ed6-bfc5-500b-85a1-50626fbb27c6",
+              "ref": "5.3",
+              "title": "5.3 The Rules of One",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Are Reaction abilities subject to the Rules of One? For example, if a unit has a Reaction ability on their warscroll, could they only use it once per phase?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                }
+              ]
+            },
+            {
+              "id": "ff931880-152d-59ff-9b25-def5deea5aac",
+              "ref": "6.0",
+              "title": "6.0 Visibility",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If a non-**FLY INFANTRY HERO** (e.g. a Scinari Cathallar) is a Shrine Guardian of a Shrine Luminor, and that Shrine Guardian is within 1\" of an obscuring terrain feature, is the Shrine Guardian visible to enemy abilities that target the Shrine Guardian?*\nA: Yes."
+                }
+              ]
+            },
+            {
+              "id": "94a4c45b-c0fd-504a-a0fc-dd6513bd5563",
+              "ref": "7.0",
+              "title": "7.0 Combat Range",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q. If a model in base-to-base contact with an enemy model retreats 3\" directly away from the enemy model, is it still in combat with that enemy model?*\n\nA. No."
+                }
+              ]
+            },
+            {
+              "id": "bc9f5204-b5e1-5597-988f-8504fc2f6d54",
+              "ref": "9.1.1",
+              "title": "9.1.1 Setting up Objectives and Terrain Features",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *If a battleplan instructs you to set up an objective on a corner of the battlefield, should you place the entire 40mm objective marker on the battlefield, or should the centre of the objective marker be on the corner?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: The centre of the objective marker should be on the corner."
+                }
+              ]
+            },
+            {
+              "id": "5fb4ca49-2b18-5d3f-8d9f-c97f8dcf99a9",
+              "ref": "9.1.2",
+              "title": "9.1.2 Territories",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If a rule requires that a unit be ‘outside of friendly territory’ or ‘wholly outside of friendly territory’, would a unit that is not on the battlefield (for example a destroyed unit or a unit in reserve) count?*\n\nA: No."
+                }
+              ]
+            },
+            {
+              "id": "281adcc8-477e-5cc0-a450-84b457c80af7",
+              "ref": "10.1",
+              "title": "10.1 Universal Deployment Phase Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Can you choose to deploy units that are in a regiment using the ‘Deploy Unit’ ability instead of ‘Deploy Regiment’?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes, however, once a unit in a regiment has been deployed in this manner, you can no longer use ‘Deploy Regiment’ to deploy the remaining units in that regiment, since the declare step of that ability specifies that ‘No units in that regiment can have already been deployed.’"
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: Is it mandatory for players to set up a faction terrain feature (if one is included on their roster) during the deployment phase?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No. A player can choose not to use the ‘Deploy Faction Terrain’ ability. However, if both players choose to set up a faction terrain feature, the player who begins deployment must set up their faction terrain features first (as specified in Step 1 of 10.0)."
+                }
+              ]
+            },
+            {
+              "id": "9e3ffe48-a416-5b52-b0ba-d56ba6279673",
+              "ref": "12.0",
+              "title": "12.0 Start of Battle Round",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *When determining the active player, how do you determine when a player has ‘finished setting up their army’?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: A player has finished setting up their army when all units in their army have been deployed. This means that non-**DEPLOY** Deployment Phase abilities (e.g. The Masque’s ‘The Endless Dance’ ability) happen after your army has ‘finished setting up’."
+                }
+              ]
+            },
+            {
+              "id": "bd454cbe-44b3-516f-b5ca-7e897acd6e51",
+              "ref": "14.3",
+              "title": "14.3 Charge Phase",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *When using the ‘Charge’ ability, does my unit need to end the charge move within 1⁄2\" of an enemy unit that was visible to the charging unit at the start of that charge move?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No. It must end the charge move within 1⁄2\" of an enemy unit that is visible to the charging unit when it finishes that charge move."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q. If an ability adds to or subtracts from the number of dice that make up a charge roll, is that a modifier to the charge roll?*\n\nA. No."
+                }
+              ]
+            },
+            {
+              "id": "4a757ea8-9056-5f4a-b554-37b5d81353b1",
+              "ref": "15.2",
+              "title": "15.2 Moving Across Terrain",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *The rules for moving across terrain state that a model cannot end a move mid-climb. How can you tell if a model is mid-climb?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: A model is mid-climb if it is not possible to rest it on its base in that location without additional support. As there is a wide variety of terrain and models, it is acceptable for a model to end a move with its base at a slight angle because of uneven terrain beneath it, but at least half of its base must be within 1\" of the terrain feature that the model is on or it will be considered mid-climb."
+                }
+              ]
+            },
+            {
+              "id": "1d2a4d89-3ab6-59d3-8aef-12e41dc474c9",
+              "ref": "15.4",
+              "title": "15.4 Flying",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *If an ability that allows a unit to move states that the unit cannot move into combat (e.g. Normal Move), does Fly allow that unit to move across an enemy unit’s combat range?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                }
+              ]
+            },
+            {
+              "id": "3fbadc56-64ae-5a2f-9984-3b145f980fd2",
+              "ref": "16.0",
+              "title": "16.0 Picking Targets",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: When making shooting attacks, can all models in the attacking unit shoot even if the target unit is not visible to some of those models?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No, the only models in the attacking unit that can make shooting attacks are those that the target unit is visible to."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q. When a unit uses a **SHOOT** ability, does it have to shoot with all of the ranged weapons that it is armed with?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                }
+              ]
+            },
+            {
+              "id": "32af855f-20bb-55b4-9003-c14da23abf07",
+              "ref": "17.0",
+              "title": "17.0 The Attack Sequence",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *If an ability allows a unit to score critical hits on unmodified rolls of 5+, but that unit needs a 6 to hit (e.g. as a result of subtracting 1 from hit rolls), would unmodified hit rolls of 5 hit the target? If so, would they still trigger any critical hit effects?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Although the hits would count as critical hits, the attacks would not score a successful hit. As the attack sequence ends if an attack fails, effects such as **Crit (2 Hits)** or **Crit (Auto-wound)** would have no effect. However, effects that are resolved immediately, such as **Crit (Mortal)**, would still be triggered by those critical hits."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If a unit is affected by two different abilities (such as the Ashen Elder’s ‘Stoked Fanaticism’ and the Taar’s Grand Forgehost spell ‘Reinforce Daemonsteel’) that would let it ignore the first damage in a phase, will it ignore the first and second damage points in that phase? If a unit takes damage in a phase before being affected by an ability that would let it ignore the first damage in a phase (e.g. by killing models that brought it wholly within such an effect), will it ignore the next damage point it would take that phase?*\nA: No and no. It will only ever ignore the first damage point that was dealt to that unit in that phase."
+                }
+              ]
+            },
+            {
+              "id": "0150615b-d940-567f-8e23-517523462bb2",
+              "ref": "18.3",
+              "title": "18.3 Slain Models",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *Do models removed as a result of a unit being out of coherency count as having been slain?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                }
+              ]
+            },
+            {
+              "id": "aa98447e-f766-59b1-9b42-c5da3955fba2",
+              "ref": "19.0",
+              "title": "19.0 STRIKE-FIRST and STRIKE-LAST",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Can I use an ability that allows a friendly unit that does not have **STRIKE-FIRST** to fight immediately after a friendly unit that has **STRIKE-FIRST** if there are one or more enemy units with **STRIKE-FIRST** that have not yet been picked to fight?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No. As mentioned in the sidebar next to 19.0, abilities that allow a unit to use a **FIGHT** ability immediately after another unit do not override the **STRIKE-FIRST** constraints, so you cannot pick a unit that does not have **STRIKE-FIRST** to fight until all other units that have **STRIKE-FIRST** have fought."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q:* *If a friendly unit is the only unit that has **STRIKE-FIRST** on the battlefield and it has an ability that allows a friendly unit to fight immediately after it, in what order would units be picked to fight?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: If you are the active player, the unit that has **STRIKE-FIRST** would fight first, then you could use the ability to allow another friendly unit to fight immediately after it, and then you would pick the next unit to fight (i.e. three friendly units would fight back to back). If your opponent is the active player, the unit that has **STRIKE-FIRST** would fight first, you could still use the ability to allow another friendly unit to fight, and then your opponent would pick the next unit to fight."
+                },
+                {
+                  "type": "text",
+                  "text": "Q: *In the combat phase, if all eligible non-**STRIKE‑LAST** units have used a **FIGHT** ability, which player gets to pick the first **STRIKE-LAST** unit to fight?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: The alternating sequence of picking units to use a **FIGHT** ability would continue and so the player who did not pick the last non-**STRIKE-LAST** unit would get to pick the first eligible **STRIKE-LAST** unit in their army to use a **FIGHT** ability."
+                }
+              ]
+            },
+            {
+              "id": "19eb19b2-cddd-5323-a828-051fa7e7487d",
+              "ref": "20.0",
+              "title": "20.0 Weapon Abilities",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Can I combine multiple instances of the same weapon ability? For example, if a weapon already has* **Anti-INFANTRY (+1 Rend)** *and it can also gain that ability from another source, would it now have +2 Rend against* **INFANTRY** *units?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If a weapon has the* **Companion** *weapon ability, would it be affected by friendly abilities that grant new weapon abilities or that modify weapon abilities that the weapon already has?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No, unless the ability specifically names the weapon or states that it affects **Companion** weapons."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: Can I make a shooting attack with a weapon with the **Shoot in Combat** weapon ability if the unit using that weapon is in combat and that unit or the target of that shooting attack is affected by an ability such as the **DAUGHTERS OF KHAINE** ‘Prophecy of Shelter’ effect of the Scourge of Ghyran **Krethusa the Croneseer**’s ‘Blood Ritual’ ability, which has an effect that results in weapon abilities other than **Companion** having no effect?*\n\nA: No."
+                }
+              ]
+            },
+            {
+              "id": "9060a003-a729-52f4-b3ad-a3b518678717",
+              "ref": "21.0",
+              "title": "21.0 Healing",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If an ability (e.g. ‘Seed of Rebirth’) would allow a unit that would be destroyed to negate all remaining damage points then heal to prevent that unit from being destroyed, and another ability (e.g. ‘Quenching the Flames’) prevents that unit from healing, would that unit still be destroyed?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                }
+              ]
+            },
+            {
+              "id": "288353b2-932c-5079-beeb-93cfd0338948",
+              "ref": "24.0",
+              "title": "24.0 Setting Up Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: Can a unit use a **MOVE** ability and then be affected by an ability which removes them from the battlefield and sets them up again in the same movement phase? For example, could a friendly non-**MONSTER** **STORMCAST ETERNALS** unit move to be wholly within 6\" of a Stormreach Portal, and then in the same movement phase use the ‘Step Into the Storm’ ability?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes. Units cannot use **MOVE** abilities in the movement phase after being set up on the battlefield that turn, but are able to use **MOVE** abilities before doing so"
+                }
+              ]
+            },
+            {
+              "id": "6dc1002f-f3c5-5739-a0f7-8968eb1956bb",
+              "ref": "24.2",
+              "title": "24.2 Replacement Units",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *If a destroyed unit had an enhancement, and an ability allows me to set up a replacement of that unit, would the replacement unit also have that enhancement?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If an ability allows a replacement unit to be set up with half the models from the original unit, and the original unit has to have a certain proportion of models equipped with specific weapons, does the new unit also need to adhere to the same restrictions?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: No. As stated in 24.2, you can pick any models from the original unit to be set up in the replacement unit."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If an ability allows a replacement unit to be set up with half the models from the original unit, could I then use an ability such as ‘Rally’ to return models to that unit until it reached the unit size of the original unit?*\n\nA: No. A replacement unit is treated as a new unit with a new unit size."
+                }
+              ]
+            },
+            {
+              "id": "f2c32c79-3b74-5cd5-a81d-f0b8a2ca1cca",
+              "ref": "25.0",
+              "title": "25.0 Guarded Heroes",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *If an ability allows me to ignore the effects of the ‘Guarded Hero’ ability when picking targets (e.g. the Warlock Engineer’s ‘Sniper-master’ ability), would the attacking unit still be affected by the -1 to hit penalty from ‘Guarded Hero’?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                }
+              ]
+            },
+            {
+              "id": "8e560abc-e0b5-5f69-aa75-fee0fea95231",
+              "ref": "26.0",
+              "title": "26.0 Random Characteristics",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "Q: *Do you roll a random characteristic roll before or after declaring a **RUN** ability?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: After declaring it and after all reactions are used."
+                }
+              ]
+            },
+            {
+              "id": "413fcdf9-349b-5da4-a62d-676ecf2e58d2",
+              "ref": "28.0",
+              "title": "28.0 Advanced Ability Rules",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If a rule says to pick a number of units with one keyword or another (e.g. ‘Pick up to 3 friendly **SKINK INFANTRY** or **CAVALRY** units’), could you pick a combination of units with either keyword, or do all the units you pick need to have the same keyword?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: You can mix and match. In the example given, you could pick 1 **SKINK INFANTRY** unit and 2 **SKINK CAVALRY** units."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q:* *If a persisting effect applies to a unit that is destroyed, and another ability allows that unit to return to the battlefield (e.g. the ‘Resurrection’ prayer from the Path to Glory: Ascension battlepack), does the persisting effect apply to the returned unit?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: If a part of an ability’s effect does not state that you ‘can’ or ‘must’ do it, is it mandatory to resolve that part of the effect?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: Yes. Any part of an effect that is not optional is mandatory. If you cannot resolve one part of an effect, none of it applies. For instance, if a player picked the **WIZARD** casting ‘The Hand of Gork’ to also be the target of the spell, the effect could not be fully resolved – it would be impossible for the target to be removed from the battlefield and set up again wholly within 24\" of the caster – and so the spell would have no effect."
+                },
+                {
+                  "type": "text",
+                  "text": "*Q: Do persisting effects continue to apply to a unit that has been destroyed?*\nA: Yes."
+                }
+              ]
+            },
+            {
+              "id": "e2c9d85c-c403-5dd8-80b1-c656a3a9ed80",
+              "ref": "28.2",
+              "title": "28.2 'Once Per' Timings",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q:* *If an ability that is not on a unit’s warscroll has the ‘Once Per Turn’, ‘Once Per Battle’ or ‘Once Per Battle Round’ timing (without ‘(Army)’ afterwards), can multiple friendly units use that ability in that time period?*"
+                },
+                {
+                  "type": "text",
+                  "text": "A: It depends on who is using the ability (see the sidebar next to 28.2). If a unit is using the ability (i.e. the declare step specifically says to pick a unit to use it), then each unit could use that ability in that time period. If the player is using the ability (i.e. nothing in the ability specifically says that it is used by a unit), it can only be used once in that time period. Note that picking the target of an ability is not the same as picking a unit to use that ability."
+                }
+              ]
+            },
+            {
+              "id": "f6899b59-d70a-5486-84e8-cbfc682c3963",
+              "ref": "32.3",
+              "title": "32.3 Terrain Control",
+              "subtitle": null,
+              "containerType": "standard",
+              "updateType": "faqs",
+              "components": [
+                {
+                  "type": "text",
+                  "text": "*Q: If a player controls a piece of terrain, can a unit be counted towards contesting a different piece of terrain while still maintaining control of the first piece?*\nA: Yes."
+                }
+              ]
+            }
+          ],
+          "sections": []
+        }
+      ]
+    }
+  ]
+}

--- a/aos/gdc/rules/faqs.json
+++ b/aos/gdc/rules/faqs.json
@@ -1,0 +1,533 @@
+[
+  {
+    "id": "f5a41e78-61ae-5a13-983c-6d94dc6266f8",
+    "source": "Core Rules",
+    "section": "Frequently Asked Questions",
+    "components": [
+      {
+        "type": "text",
+        "text": "In this series of questions and answers, the rules-writing team respond to players’ queries and explain how the rules are intended to be used."
+      }
+    ]
+  },
+  {
+    "id": "f750e351-2a6c-562c-9d78-c442842a5e81",
+    "source": "Core Rules",
+    "section": "2.2 Dice",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: If an ability allows me to re-roll one dice from an XD6 roll (e.g. the Blades of the Hollow King ‘Aurelias’ ability), could I then use a different ability to re-roll the entire XD6 roll?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No."
+      }
+    ]
+  },
+  {
+    "id": "ee450e7a-5d91-516b-b821-22c2b9caef23",
+    "source": "Core Rules",
+    "section": "4.0 Warscrolls",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: How should I resolve an ability that refers to an enemy’s Control characteristic (e.g. Ushoran’s ‘Shroudcage Fragment’) if the target does not have a Control characteristic (e.g. a manifestation)?*"
+      },
+      {
+        "type": "text",
+        "text": "A: The target is treated as having a Control characteristic of 0."
+      }
+    ]
+  },
+  {
+    "id": "cba94688-c4a6-5330-85ec-6c25a743181d",
+    "source": "Core Rules",
+    "section": "5.0 Abilities",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *Some abilities (e.g. ‘All-out Attack’) have a red timing bar. Can these abilities only be used in the combat phase?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No. The words in the timing bar or, in the case of reactions and passive abilities, the specific wording of the ability will let you know exactly when you can use it; the colour is just there as a play aid. If a phase is not specified, the colour indicates the most common phase it is used in or, if it is used in multiple phases equally, the timing bar is black."
+      },
+      {
+        "type": "text",
+        "text": "*Q: Some abilities have a green timing bar. What does this mean?*"
+      },
+      {
+        "type": "text",
+        "text": "A: The green timing bar is used to indicate defensive abilities, many of which can be used in multiple phases."
+      },
+      {
+        "type": "text",
+        "text": "*Q:* *Are non-passive abilities such as ‘Burning Wyrdflame’ optional to use?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes. You must apply the effects of passive abilities and abilities that state that they must be used if it is possible to do so, but all other abilities are optional to use."
+      }
+    ]
+  },
+  {
+    "id": "3d3ed07e-5f62-58c8-9bc4-989b9e52812f",
+    "source": "Core Rules",
+    "section": "5.1 Keywords",
+    "components": [
+      {
+        "type": "text",
+        "text": "Q: *In ‘Pick a friendly non-**HERO LEGION OF THE FIRST PRINCE DAEMON INFANTRY** or **CAVALRY** unit that has been destroyed to be the target’ (and similar wordings with multiple keywords), does ‘**CAVALRY** unit’ mean just that (i.e. with no other keywords) or does it mean ‘ friendly non-**HERO LEGION OF THE FIRST PRINCE DAEMON CAVALRY UNIT**’?*"
+      },
+      {
+        "type": "text",
+        "text": "A: It means ‘friendly non-**HERO LEGION OF THE FIRST PRINCE DAEMON CAVALRY** unit’."
+      },
+      {
+        "type": "text",
+        "text": "Q: *Where an ability references multiple keywords but has ‘non-’ at the start of the sequence of keywords(for example, the Skaven Brood Terror’s Lend a Claw ability which targets ‘non-**SKRYRE MOULDER**’ units’), does this mean the target must not have any of the keywords listed (in this example, the target couldn’t have **SKRYRE** or **MOULDER** keywords), or does it mean the target cannot have the first keyword but must have the second (in this example, it cannot have **SKRYRE** but must have **MOULDER**)?*"
+      },
+      {
+        "type": "text",
+        "text": "A: The ‘non-’ only relates to the keyword it is directly attached to. Therefore, in the example given, the target cannot have the **SKRYRE** keyword but must have the **MOULDER** keyword. If the intent were to exclude both keywords, then it would be expressed as ‘non-**SKRYRE** non-**MOULDER**'."
+      }
+    ]
+  },
+  {
+    "id": "85e04c63-d090-57ac-b3d8-fecacdb69818",
+    "source": "Core Rules",
+    "section": "5.2 Using Abilities",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *When resolving the effect of an ability that refers to a Save characteristic of 3+ or better (e.g. the ‘Cloying Quagmire’ spell), what does ‘or better’ mean?*"
+      },
+      {
+        "type": "text",
+        "text": "A: It means any Save characteristic with a lower value than 3+, such as 2+, that better protects against incoming damage."
+      },
+      {
+        "type": "text",
+        "text": "*Q: If an ability allows another friendly unit to be picked to use a **FIGHT** ability immediately after a friendly unit has used a **FIGHT** ability (for example, the Crypt Haunter Courtier’s ‘Knightly Exemplar’ ability), does the second unit being activated have to meet the requirements of the Declare step of the **FIGHT** ability it is using?*\n\nA: Yes. So, for example, if the second unit being activated was using the ‘Fight’ ability, it would need to be in combat or have charged in the same turn."
+      },
+      {
+        "type": "text",
+        "text": "*Q: If an ability references a qualifier that multiple objects are tied for (e.g. two terrain features are equally close to an Awakened Wyldwood that is using the ‘Ever Growing’ ability), what happens?*\nA: The player who used the ability chooses which object to affect."
+      }
+    ]
+  },
+  {
+    "id": "1e81b66a-5e2f-5a6b-b3cc-facfd2974a67",
+    "source": "Core Rules",
+    "section": "5.3 The Rules of One",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: Are Reaction abilities subject to the Rules of One? For example, if a unit has a Reaction ability on their warscroll, could they only use it once per phase?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes."
+      }
+    ]
+  },
+  {
+    "id": "c454b0c3-4227-5275-b24f-b3f67d3549f9",
+    "source": "Core Rules",
+    "section": "6.0 Visibility",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: If a non-**FLY INFANTRY HERO** (e.g. a Scinari Cathallar) is a Shrine Guardian of a Shrine Luminor, and that Shrine Guardian is within 1\" of an obscuring terrain feature, is the Shrine Guardian visible to enemy abilities that target the Shrine Guardian?*\nA: Yes."
+      }
+    ]
+  },
+  {
+    "id": "2ee17bdf-dd4a-51f3-bccf-4f057026f97f",
+    "source": "Core Rules",
+    "section": "7.0 Combat Range",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q. If a model in base-to-base contact with an enemy model retreats 3\" directly away from the enemy model, is it still in combat with that enemy model?*\n\nA. No."
+      }
+    ]
+  },
+  {
+    "id": "321b128d-02f1-5c32-a30c-d8f27feb3d51",
+    "source": "Core Rules",
+    "section": "9.1.1 Setting up Objectives and Terrain Features",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *If a battleplan instructs you to set up an objective on a corner of the battlefield, should you place the entire 40mm objective marker on the battlefield, or should the centre of the objective marker be on the corner?*"
+      },
+      {
+        "type": "text",
+        "text": "A: The centre of the objective marker should be on the corner."
+      }
+    ]
+  },
+  {
+    "id": "ef1e1a6c-6882-5e18-b25c-68199ce21e81",
+    "source": "Core Rules",
+    "section": "9.1.2 Territories",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: If a rule requires that a unit be ‘outside of friendly territory’ or ‘wholly outside of friendly territory’, would a unit that is not on the battlefield (for example a destroyed unit or a unit in reserve) count?*\n\nA: No."
+      }
+    ]
+  },
+  {
+    "id": "fa02743c-1d00-5d76-804a-8963aae11495",
+    "source": "Core Rules",
+    "section": "10.1 Universal Deployment Phase Abilities",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: Can you choose to deploy units that are in a regiment using the ‘Deploy Unit’ ability instead of ‘Deploy Regiment’?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes, however, once a unit in a regiment has been deployed in this manner, you can no longer use ‘Deploy Regiment’ to deploy the remaining units in that regiment, since the declare step of that ability specifies that ‘No units in that regiment can have already been deployed.’"
+      },
+      {
+        "type": "text",
+        "text": "*Q: Is it mandatory for players to set up a faction terrain feature (if one is included on their roster) during the deployment phase?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No. A player can choose not to use the ‘Deploy Faction Terrain’ ability. However, if both players choose to set up a faction terrain feature, the player who begins deployment must set up their faction terrain features first (as specified in Step 1 of 10.0)."
+      }
+    ]
+  },
+  {
+    "id": "e95fe7b3-3e29-5fca-a38c-fbc1bbe4fddc",
+    "source": "Core Rules",
+    "section": "12.0 Start of Battle Round",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *When determining the active player, how do you determine when a player has ‘finished setting up their army’?*"
+      },
+      {
+        "type": "text",
+        "text": "A: A player has finished setting up their army when all units in their army have been deployed. This means that non-**DEPLOY** Deployment Phase abilities (e.g. The Masque’s ‘The Endless Dance’ ability) happen after your army has ‘finished setting up’."
+      }
+    ]
+  },
+  {
+    "id": "f124a0ff-9cc4-5491-bc23-3ef4b1aa2141",
+    "source": "Core Rules",
+    "section": "14.3 Charge Phase",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *When using the ‘Charge’ ability, does my unit need to end the charge move within 1⁄2\" of an enemy unit that was visible to the charging unit at the start of that charge move?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No. It must end the charge move within 1⁄2\" of an enemy unit that is visible to the charging unit when it finishes that charge move."
+      },
+      {
+        "type": "text",
+        "text": "*Q. If an ability adds to or subtracts from the number of dice that make up a charge roll, is that a modifier to the charge roll?*\n\nA. No."
+      }
+    ]
+  },
+  {
+    "id": "5b2316a5-8745-5347-b686-ae4ad7e41ae6",
+    "source": "Core Rules",
+    "section": "15.2 Moving Across Terrain",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *The rules for moving across terrain state that a model cannot end a move mid-climb. How can you tell if a model is mid-climb?*"
+      },
+      {
+        "type": "text",
+        "text": "A: A model is mid-climb if it is not possible to rest it on its base in that location without additional support. As there is a wide variety of terrain and models, it is acceptable for a model to end a move with its base at a slight angle because of uneven terrain beneath it, but at least half of its base must be within 1\" of the terrain feature that the model is on or it will be considered mid-climb."
+      }
+    ]
+  },
+  {
+    "id": "9a6e59bc-b1f5-5a64-a5a8-fa287b22b81c",
+    "source": "Core Rules",
+    "section": "15.4 Flying",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *If an ability that allows a unit to move states that the unit cannot move into combat (e.g. Normal Move), does Fly allow that unit to move across an enemy unit’s combat range?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes."
+      }
+    ]
+  },
+  {
+    "id": "06af2d1c-f047-5eeb-bb39-25b8f2e1ced7",
+    "source": "Core Rules",
+    "section": "16.0 Picking Targets",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: When making shooting attacks, can all models in the attacking unit shoot even if the target unit is not visible to some of those models?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No, the only models in the attacking unit that can make shooting attacks are those that the target unit is visible to."
+      },
+      {
+        "type": "text",
+        "text": "*Q. When a unit uses a **SHOOT** ability, does it have to shoot with all of the ranged weapons that it is armed with?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes."
+      }
+    ]
+  },
+  {
+    "id": "50b24a81-bfe4-5f9c-9a25-91adf50460e1",
+    "source": "Core Rules",
+    "section": "17.0 The Attack Sequence",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *If an ability allows a unit to score critical hits on unmodified rolls of 5+, but that unit needs a 6 to hit (e.g. as a result of subtracting 1 from hit rolls), would unmodified hit rolls of 5 hit the target? If so, would they still trigger any critical hit effects?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Although the hits would count as critical hits, the attacks would not score a successful hit. As the attack sequence ends if an attack fails, effects such as **Crit (2 Hits)** or **Crit (Auto-wound)** would have no effect. However, effects that are resolved immediately, such as **Crit (Mortal)**, would still be triggered by those critical hits."
+      },
+      {
+        "type": "text",
+        "text": "*Q: If a unit is affected by two different abilities (such as the Ashen Elder’s ‘Stoked Fanaticism’ and the Taar’s Grand Forgehost spell ‘Reinforce Daemonsteel’) that would let it ignore the first damage in a phase, will it ignore the first and second damage points in that phase? If a unit takes damage in a phase before being affected by an ability that would let it ignore the first damage in a phase (e.g. by killing models that brought it wholly within such an effect), will it ignore the next damage point it would take that phase?*\nA: No and no. It will only ever ignore the first damage point that was dealt to that unit in that phase."
+      }
+    ]
+  },
+  {
+    "id": "212f0f62-d8d0-511a-a8ea-5bee0fde6daf",
+    "source": "Core Rules",
+    "section": "18.3 Slain Models",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *Do models removed as a result of a unit being out of coherency count as having been slain?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes."
+      }
+    ]
+  },
+  {
+    "id": "e1b30df9-1801-56f0-a2bf-dda59268bbf2",
+    "source": "Core Rules",
+    "section": "19.0 STRIKE-FIRST and STRIKE-LAST",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: Can I use an ability that allows a friendly unit that does not have **STRIKE-FIRST** to fight immediately after a friendly unit that has **STRIKE-FIRST** if there are one or more enemy units with **STRIKE-FIRST** that have not yet been picked to fight?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No. As mentioned in the sidebar next to 19.0, abilities that allow a unit to use a **FIGHT** ability immediately after another unit do not override the **STRIKE-FIRST** constraints, so you cannot pick a unit that does not have **STRIKE-FIRST** to fight until all other units that have **STRIKE-FIRST** have fought."
+      },
+      {
+        "type": "text",
+        "text": "*Q:* *If a friendly unit is the only unit that has **STRIKE-FIRST** on the battlefield and it has an ability that allows a friendly unit to fight immediately after it, in what order would units be picked to fight?*"
+      },
+      {
+        "type": "text",
+        "text": "A: If you are the active player, the unit that has **STRIKE-FIRST** would fight first, then you could use the ability to allow another friendly unit to fight immediately after it, and then you would pick the next unit to fight (i.e. three friendly units would fight back to back). If your opponent is the active player, the unit that has **STRIKE-FIRST** would fight first, you could still use the ability to allow another friendly unit to fight, and then your opponent would pick the next unit to fight."
+      },
+      {
+        "type": "text",
+        "text": "Q: *In the combat phase, if all eligible non-**STRIKE‑LAST** units have used a **FIGHT** ability, which player gets to pick the first **STRIKE-LAST** unit to fight?*"
+      },
+      {
+        "type": "text",
+        "text": "A: The alternating sequence of picking units to use a **FIGHT** ability would continue and so the player who did not pick the last non-**STRIKE-LAST** unit would get to pick the first eligible **STRIKE-LAST** unit in their army to use a **FIGHT** ability."
+      }
+    ]
+  },
+  {
+    "id": "4087ede1-36a0-53a6-a82b-ca6560d08ac7",
+    "source": "Core Rules",
+    "section": "20.0 Weapon Abilities",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: Can I combine multiple instances of the same weapon ability? For example, if a weapon already has* **Anti-INFANTRY (+1 Rend)** *and it can also gain that ability from another source, would it now have +2 Rend against* **INFANTRY** *units?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No."
+      },
+      {
+        "type": "text",
+        "text": "*Q: If a weapon has the* **Companion** *weapon ability, would it be affected by friendly abilities that grant new weapon abilities or that modify weapon abilities that the weapon already has?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No, unless the ability specifically names the weapon or states that it affects **Companion** weapons."
+      },
+      {
+        "type": "text",
+        "text": "*Q: Can I make a shooting attack with a weapon with the **Shoot in Combat** weapon ability if the unit using that weapon is in combat and that unit or the target of that shooting attack is affected by an ability such as the **DAUGHTERS OF KHAINE** ‘Prophecy of Shelter’ effect of the Scourge of Ghyran **Krethusa the Croneseer**’s ‘Blood Ritual’ ability, which has an effect that results in weapon abilities other than **Companion** having no effect?*\n\nA: No."
+      }
+    ]
+  },
+  {
+    "id": "cf4c268f-f055-52ae-8107-8c2da5deade9",
+    "source": "Core Rules",
+    "section": "21.0 Healing",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: If an ability (e.g. ‘Seed of Rebirth’) would allow a unit that would be destroyed to negate all remaining damage points then heal to prevent that unit from being destroyed, and another ability (e.g. ‘Quenching the Flames’) prevents that unit from healing, would that unit still be destroyed?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes."
+      }
+    ]
+  },
+  {
+    "id": "278cb516-f8ca-5e7a-a496-322406e68595",
+    "source": "Core Rules",
+    "section": "24.0 Setting Up Units",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: Can a unit use a **MOVE** ability and then be affected by an ability which removes them from the battlefield and sets them up again in the same movement phase? For example, could a friendly non-**MONSTER** **STORMCAST ETERNALS** unit move to be wholly within 6\" of a Stormreach Portal, and then in the same movement phase use the ‘Step Into the Storm’ ability?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes. Units cannot use **MOVE** abilities in the movement phase after being set up on the battlefield that turn, but are able to use **MOVE** abilities before doing so"
+      }
+    ]
+  },
+  {
+    "id": "16754ca4-e5e8-56f0-89ba-ace269879767",
+    "source": "Core Rules",
+    "section": "24.2 Replacement Units",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *If a destroyed unit had an enhancement, and an ability allows me to set up a replacement of that unit, would the replacement unit also have that enhancement?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No."
+      },
+      {
+        "type": "text",
+        "text": "*Q: If an ability allows a replacement unit to be set up with half the models from the original unit, and the original unit has to have a certain proportion of models equipped with specific weapons, does the new unit also need to adhere to the same restrictions?*"
+      },
+      {
+        "type": "text",
+        "text": "A: No. As stated in 24.2, you can pick any models from the original unit to be set up in the replacement unit."
+      },
+      {
+        "type": "text",
+        "text": "*Q: If an ability allows a replacement unit to be set up with half the models from the original unit, could I then use an ability such as ‘Rally’ to return models to that unit until it reached the unit size of the original unit?*\n\nA: No. A replacement unit is treated as a new unit with a new unit size."
+      }
+    ]
+  },
+  {
+    "id": "b17f9ac3-3fde-5d3f-b3a8-fe49a6f0d18e",
+    "source": "Core Rules",
+    "section": "25.0 Guarded Heroes",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *If an ability allows me to ignore the effects of the ‘Guarded Hero’ ability when picking targets (e.g. the Warlock Engineer’s ‘Sniper-master’ ability), would the attacking unit still be affected by the -1 to hit penalty from ‘Guarded Hero’?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes."
+      }
+    ]
+  },
+  {
+    "id": "b4e9dd6e-4d3c-5c02-8f97-44cfb7bda1f4",
+    "source": "Core Rules",
+    "section": "26.0 Random Characteristics",
+    "components": [
+      {
+        "type": "text",
+        "text": "Q: *Do you roll a random characteristic roll before or after declaring a **RUN** ability?*"
+      },
+      {
+        "type": "text",
+        "text": "A: After declaring it and after all reactions are used."
+      }
+    ]
+  },
+  {
+    "id": "39b50fe9-d49d-56d2-82b2-7229473268cc",
+    "source": "Core Rules",
+    "section": "28.0 Advanced Ability Rules",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: If a rule says to pick a number of units with one keyword or another (e.g. ‘Pick up to 3 friendly **SKINK INFANTRY** or **CAVALRY** units’), could you pick a combination of units with either keyword, or do all the units you pick need to have the same keyword?*"
+      },
+      {
+        "type": "text",
+        "text": "A: You can mix and match. In the example given, you could pick 1 **SKINK INFANTRY** unit and 2 **SKINK CAVALRY** units."
+      },
+      {
+        "type": "text",
+        "text": "*Q:* *If a persisting effect applies to a unit that is destroyed, and another ability allows that unit to return to the battlefield (e.g. the ‘Resurrection’ prayer from the Path to Glory: Ascension battlepack), does the persisting effect apply to the returned unit?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes."
+      },
+      {
+        "type": "text",
+        "text": "*Q: If a part of an ability’s effect does not state that you ‘can’ or ‘must’ do it, is it mandatory to resolve that part of the effect?*"
+      },
+      {
+        "type": "text",
+        "text": "A: Yes. Any part of an effect that is not optional is mandatory. If you cannot resolve one part of an effect, none of it applies. For instance, if a player picked the **WIZARD** casting ‘The Hand of Gork’ to also be the target of the spell, the effect could not be fully resolved – it would be impossible for the target to be removed from the battlefield and set up again wholly within 24\" of the caster – and so the spell would have no effect."
+      },
+      {
+        "type": "text",
+        "text": "*Q: Do persisting effects continue to apply to a unit that has been destroyed?*\nA: Yes."
+      }
+    ]
+  },
+  {
+    "id": "eb9bb6b6-8b6a-5372-b988-b7d08445c1c7",
+    "source": "Core Rules",
+    "section": "28.2 'Once Per' Timings",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q:* *If an ability that is not on a unit’s warscroll has the ‘Once Per Turn’, ‘Once Per Battle’ or ‘Once Per Battle Round’ timing (without ‘(Army)’ afterwards), can multiple friendly units use that ability in that time period?*"
+      },
+      {
+        "type": "text",
+        "text": "A: It depends on who is using the ability (see the sidebar next to 28.2). If a unit is using the ability (i.e. the declare step specifically says to pick a unit to use it), then each unit could use that ability in that time period. If the player is using the ability (i.e. nothing in the ability specifically says that it is used by a unit), it can only be used once in that time period. Note that picking the target of an ability is not the same as picking a unit to use that ability."
+      }
+    ]
+  },
+  {
+    "id": "7f140b6c-0cfa-58d5-9214-ece1424da451",
+    "source": "Core Rules",
+    "section": "32.3 Terrain Control",
+    "components": [
+      {
+        "type": "text",
+        "text": "*Q: If a player controls a piece of terrain, can a unit be counted towards contesting a different piece of terrain while still maintaining control of the first piece?*\nA: Yes."
+      }
+    ]
+  }
+]

--- a/aos/gdc/rules/glossary.json
+++ b/aos/gdc/rules/glossary.json
@@ -1,0 +1,2425 @@
+{
+  "id": "e1afd091-7261-526e-bea9-a0a137ec6243",
+  "name": "Glossary 2026-27",
+  "cardType": "Glossary",
+  "source": "aos-4e",
+  "season": 2026,
+  "updated": "2026-07-05T15:43:06.044Z",
+  "compatibleDataVersion": 446,
+  "sections": [
+    {
+      "id": "77eaf0b6-5c44-58d5-a5b8-dcb77e301245",
+      "ref": null,
+      "name": "Glossary 2026-27",
+      "containers": [
+        {
+          "id": "4a07fafd-303b-526f-bb87-a32cdd7fb98a",
+          "ref": null,
+          "title": "Glossary 2026-27",
+          "subtitle": null,
+          "containerType": "introduction",
+          "updateType": null,
+          "components": [
+            {
+              "type": "textBold",
+              "text": "This glossary is an alphabetised list of rules definitions. It is intended to be a useful resource if you need a quick reminder of what a rule does or a short summary of a game term. It is not intended as an exhaustive list of precise definitions – if you need the full rule, refer to the relevant rules module. If there are any contradictions between this glossary and a rules module, the rules module takes precedence."
+            },
+            {
+              "type": "header",
+              "text": "Rules Module Abbreviations"
+            },
+            {
+              "type": "textBold",
+              "text": "CR - Core Rules\nCM - Commands\nAC - Army Composition\nMG - Magic\nBT - Battle Tactics\nTR - Terrain\nCMOD - Command Models"
+            },
+            {
+              "type": "text",
+              "text": "**Designer’s Note:** *Rules modules with a date suffix are not the same as their equivalents with no date suffix. For example, ‘AC, 4.1’ and ‘AC 2026‑27, 4.1’ refer to different modules. The reference without the suffix refers to the original module; the reference with the suffix refers to a later version of that module that contains important rules changes for the current season of Matched Play.*"
+            }
+          ]
+        },
+        {
+          "id": "a485df48-a135-5196-9c87-6d56dae29cba",
+          "ref": null,
+          "title": "abiliies",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The things that units can do in the game. Some abilities, like ‘Normal Move’ and ‘Fight’, are common to all units; others are specific to certain units and only appear on their warscroll. Sometimes the players themselves use abilities. (CR, 5.0)"
+            }
+          ]
+        },
+        {
+          "id": "90704e63-7cdc-542c-b03c-1fe25a7cf6e3",
+          "ref": null,
+          "title": "Activate Place of Power",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Start of Any Turn. If **HERO** is within 3\" of a Place of Power, on a 2+, can gain 2 rage dice, +1 to casting or chanting rolls or use ‘Unbind’ or ‘Banish Manifestation’ as if they had **WIZARD (1).**"
+            }
+          ]
+        },
+        {
+          "id": "cec8f6e8-dddc-54a7-92ae-7a80adfd43ce",
+          "ref": null,
+          "title": "active player",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The player whose turn is taking place. There are 2 turns in a battle round. The active player can use abilities with the ‘Your Phase’ timing. (CR, 12.0)"
+            }
+          ]
+        },
+        {
+          "id": "6f3d7985-68be-50a5-919c-fdc940dfc0e8",
+          "ref": null,
+          "title": "allocate",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Damage points are allocated one at a time to a unit after all the damage points inflicted by an ability have been totalled in the damage pool. (CR, 18.2)"
+            }
+          ]
+        },
+        {
+          "id": "6a87eec6-8532-52e9-a7da-d3d02efac5da",
+          "ref": null,
+          "title": "All-out Attack",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 1CP, reaction. Attacking unit adds 1 to hit rolls but subtracts 1 from save rolls. (CM 2026‑27, 6.0)"
+            }
+          ]
+        },
+        {
+          "id": "998009a3-5152-50c1-8624-8c10a5ea3a31",
+          "ref": null,
+          "title": "All-out Defence",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 1CP, reaction. Target unit adds 1 to save rolls. (CM 2026‑27, 7.0)"
+            }
+          ]
+        },
+        {
+          "id": "25a3b301-c91b-5e89-8379-724ea583d110",
+          "ref": null,
+          "title": "Anti-X (+1 Rend)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Weapon ability. +1 Rend for attacks that target units that fulfil the condition after ‘Anti-'. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "e34d9cd4-c059-58b1-8987-8da0fb1e3088",
+          "ref": null,
+          "title": "Any (…) Phase",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Timing. Either player can use abilities with this timing, regardless of who the active player is. (CR, 13.0)"
+            }
+          ]
+        },
+        {
+          "id": "35bdb835-4577-556d-9971-344edbb852ba",
+          "ref": null,
+          "title": "army",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "All of a player’s units are collectively referred to as their army. (CR, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "5d4b1aa8-fcfb-5f0d-9e15-54de03a789e1",
+          "ref": null,
+          "title": "army composition",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The step before a battle in which the players build their armies. The battlepack may specify in more detail what they can and can’t include in their armies"
+            }
+          ]
+        },
+        {
+          "id": "f17a4309-b8c3-536c-a2a0-827b53fe8ee6",
+          "ref": null,
+          "title": "Army of Renown",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A special type of army that uses a modified set of faction rules. (AC 2026‑27, 2.2)"
+            }
+          ]
+        },
+        {
+          "id": "8fbe2607-5501-500b-9156-e89c494a0808",
+          "ref": null,
+          "title": "army roster",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The list of units in a player’s army and any other important information like enhancements. Players can check each other’s rosters any time they like. (AC 2026‑27, 1.1)"
+            }
+          ]
+        },
+        {
+          "id": "41a6c2a5-d62a-53f8-8a71-3061d28eb089",
+          "ref": null,
+          "title": "artefact of power",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Enhancement. You can give 1 **HERO** in your army an artefact of power. (AC 2026‑27, 4.1)"
+            }
+          ]
+        },
+        {
+          "id": "8a6d5db5-441f-5045-8654-4bb6512307e3",
+          "ref": null,
+          "title": "At the Double",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 1CP, reaction. Add 6\" to Move instead of making the run roll. (CM 2026‑27, 3.0)"
+            }
+          ]
+        },
+        {
+          "id": "9e594823-8129-518c-8445-f81f52394507",
+          "ref": null,
+          "title": "attack sequence",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Make hit roll, wound roll and save roll, then determine damage points inflicted. (CR, 17.0)"
+            }
+          ]
+        },
+        {
+          "id": "dc2b2371-6f1f-59e6-a21f-1258f3e088f2",
+          "ref": null,
+          "title": "auxiliary unit",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit on your army roster that is not part of a regiment. (AC 2026‑27, 3.6)"
+            }
+          ]
+        },
+        {
+          "id": "b193f45d-1734-53ca-96b8-9da0bf29c9cd",
+          "ref": null,
+          "title": "Banish Manifestation",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Your Hero Phase, 30\", banishment roll of 2D6. Equal or beat banishment value of the manifestation to remove it from play. +1 to roll for each enemy manifestation on the battlefield after the first. (MG 2026‑27, 7.2)"
+            }
+          ]
+        },
+        {
+          "id": "7b8df91d-2684-5145-b8f6-331d4db59866",
+          "ref": null,
+          "title": "battle profile",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Important information about a unit that you will need to refer to if you wish to include it in your army, such as its points value and minimum unit size. (AC 2026‑27, 1.3)"
+            }
+          ]
+        },
+        {
+          "id": "8cc3e0d2-ced4-50c0-ab05-128d40ab96eb",
+          "ref": null,
+          "title": "battle round",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The battle lasts a number of battle rounds specified in the battleplan. Each battle round has 2 turns (1 for each player), and each turn has 7 phases. (CR, 11.0)"
+            }
+          ]
+        },
+        {
+          "id": "7b117c86-256f-5877-acfa-a7ab99a44f51",
+          "ref": null,
+          "title": "battle tactics",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Score up to 1 on each of your battle tactics cards at the end of your turn. Cannot complete Strike unless Affray has been completed. Cannot complete Domination unless Strike has been completed. (BT 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "27230c0f-30d7-5674-bf99-3994b6753720",
+          "ref": null,
+          "title": "battle tactics card",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Pick 2 battle tactics cards during army composition. Each has 3 battle tactics: 1 Affray, 1 Strike and 1 Domination. (BT 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "8553a37d-7db0-5341-8674-99071689c685",
+          "ref": null,
+          "title": "battle trait",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A type of faction rule that usually affects your army as a whole and reflects the way your faction does battle, as opposed to individual units."
+            }
+          ]
+        },
+        {
+          "id": "a96f73ea-576d-5151-9387-9e3dfc49a3dd",
+          "ref": null,
+          "title": "battlefield",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The flat surface on which the battle is fought. Usually has 2 short edges and 2 long edges, which may collectively be referred to as ‘the battlefield edge’. It is divided into 4 large quarters, each of which is divided into 4 small quarters (effectively sixteenths)."
+            }
+          ]
+        },
+        {
+          "id": "5a0d06e4-9fc2-5986-aebe-9bd745293fe9",
+          "ref": null,
+          "title": "battleplan",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The set of rules that describes the scenario of the battle and determines things such as where the armies deploy, where any objectives are located and how the players win the battle. (CR, 9.0)"
+            }
+          ]
+        },
+        {
+          "id": "451bf704-1f39-5dbd-b44a-aba6a0fb2533",
+          "ref": null,
+          "title": "begins deployment",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The player who is allowed to use a **DEPLOY** ability during deployment first is said to be the one who begins deployment. The battleplan will specify which player does so. (CR, 10.0)"
+            }
+          ]
+        },
+        {
+          "id": "76c682fb-dc67-526c-8b03-1836facce533",
+          "ref": null,
+          "title": "behind a terrain feature",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Impossible to draw a line from closest point on the base of a model in the attacking unit to closest point on the base of a model in the target unit that is in range without it passing across the terrain feature. (TR 2026‑27, 1.1)"
+            }
+          ]
+        },
+        {
+          "id": "45e7fc3a-cb21-52fb-abfd-75fad4e46293",
+          "ref": null,
+          "title": "CAVALRY",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit keyword. Mounted on warbeasts. **CAVALRY** are fast and hard-hitting but are generally vulnerable to attritional combat."
+            }
+          ]
+        },
+        {
+          "id": "f7b0459d-a192-549e-85da-03c3fdaae260",
+          "ref": null,
+          "title": "Champion",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Model’s weapons have +1 to Attacks characteristic. Affects Companion weapons if **BEAST**. (CMOD 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "289ff9ba-92e4-5f05-b81f-f6b81af52114",
+          "ref": null,
+          "title": "Charge",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Your Charge Phase, charge roll of 2D6. Must get within ½\" of any visible enemy units to succeed, otherwise unit stays where it is. (CR, 14.3)"
+            }
+          ]
+        },
+        {
+          "id": "2655c93b-6444-5ed7-bc60-106a8f1da9ba",
+          "ref": null,
+          "title": "Charge (+1 Damage)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Weapon ability. +1 Damage if attacking unit charged. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "f097b3b6-5a98-53e7-936b-bf466f7cf238",
+          "ref": null,
+          "title": "climb",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Movement vertically up or down the surface of a terrain feature. The model’s base is assumed to stay in contact with the terrain feature as it moves and remain parallel with the battlefield floor. (CR, 15.2)"
+            }
+          ]
+        },
+        {
+          "id": "5e8321fd-ee74-50fc-8192-1afa73662512",
+          "ref": null,
+          "title": "coherency",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "When a unit is set up, ends a move or has slain models removed from it, each model in the unit must be within coherency range. (CR, 15.1)"
+            }
+          ]
+        },
+        {
+          "id": "8acfe76c-ceb2-5b42-8ff5-067e1b3eba9e",
+          "ref": null,
+          "title": "coherency range",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "½\" horizontally and any distance vertically of 1 or more other models if unit has 6 or fewer models; 2 or more if unit has 7+ models. (CR, 15.1)"
+            }
+          ]
+        },
+        {
+          "id": "0f6c0d60-4d43-5f28-972b-f6ddbc09443a",
+          "ref": null,
+          "title": "combat attack",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "An attack made with a melee weapon. (CR, 16.0)"
+            }
+          ]
+        },
+        {
+          "id": "9c9593d2-7c07-57a9-b2ad-bca275ee78aa",
+          "ref": null,
+          "title": "combat range",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Model’s combat range = 3\" horizontally and any distance vertically from model. Unit’s combat range = 3\" horizontally and any distance vertically from all models in unit. A unit is in combat if any enemy models are within its combat range and visible to it. (CR, 7.0)"
+            }
+          ]
+        },
+        {
+          "id": "4a016b2a-78fa-5e33-bd7a-0f9cdf2d7e32",
+          "ref": null,
+          "title": "command points",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Each player gets 4 command points at start of round. Underdog gets 1 extra. (CM 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "eef16b67-7253-5ada-a5e0-3c3772d33561",
+          "ref": null,
+          "title": "commander",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "You are the commander of your army and everything in it (units, models, etc.)."
+            }
+          ]
+        },
+        {
+          "id": "91c6ad3f-137f-50cd-be49-376d68dba241",
+          "ref": null,
+          "title": "commands",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Abilities that require you to spend a number of command points in order to use them. (CM 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "009d3da2-590f-5b14-bd01-f3cdf2e732c7",
+          "ref": null,
+          "title": "Companion",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Weapon ability. Weapon’s attacks are not affected by friendly abilities that modify hit rolls, wound rolls or weapon characteristics, except for those that apply negative modifiers. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "0840165b-359d-599a-b574-a7969d67c6f2",
+          "ref": null,
+          "title": "contesting",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Models contest objectives in their combat range (3\"). When determining objective control, the same unit cannot contest more than 1 objective at the same time; the player must pick 1 if more than 1 is within range. When determining objective and terrain feature control, each unit can contest 1 objective and 1 terrain feature at the same time. (CR, 32.1)"
+            }
+          ]
+        },
+        {
+          "id": "9fdeb0ff-24c9-55fb-aac0-f60ad5ac1bd1",
+          "ref": null,
+          "title": "control",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Determined at the start of the first battle round and the end of each turn. Objectives are controlled by player that has the highest army control score for that objective and remain in their control until other player gains control of it. Terrain features are controlled in the same way but do not remain in that player’s control if none of their models are contesting it. (CR, 32.2)"
+            }
+          ]
+        },
+        {
+          "id": "837ee01e-f339-5ae5-9c1d-2255330ecfaa",
+          "ref": null,
+          "title": "Control characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Determines how good unit is at contesting objectives (see ‘control’). (CR, 4.0)"
+            }
+          ]
+        },
+        {
+          "id": "f221fc1a-d428-5a1e-a1f2-d7aea8c63a53",
+          "ref": null,
+          "title": "control score",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit’s control score is determined by adding all the Control characteristics of models in the unit contesting the objective in question. An army’s control score for that objective is determined by adding together all the control scores of units in the army contesting that objective. (CR, 32.2)"
+            }
+          ]
+        },
+        {
+          "id": "dff1abbf-02fc-5846-9fef-b67a6aa66cb1",
+          "ref": null,
+          "title": "CORE",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Basic ability that can only be used by each unit once per phase, e.g. Move, Shoot, Fight. (CR, 5.1)"
+            }
+          ]
+        },
+        {
+          "id": "43bf2194-5b15-5191-966b-d05c54775565",
+          "ref": null,
+          "title": "Counter-charge",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 2CP. Charge in enemy charge phase. (CM 2026‑27, 5.0)"
+            }
+          ]
+        },
+        {
+          "id": "791b7f69-688d-5427-a1c9-a0acfd40a1a9",
+          "ref": null,
+          "title": "Cover",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "-1 to hit rolls for attacks that target a unit behind or wholly on this terrain feature, unless unit **charged** this turn or has **FLY**. (TR 2026‑27, 1.2)"
+            }
+          ]
+        },
+        {
+          "id": "bd1c727c-76b3-5f94-a858-d3b35bba911d",
+          "ref": null,
+          "title": "Covering Fire",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 1CP. Shoot in enemy shooting phase, but -1 to hit rolls and must target nearest eligible enemy unit. Cannot target manifestations or faction terrain. (CM 2026‑27, 4.0)"
+            }
+          ]
+        },
+        {
+          "id": "cb4bfd1f-b542-51bc-b492-4c0ba43ef3f1",
+          "ref": null,
+          "title": "Crit (2 Hits)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Weapon ability. Unmodified hit roll of 6 scores 2 hits on target. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "433e48b1-cc1a-5dff-a84e-a109846f355e",
+          "ref": null,
+          "title": "Crit (Auto-wound)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Weapon ability. Unmodified hit roll of 6 skips wound roll step. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "6d1d9b44-894c-5cc6-9b05-d322d4bde0fb",
+          "ref": null,
+          "title": "Crit (Mortal)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Weapon ability. Unmodified hit roll of 6 inflicts an amount of mortal damage equal to the Damage characteristic of the weapon and the sequence ends. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "9c6c3fdc-6d16-5fb3-a0e8-5ec323e4778b",
+          "ref": null,
+          "title": "critical hit",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Unmodified hit roll of 6. (CR, 17.0)"
+            }
+          ]
+        },
+        {
+          "id": "c6a12930-113b-52f6-abe5-2eb3a3d84211",
+          "ref": null,
+          "title": "D3",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Roll a D6 and halve the result, rounding up. (CR, 2.2)"
+            }
+          ]
+        },
+        {
+          "id": "78331ecd-f830-5a2c-a5ea-1d96871c2a17",
+          "ref": null,
+          "title": "Damage characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Determines number of damage points inflicted by successful attack. (CR, 17.0)"
+            }
+          ]
+        },
+        {
+          "id": "3c4e6a57-8fb7-5f03-981f-37ce64626c13",
+          "ref": null,
+          "title": "damage points",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Damage points are inflicted by successful attacks and mortal damage. Damage points go into a damage pool first, then they must be allocated one at a time to the target unit. Each time the number of damage points allocated to a unit equals its Health characteristic, a model in the unit is slain. (CR, 17.0)"
+            }
+          ]
+        },
+        {
+          "id": "098ed0c5-3996-512e-a1cc-eeb258da6314",
+          "ref": null,
+          "title": "damage pool",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Inflicted damage points are added to the target’s damage pool until all damage points inflicted by the ability have been calculated. Then, each of those damage points must be allocated one at a time to the target unit. (CR, 17.0)"
+            }
+          ]
+        },
+        {
+          "id": "f86126b9-6191-5788-922b-1d3da9543fb9",
+          "ref": null,
+          "title": "damaged",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit is damaged if it has any damage points currently allocated to it (i.e. if the damage points allocated to it were not enough to slay a model in the unit). Some abilities heal damaged units. (CR, 18.2)"
+            }
+          ]
+        },
+        {
+          "id": "63740ab4-2230-513a-b3b3-82600aeaccb2",
+          "ref": null,
+          "title": "Declare",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The step of every ability after which players may use reactions but before the effect is resolved. (CR, 5.2)"
+            }
+          ]
+        },
+        {
+          "id": "18a77e62-6247-52a4-a270-56c66763ccd6",
+          "ref": null,
+          "title": "deployment phase",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Phase in which players use **DEPLOY** abilities to deploy their armies. (CR, 10.0)"
+            }
+          ]
+        },
+        {
+          "id": "fcce8433-4025-58c4-9023-0f3f1b6ac91b",
+          "ref": null,
+          "title": "destroyed",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit is destroyed when the last model in the unit is slain. (CR, 18.4)"
+            }
+          ]
+        },
+        {
+          "id": "d1cb7220-9311-596a-85ea-c0f643906739",
+          "ref": null,
+          "title": "destroyed by",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit is said to have destroyed another unit when an attack it made or an ability it used caused the last model in the target unit to be slain."
+            }
+          ]
+        },
+        {
+          "id": "0b896462-ea7c-5bf2-9086-922407ec1f16",
+          "ref": null,
+          "title": "drops",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The minimum number of **DEPLOY** abilities that a player can use to set up their army. This is usually equal to the number of regiments in their army plus the number of auxiliary units in their army. (CR, 10.1)"
+            }
+          ]
+        },
+        {
+          "id": "06ed57e7-6ec0-5fdb-b8f1-030c746a8c49",
+          "ref": null,
+          "title": "effect",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Abilities have effects, which are resolved after the declare and reaction step. The thing to which the effect is applied is said to be affected by the ability. (CR, 5.2)"
+            }
+          ]
+        },
+        {
+          "id": "d46010e0-dece-57ec-bd3f-950bbb5262f2",
+          "ref": null,
+          "title": "endless spells",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A type of manifestation summoned by a **WIZARD**. (MG 2026‑27, 7.0)"
+            }
+          ]
+        },
+        {
+          "id": "c70f4f2b-9b8d-5f5e-b5a3-8f759c66d97e",
+          "ref": null,
+          "title": "enemy models/units",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Models/units in your opponent’s army. (CR, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "1d2cb0d3-3015-515b-9a42-7b2eacad029b",
+          "ref": null,
+          "title": "Enemy (…) Phase",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Timing. A phase in which your opponent is the active player. (CR, 13.0)"
+            }
+          ]
+        },
+        {
+          "id": "4e818437-6cfb-5de9-a00f-1e606d5000ed",
+          "ref": null,
+          "title": "enhancements",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A type of faction rule. You can take 1 enhancement of each type for your army, you can’t take the same enhancement more than once, and you can’t give the same unit more than 1 enhancement of the same type. (AC 2026‑27, 4.1)"
+            }
+          ]
+        },
+        {
+          "id": "ffb07a68-84ab-5317-8e70-ab72905c11ad",
+          "ref": null,
+          "title": "faction",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The units in your army must all belong to the same faction (excepting Regiments of Renown). Most factions in Warhammer Age of Sigmar have their own battletome, which contains the rules for the units from that faction, along with the battle traits and enhancements for that faction."
+            }
+          ]
+        },
+        {
+          "id": "bfe26877-f227-5d11-b4fb-16436a19b9f9",
+          "ref": null,
+          "title": "faction rules",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "These are split into battle traits and enhancements. Battle traits tend to be army-wide abilities, while enhancements are given to specific units."
+            }
+          ]
+        },
+        {
+          "id": "f6fec6df-546f-5eda-a9cf-cad4816ebfad",
+          "ref": null,
+          "title": "Fight",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Any Combat Phase. The **CORE** ability that units use to attack each other in combat. (CR, 14.4)"
+            }
+          ]
+        },
+        {
+          "id": "792e3474-79c3-552d-9fb1-cfebc7bd88b3",
+          "ref": null,
+          "title": "Fly",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A keyword. Units that can fly often ignore intervening models and terrain when moving. (CR, 15.4)"
+            }
+          ]
+        },
+        {
+          "id": "8c99a46b-4ae7-52fc-a4a1-45315c0954c4",
+          "ref": null,
+          "title": "Forward to Victory",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 1CP, reaction. Re‑roll charge roll. (CM 2026‑27, 5.0)"
+            }
+          ]
+        },
+        {
+          "id": "a33f7f81-c4e7-55e6-89b4-606dc5575233",
+          "ref": null,
+          "title": "fought",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit has fought if it used any **FIGHT** abilities in the same turn."
+            }
+          ]
+        },
+        {
+          "id": "4ada0dd5-1312-5933-a290-cb982d6d003b",
+          "ref": null,
+          "title": "friendly models/units",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Models/units in your army. (CR, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "096c638e-0fa6-5ba0-9a46-2d398bd9af41",
+          "ref": null,
+          "title": "general",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "You must pick 1 **HERO** in your army to be your general. Certain rules will interact with your general. (AC 2026‑27, 3.2)"
+            }
+          ]
+        },
+        {
+          "id": "008caf6c-2454-5763-9946-43ea398c104e",
+          "ref": null,
+          "title": "Guarded Hero",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Passive ability that all **HEROES** have. If **HERO** is within 3\" of a friendly non-**HERO** unit, then shooting attacks targeting the **HERO** are -1 to hit, and if **HERO** is **INFANTRY**, they also cannot be picked as the target of **shooting attacks** made by models more than 12\" from them. (CR, 25.0)"
+            }
+          ]
+        },
+        {
+          "id": "071023ce-d499-5ac4-a89f-e5a8a7729fe5",
+          "ref": null,
+          "title": "Heal",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Remove a number of damage points that have been allocated to a unit equal to the number in brackets after ‘Heal’. (CR, 21.0)"
+            }
+          ]
+        },
+        {
+          "id": "95ad3652-1601-5fca-b863-527d170da2fc",
+          "ref": null,
+          "title": "Health characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The characteristic that shows the number of damage points that can be allocated to the unit before a model in the unit is slain. (CR, 4.0)"
+            }
+          ]
+        },
+        {
+          "id": "56219f2b-439d-54a6-93eb-7126b8bb885e",
+          "ref": null,
+          "title": "heroic trait",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Enhancement that can be given to a **HERO** in your army. (AC 2026‑27, 4.1)"
+            }
+          ]
+        },
+        {
+          "id": "72ed80a5-1fec-525d-a99c-8d37ed805a49",
+          "ref": null,
+          "title": "hit roll modifiers",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Add up all modifiers to a hit roll and cap at +1 if the result is a positive value or -1 if the result is a negative value. (CR, 17.1)"
+            }
+          ]
+        },
+        {
+          "id": "bfc5a537-6258-571c-a574-7b259c468174",
+          "ref": null,
+          "title": "in combat",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit is in combat if any visible enemy models are within its combat range (within 3\"). (CR, 7.0)"
+            }
+          ]
+        },
+        {
+          "id": "04dd9fbe-b211-5c47-9127-37604f5789f0",
+          "ref": null,
+          "title": "INFANTRY",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit keyword. Models on foot. **INFANTRY** form the backbone of most armies and tend to be good at contesting objectives."
+            }
+          ]
+        },
+        {
+          "id": "22e4af23-4b40-51d0-a02e-cf0d39d6f3e8",
+          "ref": null,
+          "title": "inflict",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Successful attacks inflict damage points. Inflict is not the same as allocate. Ward rolls can be made for inflicted damage points before they are allocated. (CR, 17.0)"
+            }
+          ]
+        },
+        {
+          "id": "b012247d-8fbe-5749-b6f4-5ac30a18fcf6",
+          "ref": null,
+          "title": "invocation",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A type of manifestation summoned by a **PRIEST**. (MG 2026‑27, 7.0)"
+            }
+          ]
+        },
+        {
+          "id": "4d1a033f-babc-5af9-968d-70d33a4681d4",
+          "ref": null,
+          "title": "jump down",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Models can move directly down through the air from a terrain feature to the battlefield. They can do so any distance, but it ends their move (CR, 15.2.1)"
+            }
+          ]
+        },
+        {
+          "id": "78fecbc7-a172-5edb-94d8-517b8da07765",
+          "ref": null,
+          "title": "keyword",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A term that carries **KEYWORD FORMAT**, allowing the thing that has it to be tagged and referenced by other rules. (CR, 5.1)"
+            }
+          ]
+        },
+        {
+          "id": "37b43724-631f-59b4-9028-1608bf47baa7",
+          "ref": null,
+          "title": "Magical Intervention",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 1CP. **WIZARD** or **PRIEST** can cast or chant in enemy hero phase, but -1 to casting/chanting roll. (CM 2026‑27, 2.0)"
+            }
+          ]
+        },
+        {
+          "id": "421ffef8-7f8b-52c8-9ba8-56ce1dd09542",
+          "ref": null,
+          "title": "manifestation lore",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If taken, all **WIZARDS** in your army know all spells from that lore, and all **PRIESTS** in your army know all prayers from that lore. (AC 2026‑27, 4.2)"
+            }
+          ]
+        },
+        {
+          "id": "e5d48aad-9daf-5b7b-b2ac-f92afb39f660",
+          "ref": null,
+          "title": "manifestations",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Arcane or divine entities or phenomena that have their own miniatures and are summoned to the battlefield by a **WIZARD** or **PRIEST**. (MG 2026‑27, 7.0)"
+            }
+          ]
+        },
+        {
+          "id": "cafac494-c032-5ed2-b018-c0bc80471346",
+          "ref": null,
+          "title": "miscast",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Casting roll that contains two or more 1s is a miscast (D3 mortal damage, attempt fails, and caster can’t cast any more spells that phase). (MG 2026‑27, 2.0)"
+            }
+          ]
+        },
+        {
+          "id": "5e6a1a92-f418-5ed5-bd04-d323553d7381",
+          "ref": null,
+          "title": "models",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The warriors in your army are referred to as models and are grouped into units. Some units consist of only 1 model."
+            }
+          ]
+        },
+        {
+          "id": "d3e43a51-81f5-57aa-bd94-f4e0d59e462d",
+          "ref": null,
+          "title": "modifiers (characteristics)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Characteristics cannot be modified to less than 1, with the exception of Rend, which can be modified to 0. Round down any fractions. Set, multiply or divide, then add or subtract, in that order (if more than one modifier applies). (CR, 27.0)"
+            }
+          ]
+        },
+        {
+          "id": "bd4c0471-ae08-56bd-b738-6503bfa35239",
+          "ref": null,
+          "title": "modifiers (dice rolls)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Many rules let you change the result of a dice roll. Sometimes, multiple modifiers will apply to the same roll. Modifiers to some types of rolls, such as hit and wound rolls, are capped."
+            }
+          ]
+        },
+        {
+          "id": "618f2e44-4e6a-557a-acc8-2974977c0d75",
+          "ref": null,
+          "title": "MONSTER",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit keyword. **MONSTERS** are large and imposing units, often consisting of a single model that can have a large impact all by itself."
+            }
+          ]
+        },
+        {
+          "id": "1386e6e6-4bd3-544c-8f25-fb1ad350d845",
+          "ref": null,
+          "title": "mortal damage",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If mortal damage is inflicted, just add that many damage points to the damage pool. (CR, 17.2)"
+            }
+          ]
+        },
+        {
+          "id": "b066cefa-adb8-535e-920d-cde2294d5947",
+          "ref": null,
+          "title": "mount trait",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Enhancement that can be given to a **HERO** riding a warbeast. (AC 2026‑27, 4.1)"
+            }
+          ]
+        },
+        {
+          "id": "d91acb22-3162-5a16-a3db-b040c79f6729",
+          "ref": null,
+          "title": "Move characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Characteristic that determines the number of inches a unit can move across the battlefield when using certain abilities, most commonly Normal Move. (CR, 4.0)"
+            }
+          ]
+        },
+        {
+          "id": "f9442892-6bfe-56be-96ad-26dc20b08195",
+          "ref": null,
+          "title": "Musician",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "While unit contains any musicians, if it uses the ‘Rally’ command, make 1 additional rally roll of D6. (CMOD 2026‑27, 2.0)"
+            }
+          ]
+        },
+        {
+          "id": "094edef9-9a6a-5528-9cd6-0a6e3b831631",
+          "ref": null,
+          "title": "neutral territory",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The area of the battlefield that is neither player’s territory. (CR, 9.1.2)"
+            }
+          ]
+        },
+        {
+          "id": "190ef83e-581c-5046-8aec-b4e51228dfa6",
+          "ref": null,
+          "title": "Normal Move",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Your Movement Phase. Move each model in unit up to Move characteristic but models cannot move into combat. (CR, 14.1)"
+            }
+          ]
+        },
+        {
+          "id": "4ff8ded2-212a-563e-b7f1-6a008adbfb87",
+          "ref": null,
+          "title": "objectives",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Many battleplans require players to gain control of specific points on the battlefield to secure victory. Objectives are represented by 40mm round markers. Models can move over and end a move on an objective marker. (CR, 32.0)"
+            }
+          ]
+        },
+        {
+          "id": "60a42e4c-8caa-5e87-970a-2cacd2281a6f",
+          "ref": null,
+          "title": "Obscuring",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If all a unit’s models are within 1\" of this terrain (unless **WAR MACHINE**, **MONSTER** or has **FLY**), the Range of its ranged weapons is halved and it is not visible to enemy units outside its combat range. (TR 2026‑27, 1.2)"
+            }
+          ]
+        },
+        {
+          "id": "ac808744-9413-5197-96be-58baaf04f144",
+          "ref": null,
+          "title": "passive abilities",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The effects of passive abilities are applied any time their conditions are met. You cannot use reactions in response to passive abilities. (CR, 5.4)"
+            }
+          ]
+        },
+        {
+          "id": "ffb56398-dc82-5b78-88c2-22616c0315e0",
+          "ref": null,
+          "title": "persisting abilities",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Abilities that have effects that last for a specified length of time, for example, ‘add 1 to wound rolls for attacks made by this unit until the start of your next turn.’"
+            }
+          ]
+        },
+        {
+          "id": "6dafbb0b-752c-551b-8b65-c76380ab7894",
+          "ref": null,
+          "title": "phases",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "There are 7 phases in each turn: Start of Turn, Hero Phase, Movement Phase, Shooting Phase, Charge Phase, Combat Phase, End of Turn. Ability timings can be Your Phase (you are the active player), Enemy Phase (opponent is active player) or Any Phase (either player is active player). (CR, 13.0)"
+            }
+          ]
+        },
+        {
+          "id": "75898cf5-6004-5749-8891-3fd090fb9e62",
+          "ref": null,
+          "title": "pile-in",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A short move, usually 3\", that allows a unit using a **FIGHT** ability to get a bit closer to the unit(s) it is in combat with. (CR, 15.3)"
+            }
+          ]
+        },
+        {
+          "id": "84c4e96f-0462-58e6-ab63-bdce532a0012",
+          "ref": null,
+          "title": "Place of Power",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "**HEROES** within 3\" of this terrain feature can use the ‘Activate Place of Power’ ability. (TR 2026‑27, 1.2)"
+            }
+          ]
+        },
+        {
+          "id": "639543fe-ba73-5d4e-a8a7-5ef02ba4d585",
+          "ref": null,
+          "title": "points limit",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The combined points cost of units in your army cannot exceed the points limit for the battle. Players usually agree on the points limit before the battle, but it may be pre-determined by the battlepack being used. (AC 2026‑27, 1.2)"
+            }
+          ]
+        },
+        {
+          "id": "4bf417d0-de47-5e47-a590-9adb9d1cbcd5",
+          "ref": null,
+          "title": "power level",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The number in brackets after the **WIZARD** or **PRIEST** keyword. A **WIZARD**’s casting power level determines the number of **SPELL** abilities they can use per phase. A **PRIEST**’s casting power level determines the number of **PRAYER** abilities they can use per phase. (MG 2026‑27, 1.1)"
+            }
+          ]
+        },
+        {
+          "id": "98994645-705f-54e4-b4a8-83790512a8ef",
+          "ref": null,
+          "title": "prayer",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A special type of ability that can only be used by **PRIESTS**. (MG 2026‑27, 3.0)"
+            }
+          ]
+        },
+        {
+          "id": "ee0179be-c5b9-5a3d-9a49-6042c8e11f25",
+          "ref": null,
+          "title": "prayer lore",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If taken, all eligible **PRIESTS** in your army know the prayers from that lore. (AC 2026‑27, 4.2)"
+            }
+          ]
+        },
+        {
+          "id": "7f6cf1f3-b292-5324-9f83-da2883869f90",
+          "ref": null,
+          "title": "PRIEST",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Unit that can use prayers. (MG 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "3942fafe-ac52-5f05-8cc6-1bb0159f1c40",
+          "ref": null,
+          "title": "Rally",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, Any Hero Phase, 1CP. Roll 6 dice; for each 4+, gain 1 rally point. For each rally point, **Heal (1)** or spend a number of rally points equal to Health characteristic to return 1 slain model. (CM 2026‑27, 2.0)"
+            }
+          ]
+        },
+        {
+          "id": "06d6c347-5ae4-58ec-a3f0-901da7af22df",
+          "ref": null,
+          "title": "random characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Generate the characteristic before applying modifiers, and each time it is needed for an ability. Random Attacks characteristics are generated per **ATTACK** ability; other random weapon characteristics are generated per attack made with the weapon. (CR, 26.0)"
+            }
+          ]
+        },
+        {
+          "id": "c854cd25-154e-5503-9b34-84c889675b2c",
+          "ref": null,
+          "title": "Range characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A characteristic, most often on weapon profiles, that determines how close something must be for it to be an eligible target. (CR, 16.0)"
+            }
+          ]
+        },
+        {
+          "id": "085f3255-6e02-5945-9ba7-311eacffe554",
+          "ref": null,
+          "title": "Reaction",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "After an ability is declared, starting with the player using the ability, players alternate using any eligible reactions they wish to. Then the effect of the ability is resolved. (CR, 5.2)"
+            }
+          ]
+        },
+        {
+          "id": "5d47159f-760b-5bba-b865-5d8e2819cdf3",
+          "ref": null,
+          "title": "Redeploy",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Command, 1CP. D6\" move in enemy movement phase. (CM 2026‑27, 3.0)"
+            }
+          ]
+        },
+        {
+          "id": "842cdce1-6fb3-5533-af32-c75992186f28",
+          "ref": null,
+          "title": "regiment",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A group of units, including a **HERO**, that are taken as a set during Army Composition. Regiments often allow multiple units to be deployed at the same time. (AC 2026‑27, 3.1)"
+            }
+          ]
+        },
+        {
+          "id": "dce79545-3d9d-5835-ab74-bc7d4f10d1a4",
+          "ref": null,
+          "title": "Regiment of Renown",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A fixed regiment that has its own rules for including it in an army and may also have a special ability or abilities. (AC 2026‑27, 3.5)"
+            }
+          ]
+        },
+        {
+          "id": "70400b95-d91e-5161-b38a-00c628af8d41",
+          "ref": null,
+          "title": "regimented forces",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If a player has more regiments at the start of the battle, they can, once per battle, re- roll their priority roll after seeing the result of the rolls. (AC 2026-27, 3.1.1)"
+            }
+          ]
+        },
+        {
+          "id": "c6030941-8540-5cbc-83fd-f3f5e694760f",
+          "ref": null,
+          "title": "reinforced unit",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit whose minimum unit size and points cost is doubled when you add it to your army. You cannot reinforce units with a minimum unit size of 1. (AC 2026‑27, 3.3)"
+            }
+          ]
+        },
+        {
+          "id": "8833fca6-cc64-528f-9b58-3e8b38ccd8bc",
+          "ref": null,
+          "title": "removed from play/removed from the battlefield",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "When a model or unit is removed from the battlefield, it no longer has any effect on the battle, though it can still be relevant for abilities that allow you to return models or replace units."
+            }
+          ]
+        },
+        {
+          "id": "8d8e72fd-2a45-5af9-b711-b515b5a7cb86",
+          "ref": null,
+          "title": "Rend characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Subtract the Rend of the weapon from save rolls made for the target unit. (CR, 17.0)"
+            }
+          ]
+        },
+        {
+          "id": "1139dd53-0b15-5a79-9009-21b92233d7c5",
+          "ref": null,
+          "title": "replace roll",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Instead of rolling the dice, use the specified fixed value."
+            }
+          ]
+        },
+        {
+          "id": "1e597f43-400f-54b8-b03b-e0b3ca3cb995",
+          "ref": null,
+          "title": "replacement unit",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit that is brought back to the battlefield after it has been destroyed. Although the same miniatures are used, the unit counts as an entirely new unit in the rules, unless specified otherwise. (CR, 24.2)"
+            }
+          ]
+        },
+        {
+          "id": "57bea115-041d-501e-aab4-02c53cde8d12",
+          "ref": null,
+          "title": "reserves/in reserve",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit set up in reserve is set up off the battlefield and will be set up on the battlefield at a specified time once the battle is under way. (CR, 24.1)"
+            }
+          ]
+        },
+        {
+          "id": "8ae370b1-6c8c-532f-b79c-45b9c2a482b8",
+          "ref": null,
+          "title": "Retreat",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Your Movement Phase. Inflict D3 mortal damage on the unit then move it out of combat. Cannot use **SHOOT** or **CHARGE** abilities later in turn. (CR, 14.1)"
+            }
+          ]
+        },
+        {
+          "id": "aa659701-27b3-5715-a7cc-5d666dd5337f",
+          "ref": null,
+          "title": "return slain model",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Set up model that was slain with no damage points allocated to it and within coherency range of models in its unit not returned/added this phase. If unit will have 7+ models, set up model within coherency range of at least 2 other models. Only set up in combat if its unit is already in combat. (CR, 22.0)"
+            }
+          ]
+        },
+        {
+          "id": "aee15863-90c1-58d6-b208-0704ae3f4662",
+          "ref": null,
+          "title": "roll off",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Each player rolls a D6; player who rolls highest wins. If tied, keep rolling off until there is a winner. (CR, 2.2)"
+            }
+          ]
+        },
+        {
+          "id": "1e30e7a4-0bc8-5037-a7cf-6b4c74da2a23",
+          "ref": null,
+          "title": "Run",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Your Movement Phase. Roll D6 and add to unit’s Move, then move unit up to that distance. Cannot use **SHOOT** or **CHARGE** abilities later in turn. (CR, 14.1)"
+            }
+          ]
+        },
+        {
+          "id": "4612cd5b-470b-550c-b21b-7000d14b111a",
+          "ref": null,
+          "title": "Sacred Rites",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Your Hero Phase, give a number of ritual points to the chanter equal to the chanting roll; remove 1 instead of D3 on an unmodified chanting roll of 1. (MG 2026‑27, 3.0)"
+            }
+          ]
+        },
+        {
+          "id": "6a238677-50a3-5620-bb6d-f9f4cd360230",
+          "ref": null,
+          "title": "Save characteristic",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The number you need to equal or beat to make a successful save roll for the unit. Attacks that are saved do not inflict damage points. (CR, 4.0)"
+            }
+          ]
+        },
+        {
+          "id": "3457d218-7289-5a15-8968-0c0dd413505e",
+          "ref": null,
+          "title": "save roll modifiers",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Save roll modifiers are capped at +1 but there is no negative cap. (CR, 17.1)"
+            }
+          ]
+        },
+        {
+          "id": "44227bc4-a18e-5e96-9cb1-31f8daf83ced",
+          "ref": null,
+          "title": "seize the initiative",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If you choose to take the double turn and are not behind by 11 or more VPs, your opponent counts as the underdog until they seize the initiative. (BT 2026‑27, 2.0)"
+            }
+          ]
+        },
+        {
+          "id": "605b656a-e38b-5680-a3f8-81d06611efbe",
+          "ref": null,
+          "title": "set up",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "When setting up a unit, all models in the unit must be set up, otherwise the ability cannot be used. A unit set up on the battlefield in a phase other than the deployment phase cannot use **MOVE** abilities in the movement phase of the same turn. (CR, 24.0)"
+            }
+          ]
+        },
+        {
+          "id": "31d5a516-262b-566f-bfa4-fae4912f970c",
+          "ref": null,
+          "title": "Shoot",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Your Shooting Phase. Attack with ranged weapons. Units cannot shoot if they are in combat. (CR, 14.2)"
+            }
+          ]
+        },
+        {
+          "id": "ae4ed2bd-9f15-55f0-b4dd-bcc10ae8040e",
+          "ref": null,
+          "title": "Shoot in Combat",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Weapon ability. Weapon can be used to make shooting attacks even if attacking unit is in combat. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "f25661f5-759a-5109-972a-5f9b7957af87",
+          "ref": null,
+          "title": "slain",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A model in a unit is slain each time the number of damage points allocated to the unit equals its Health characteristic. Each time a model is slain, the number of damage points allocated to the unit resets to 0. If there are still damage points in the damage pool, keep allocating them and removing slain models until there are no damage points left. (CR, 18.2)"
+            }
+          ]
+        },
+        {
+          "id": "f43d94d2-e6c1-523b-986b-0fb1b7826b7f",
+          "ref": null,
+          "title": "slain by",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A model is said to have been slain by a unit when an attack made by or an ability used by that unit caused that model to be slain."
+            }
+          ]
+        },
+        {
+          "id": "f70a30ad-7caa-5e5a-9dd3-69f83f16aff1",
+          "ref": null,
+          "title": "spell",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A special type of ability that can only be used by **WIZARDS**. (MG 2026‑27, 2.0)"
+            }
+          ]
+        },
+        {
+          "id": "97aaf0cc-b82b-5e6c-8d86-8eccabdeb151",
+          "ref": null,
+          "title": "spell lore",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If taken, all eligible **WIZARDS** in your army know the spells from that lore. (AC 2026‑27, 4.2)"
+            }
+          ]
+        },
+        {
+          "id": "62d39117-c729-55e2-a0bf-ab1bb3d0d16c",
+          "ref": null,
+          "title": "Standard Bearer",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Add 1 to the control score of units with any standard bearers. (CMOD 2026‑27, 3.0)"
+            }
+          ]
+        },
+        {
+          "id": "5dc15d1e-4575-54ab-89f7-cb08bb979ae0",
+          "ref": null,
+          "title": "straight line",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "If a rule asks you to draw a line between two points, it is assumed to be an imaginary line 1mm wide."
+            }
+          ]
+        },
+        {
+          "id": "8f5cc104-c604-5bed-890e-8a21daf966fd",
+          "ref": null,
+          "title": "STRIKE-FIRST",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Units with this keyword use **FIGHT** abilities **before** units that don’t have this keyword. If both players have units with **STRIKE-FIRST**, they alternate fighting with those units before other units get to fight, starting with the active player. After those units have fought, the active player chooses the next unit to fight. (CR, 19.0)"
+            }
+          ]
+        },
+        {
+          "id": "a40456f5-448e-50dd-859a-896cba347f33",
+          "ref": null,
+          "title": "STRIKE-LAST",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Units with this keyword use **FIGHT** abilities after all units that don’t have this keyword. If both players have units with **STRIKE-LAST**, they alternate fighting with those units after all other eligible units have fought. (CR, 19.0)"
+            }
+          ]
+        },
+        {
+          "id": "d94b111b-6498-5d1a-84c6-ae4141d8dee1",
+          "ref": null,
+          "title": "summon",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Manifestations are summoned to the battlefield using the spell or prayer in their manifestation lore. (MG 2026‑27, 7.0)"
+            }
+          ]
+        },
+        {
+          "id": "b1d5c978-765f-56d0-9dd7-0311a1d8bfb1",
+          "ref": null,
+          "title": "target (attacks)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "You must declare the targets of all the attacks you are making with a unit before following the attack sequence for those attacks, and you can split attacks freely between eligible target units. (CR, 16.0)"
+            }
+          ]
+        },
+        {
+          "id": "cd2ec7f0-3cd3-5aa2-a63f-71c54491cba8",
+          "ref": null,
+          "title": "terrain features",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Models that reflect the battlefield environment. They often have their own rules. (TR 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "1a86434d-ae0f-5fdb-86db-b28df965d36c",
+          "ref": null,
+          "title": "territory (within/wholly within)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit is within a territory if any part of the base of any model in the unit is within that territory. A unit is wholly within a territory if all parts of the bases of all models in the unit are within that territory. (CR, 9.1.2)"
+            }
+          ]
+        },
+        {
+          "id": "704945e7-ba67-542c-8451-c262045a80d1",
+          "ref": null,
+          "title": "timing",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "The part of an ability that specifies when it can be used. Usually appears as a colour-coded bar at the top of the ability. (CR, 5.2)"
+            }
+          ]
+        },
+        {
+          "id": "a60d9a4c-5c1b-5a14-ae5d-de4cac6581f9",
+          "ref": null,
+          "title": "token",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Tokens are not considered models for rules purposes. Their main purpose is to act as reminders for persisting effects that apply to specific units. They are otherwise ignored and can be freely moved if they get in the way. (CR, 23.0)"
+            }
+          ]
+        },
+        {
+          "id": "7f476131-9e2e-57b5-9964-65b5a48f56ac",
+          "ref": null,
+          "title": "turns",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Each battle round consists of 2 turns (1 for each player), each comprising 7 phases. The player whose turn is taking place is the active player. (CR, 11.0)"
+            }
+          ]
+        },
+        {
+          "id": "7e2900de-a7d4-562b-ae3a-201be191fba3",
+          "ref": null,
+          "title": "Unbind",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Reaction to a **SPELL** ability. Make an unbinding roll of 2D6. If the roll beats the casting roll, the Spell ability fails. (MG 2026‑27, 4.0)"
+            }
+          ]
+        },
+        {
+          "id": "821f6a23-d498-5447-b7c3-eb0c208077b6",
+          "ref": null,
+          "title": "underdog",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Player with fewest victory points. If tied, there is no underdog for that battle round. (CR, 12.0)"
+            }
+          ]
+        },
+        {
+          "id": "aa924807-3a5c-50ba-af2c-ef69c89e8401",
+          "ref": null,
+          "title": "UNIQUE",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit with this keyword can only be included in your army once. (AC 2026‑27, 3.4)"
+            }
+          ]
+        },
+        {
+          "id": "4f4408d3-93d9-5788-8544-61dbfb3f3f95",
+          "ref": null,
+          "title": "unique enhancements",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Special types of enhancement that some factions have access to. They will be accompanied by rules that tell you which units can be given them."
+            }
+          ]
+        },
+        {
+          "id": "44c8f147-5fe0-53b3-8ace-4ee70a2cdd9c",
+          "ref": null,
+          "title": "units",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A group of models that move and fight together. An army is made up of a number of units. Each unit has a warscroll that details its characteristics and abilities."
+            }
+          ]
+        },
+        {
+          "id": "a65ec33a-fc70-541b-a505-5ff8fa22c85d",
+          "ref": null,
+          "title": "Unstable",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Models can move across but cannot be set up on or end a move on parts of this terrain feature taller than 1\". (TR 2026‑27, 1.2)"
+            }
+          ]
+        },
+        {
+          "id": "e89dc40a-11e6-5681-8316-7be9853ba5a3",
+          "ref": null,
+          "title": "used",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "An ability has been used once it has been declared, whether or not its effect was successfully resolved. (CR, 5.2)"
+            }
+          ]
+        },
+        {
+          "id": "cedee827-0298-5fe6-b7bd-687b7f790687",
+          "ref": null,
+          "title": "visible",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "An observing model can see a target model if you could draw a straight line from any point on the observing model to the target model without it crossing any objects except other models in the observing model’s unit. A model is always visible to itself. (CR, 6.0)"
+            }
+          ]
+        },
+        {
+          "id": "aeddd35c-cb8f-52ef-bcd8-c9df226b3f72",
+          "ref": null,
+          "title": "WARD",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Before you allocate an inflicted damage point to a unit that has this keyword, you can make a ward roll. If the result equals or beats the number in brackets after **WARD**, that damage point is negated and ignored. (CR, 18.1)"
+            }
+          ]
+        },
+        {
+          "id": "1ca81d96-d50e-51f0-90c7-ac0c1077eb88",
+          "ref": null,
+          "title": "warscroll",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Every unit has a warscroll, which includes vital information that determines the unit’s capabilities in battle. (CR, 4.0)"
+            }
+          ]
+        },
+        {
+          "id": "a2e8b648-e286-53f8-9295-1bd40ecf8f76",
+          "ref": null,
+          "title": "weapon ability",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A passive ability that affects attacks made with the weapon that has the ability. (CR, 20.0)"
+            }
+          ]
+        },
+        {
+          "id": "1e1a4da8-4425-561b-a84c-a9ec337396af",
+          "ref": null,
+          "title": "wholly on a terrain feature",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "A unit is wholly on terrain if all parts of the bases of all models in the unit are on the same terrain feature. (TR 2026‑27, 1.1)"
+            }
+          ]
+        },
+        {
+          "id": "39df42c7-e8ab-5c9d-8158-e90959a58d26",
+          "ref": null,
+          "title": "wholly within (model)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "*model x* is wholly within a distance of *y* if every part of *model x’s* base is within that distance of *y*."
+            }
+          ]
+        },
+        {
+          "id": "5c100beb-93b3-5a84-b41f-ada8c0030e51",
+          "ref": null,
+          "title": "wholly within (unit)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "*unit x* is wholly within a distance of *y* if every part of all the bases of all the models in *unit x* is within that distance of *y*."
+            }
+          ]
+        },
+        {
+          "id": "4f3e03f9-b78c-5e8e-a7fb-fca389fd7f88",
+          "ref": null,
+          "title": "within (model)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "*model x* is within a specified distance of *y* if any part of *model x’s* base is within that distance of *y*."
+            }
+          ]
+        },
+        {
+          "id": "82bec86e-67bd-5007-9997-258522f82d37",
+          "ref": null,
+          "title": "within (unit)",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "*unit x* is within a specified distance of *y* if any part of the base of any model in *unit x* is within that distance of *y.*"
+            }
+          ]
+        },
+        {
+          "id": "7a6c814c-f7c9-5778-8091-4e0063f5981b",
+          "ref": null,
+          "title": "WIZARD",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Unit that can use spells (MG 2026‑27, 1.0)"
+            }
+          ]
+        },
+        {
+          "id": "4f922190-dd1e-5c9e-b3a3-d84870fbbb88",
+          "ref": null,
+          "title": "wound roll modifiers",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Add up all modifiers to a wound roll and cap at +1 if the result is a positive value or -1 if the result is a negative value. (CR, 17.1)"
+            }
+          ]
+        },
+        {
+          "id": "6ef13e80-b2a0-5b49-ad5d-c9a3e4800998",
+          "ref": null,
+          "title": "Your (…) Phase",
+          "subtitle": null,
+          "containerType": "standard",
+          "updateType": null,
+          "components": [
+            {
+              "type": "text",
+              "text": "Timing. Only the active player can use abilities with this timing. (CR, 13.0)"
+            }
+          ]
+        }
+      ],
+      "sections": []
+    }
+  ]
+}

--- a/aos/gdc/rules/index.json
+++ b/aos/gdc/rules/index.json
@@ -1,0 +1,27 @@
+{
+  "updated": "2026-07-05T15:43:07.872Z",
+  "compatibleDataVersion": 446,
+  "files": {
+    "core_rules.json": {
+      "groups": 8,
+      "sections": 46,
+      "containers": 125,
+      "components": 281
+    },
+    "glossary.json": {
+      "name": "Glossary 2026-27",
+      "sections": 1,
+      "containers": 171,
+      "components": 174
+    },
+    "advanced_rules.json": {
+      "name": "General's Handbook 2026-27: Advanced Rules",
+      "sections": 29,
+      "containers": 56,
+      "components": 90
+    },
+    "faqs.json": {
+      "entries": 29
+    }
+  }
+}


### PR DESCRIPTION
## What

First output of the new `readCoreRules.mjs` pipeline extractor (see the companion datasources-pipeline PR): `aos/gdc/rules/` with five files generated from the `data-export-446` archive.

- **`core_rules.json`** — the complete AoS Core Rules: 8 groups, numbered sections 1.0–33.0, 125 containers / 281 components with resolved abilities, plus Addenda (8), Errata (12) and FAQ (29) containers tagged with their `updateType`.
- **`glossary.json`** — Glossary 2026-27.
- **`advanced_rules.json`** — General's Handbook 2026-27: Advanced Rules.
- **`faqs.json`** — the aggregated rules FAQ set (Core Rules + Advanced Rules + Matched Play Battlepack + Glossary sources; no faction FAQs).
- **`index.json`** — counts + compatible data version (446).

These feed the Core Rules browser and FAQ page on aosmissions.app. Future dumps regenerate them automatically once the pipeline PR is merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcXK9xr3ssZj7su3QNwsA9)_