### PR TITLE
40k 11th: add detachment points cost and force disposition to detachments

### DIFF
--- a/11th/gdc/adeptasororitas.json
+++ b/11th/gdc/adeptasororitas.json
@@ -337,14 +337,42 @@
       "name": {
         "en": "Penitent Host"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "5e3bb5a9-1e75-455e-a87d-13e59948be68",
       "name": {
         "en": "Hallowed Martyrs"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "730c8f71-c997-4071-98f0-8aa377e762f3",
@@ -358,7 +386,21 @@
         "ko": "규탄의 합창",
         "zh": "定罪合唱"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "7cf2f061-bc54-4c2f-be17-2959cf840fdf",
@@ -372,21 +414,63 @@
         "ko": "축성받은 연설가",
         "zh": "祝圣演说者"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "c0a5cd98-3a84-4074-ad62-b4d848d2bcf6",
       "name": {
         "en": "Bringers of Flame"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "c1eaf854-a425-4cc8-b29e-557b8b89f8c1",
       "name": {
         "en": "Champions of Faith"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "d8dfdc5f-4e0b-4233-8f2f-2ee703664afb",
@@ -400,14 +484,42 @@
         "ko": "거룩한 용사회",
         "zh": "神圣冠军"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "f3dbfd5c-d553-436f-9617-4c8269cb5b09",
       "name": {
         "en": "Army of Faith"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/adeptuscustodes.json
+++ b/11th/gdc/adeptuscustodes.json
@@ -327,21 +327,63 @@
       "name": {
         "en": "Lions of the Emperor"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "2ed9481a-9f80-4e78-8931-b8070fef82e3",
       "name": {
         "en": "Auric Champions"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "3cb02267-28e0-4dab-9ff3-976caa1b7a31",
       "name": {
         "en": "Solar Spearhead"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "4edac749-d510-4161-b3c3-1fd31e91cfcf",
@@ -355,7 +397,21 @@
         "ko": "강대한 모리토이",
         "zh": "亡者之势"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "58dd1c38-27e6-4ccf-a7f5-53068e61b838",
@@ -369,14 +425,42 @@
         "ko": "침묵 속의 사냥꾼",
         "zh": "寂静猎手"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "71a22085-3750-4339-bd18-7b7511e831ee",
       "name": {
         "en": "Shield Host"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "92ae3afb-c5d5-41a9-80da-8db33c91ed41",
@@ -390,21 +474,63 @@
         "ko": "타라나토이 맹격대",
         "zh": "雷灭锤击"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "b70a6b14-333a-4f04-a3c3-b3341e48c08c",
       "name": {
         "en": "Null Maiden Vigil"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "f0e490e7-c6e3-4c51-9162-93dca988eee5",
       "name": {
         "en": "Talons of the Emperor"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/adeptusmechanicus.json
+++ b/11th/gdc/adeptusmechanicus.json
@@ -467,7 +467,21 @@
       "name": {
         "en": "Haloscreed Battle Clade"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "40fdf203-095d-45f2-9678-3a0e7c30346d",
@@ -481,7 +495,21 @@
         "ko": "광휘성 자동성가대",
         "zh": "启明​​自动合唱团"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "8a1e297b-d845-493b-9371-1e245b85b98a",
@@ -495,28 +523,84 @@
         "ko": "제조소의 영주",
         "zh": "熔炉领主"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "8affc9e3-5c18-407d-9221-78bb107b7bd5",
       "name": {
         "en": "Cohort Cybernetica"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "a3be11dc-9a25-4d6b-90a2-1828e6d2d10b",
       "name": {
         "en": "Skitarii Hunter Cohort"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "a6cedc66-4c91-4957-b8c3-fa1b30fd8f5a",
       "name": {
         "en": "Data-psalm Conclave"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "b8fe0260-4813-45c4-996b-1622ae022223",
@@ -530,28 +614,84 @@
         "ko": "취득 코호트",
         "zh": "求知大队"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "cdf5ae0a-7913-4ebc-b7c8-949f48e869f8",
       "name": {
         "en": "Explorator Maniple"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "e00b5962-4b5a-4857-bb5d-d1372e762d2f",
       "name": {
         "en": "Rad-Zone Corps"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "ef26ded5-b525-47c9-8329-deaab91c2c74",
       "name": {
         "en": "Eradication Cohort"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/aeldari.json
+++ b/11th/gdc/aeldari.json
@@ -600,21 +600,63 @@
       "name": {
         "en": "Ghosts of the Webway"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "116e5e49-e39e-4e06-9b10-c7d7d77defdb",
       "name": {
         "en": "Windrider Host"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "2651d2ae-b43a-4576-9e58-6d5275c89350",
       "name": {
         "en": "Serpent’s Brood"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "28ea8bf8-1cb6-4ae3-b0c7-2a171e5dc29f",
@@ -628,14 +670,42 @@
         "ko": "운명적 공연",
         "zh": "宿命的演出"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "33492cd0-2688-4ce1-b174-2f5a7b31a54b",
       "name": {
         "en": "Spirit Conclave"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "366e2930-9de3-4494-bcee-e6fed3c3ad1e",
@@ -649,35 +719,105 @@
         "ko": "깜빡이는 어스름",
         "zh": "暮光闪现"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "3b0ed811-f339-4f72-ba0b-532a04a18089",
       "name": {
         "en": "Devoted of Ynnead"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "43121bed-ff37-44a9-8c6c-44f29cf2c858",
       "name": {
         "en": "Guardian Battlehost"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "6fe9602c-f133-4a56-9d82-c9137a9ecc10",
       "name": {
         "en": "Corsair Coterie"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "9915f243-6846-46c2-a616-701659f50a8e",
       "name": {
         "en": "Eldritch Raiders"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "ab0126f1-e344-469a-8125-2838fdcefe8d",
@@ -691,7 +831,21 @@
         "ko": "방랑의 길",
         "zh": "流放者之道"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "b58e871b-db2a-47e2-a6cb-38e6db200209",
@@ -705,28 +859,84 @@
         "ko": "기갑 천군",
         "zh": "装甲战群"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "b5d7418d-8a4d-42c8-86d8-b8a0c5c788aa",
       "name": {
         "en": "Seer Council"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "df808d6f-3013-4a9b-8a6f-0b68785891d0",
       "name": {
         "en": "Warhost"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "fc9dead1-222d-4925-bf9c-ba18c4121f50",
       "name": {
         "en": "Aspect Host"
       },
-      "faction": "Asuryani"
+      "faction": "Asuryani",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/agents.json
+++ b/11th/gdc/agents.json
@@ -292,35 +292,105 @@
       "name": {
         "en": "Imperialis Fleet"
       },
-      "faction": "Agents of the Imperium"
+      "faction": "Agents of the Imperium",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "6a6e3903-1b61-4706-8fc7-e48729a9880d",
       "name": {
         "en": "Ordo Hereticus, Purgation Force"
       },
-      "faction": "Agents of the Imperium"
+      "faction": "Agents of the Imperium",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "be6ba720-81c6-4dbc-8a37-1d61b4564f60",
       "name": {
         "en": "Veiled Blade Elimination Force"
       },
-      "faction": "Agents of the Imperium"
+      "faction": "Agents of the Imperium",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "e072fa96-aa3e-4a5f-ba03-376879f16c7f",
       "name": {
         "en": "Ordo Xenos, Alien Hunters"
       },
-      "faction": "Agents of the Imperium"
+      "faction": "Agents of the Imperium",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "e89bc216-2de7-4cf9-a640-2dcbfde06b56",
       "name": {
         "en": "Ordo Malleus, Daemon Hunters"
       },
-      "faction": "Agents of the Imperium"
+      "faction": "Agents of the Imperium",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/astramilitarum.json
+++ b/11th/gdc/astramilitarum.json
@@ -443,35 +443,105 @@
       "name": {
         "en": "Armoured Infantry"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "3062acc0-d72e-471a-bbd1-26598bc30ec4",
       "name": {
         "en": "Recon Element"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "4fa424ac-a7aa-4830-b497-45c89aae7fbb",
       "name": {
         "en": "Hammer of the Emperor"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "660a5970-862e-4ea0-8365-1901adb404be",
       "name": {
         "en": "Steel Hammer"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "6ae8f235-c8b0-4485-8e18-505b6926f1b2",
       "name": {
         "en": "Combined Arms"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "7b0fe28b-5a8e-48cd-bbe7-699babfbd463",
@@ -485,7 +555,21 @@
         "ko": "아인종 보조군",
         "zh": "亚人类辅助军"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "7c12acc3-f2ae-4fa7-b80b-03dae96b72da",
@@ -499,14 +583,42 @@
         "ko": "지정 부대",
         "zh": "指示部队"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "8f29b4e9-92c8-450f-8d35-5561c49e8803",
       "name": {
         "en": "Grizzled Company"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "aae77907-0898-4c11-8a9e-a866a3e67456",
@@ -520,21 +632,63 @@
         "ko": "교두보 타격대",
         "zh": "桥头堡突袭军"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "c3170734-b810-4e24-8244-0371f715ff9c",
       "name": {
         "en": "Mechanised Assault"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "f284cddb-5060-44ff-abbb-a2876dedcf18",
       "name": {
         "en": "Siege Regiment"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/blacktemplar.json
+++ b/11th/gdc/blacktemplar.json
@@ -312,14 +312,42 @@
         "ko": "살아있는 기적",
         "zh": "活奇迹"
       },
-      "faction": "Black Templars"
+      "faction": "Black Templars",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "88882c56-6492-4cd0-8b73-34e1c80e55ae",
       "name": {
         "en": "Companions of Vehemence"
       },
-      "faction": "Black Templars"
+      "faction": "Black Templars",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "aab75a4c-d486-47e0-b800-caf0028b62c8",
@@ -333,14 +361,42 @@
         "ko": "분노의 행렬",
         "zh": "愤怒巡游队"
       },
-      "faction": "Black Templars"
+      "faction": "Black Templars",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "b22f1234-d890-401a-b6cb-cf03bc1b5505",
       "name": {
         "en": "Vindication Task Force"
       },
-      "faction": "Black Templars"
+      "faction": "Black Templars",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "b78cbc68-a012-494f-bd72-91873b382204",
@@ -354,14 +410,42 @@
         "ko": "마샬 가문",
         "zh": "元帅亲军"
       },
-      "faction": "Black Templars"
+      "faction": "Black Templars",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "d8ec92c4-5d86-4e48-a27e-fab751c097ac",
       "name": {
         "en": "Godhammer Assault Force"
       },
-      "faction": "Black Templars"
+      "faction": "Black Templars",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/bloodangels.json
+++ b/11th/gdc/bloodangels.json
@@ -306,21 +306,63 @@
       "name": {
         "en": "The Lost Brethren"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "2de2e2bc-8c9a-415e-ad61-11a8c2704590",
       "name": {
         "en": "Angelic Inheritors"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "5f032619-a925-4e61-8d52-5d2e5f81311f",
       "name": {
         "en": "Liberator Assault Group"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "6c2b0c94-4bce-40ba-b6cc-8effe9e5efff",
@@ -334,21 +376,63 @@
         "ko": "은총의 유산",
         "zh": "优雅传承"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "8351fbfa-edd6-4db9-a21d-400c05f1e9f1",
       "name": {
         "en": "The Angelic Host"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "98d89ce1-bf5b-49f5-bbcc-cba5e32659e5",
       "name": {
         "en": "Rage-cursed Onslaught"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "b5a5858b-3187-44f3-95af-e34dfe7eb7c9",
@@ -362,7 +446,21 @@
         "ko": "저주받은 이들의 분노",
         "zh": "迷失者的怒火"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "ce2408b7-6810-4219-9f28-3c20499f0e13",
@@ -376,7 +474,21 @@
         "ko": "혈염의 선봉대",
         "zh": "血色矛头"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/chaos_spacemarines.json
+++ b/11th/gdc/chaos_spacemarines.json
@@ -588,28 +588,84 @@
       "name": {
         "en": "Huron’s Marauders"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "1a658734-6ba0-4fe7-8f05-ddf084cc694d",
       "name": {
         "en": "Renegade Raiders"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "3fe68451-1e4f-41e0-85a9-ecaf0d20e60c",
       "name": {
         "en": "Fellhammer Siege-host"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "41e763bc-5f5c-4e65-be45-9c168c962033",
       "name": {
         "en": "Deceptors"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "64363c88-2015-4700-9f88-ac03407213db",
@@ -623,7 +679,21 @@
         "ko": "살육갈퀴 습격대",
         "zh": "杀戮利爪掠夺队"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "802cf206-9418-4fa8-9b4a-3ac3d2b9d01d",
@@ -637,70 +707,210 @@
         "ko": "파괴 신봉자",
         "zh": "毁灭崇拜者"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "807aa974-ca16-4d8a-8958-68c1a32f9c86",
       "name": {
         "en": "Soulforged Warpack"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "8f4e4263-86bf-426d-b235-6d760ffe8584",
       "name": {
         "en": "Renegade Warband"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "92401979-2a38-4cbd-9781-d3d53d6ad2e0",
       "name": {
         "en": "Dread Talons"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "93ea6b6a-690f-4a73-bb76-638cc4da5641",
       "name": {
         "en": "Chaos Cult"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "a0d2bc8f-ba0c-4ea6-8ee1-42dccb8fbc4d",
       "name": {
         "en": "Veterans of the Long War"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "b7654c2c-0922-444c-a98a-f49438d4f22c",
       "name": {
         "en": "Nightmare Hunt"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "b7baa3d5-a100-40d8-9e84-44ec95a8dcfc",
       "name": {
         "en": "Warpstrike Champions"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "b7c5bcb7-eecb-4ae5-a18b-b96143c34fa8",
       "name": {
         "en": "Pactbound Zealots"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "c61a7add-d879-4bb6-a61e-dfa1c621e203",
       "name": {
         "en": "Cult of the Arkifane"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "cbb28bd5-40ae-4d3e-8dbd-3b3e1591a89a",
@@ -714,14 +924,42 @@
         "ko": "카오스 결사",
         "zh": "混沌巫会"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "d730df46-12ec-4dff-80cf-60aeea5eefcd",
       "name": {
         "en": "Creations of Bile"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/chaosdaemons.json
+++ b/11th/gdc/chaosdaemons.json
@@ -430,28 +430,84 @@
       "name": {
         "en": "Blood Legion"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "5357f63c-7c70-459e-aa3b-1ea9c4ef48bb",
       "name": {
         "en": "Daemonic Incursion"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "778d3486-9f71-4253-90b9-c7ca150fc011",
       "name": {
         "en": "Plague Legion"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "95dd7e2e-5318-4271-b9dc-38592794539f",
       "name": {
         "en": "Shadow Legion"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "b3ac1391-84a9-4f8b-8755-d75eccfa5b70",
@@ -465,7 +521,21 @@
         "ko": "카오스 기마대",
         "zh": "混沌骑兵队"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "bdbd5d64-bccf-4d77-bcac-2e19815d1516",
@@ -479,21 +549,63 @@
         "ko": "워프 범람",
         "zh": "次元魔潮"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "d7d52d0d-d7af-4bc4-9a77-6ca0250a1d2c",
       "name": {
         "en": "Scintillating Legion"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "e64491c2-1e38-485c-959c-2b0bdf2cffaa",
       "name": {
         "en": "Legion of Excess"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "fe916344-deef-4c81-99ed-2adae0a8c296",
@@ -507,7 +619,21 @@
         "ko": "워프의 군주들",
         "zh": "亚空间领主"
       },
-      "faction": "Legiones Daemonica"
+      "faction": "Legiones Daemonica",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/chaosknights.json
+++ b/11th/gdc/chaosknights.json
@@ -362,14 +362,42 @@
       "name": {
         "en": "Lords of Dread"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "86620542-e27d-4e99-a70e-da69a673c9fb",
       "name": {
         "en": "Infernal Lance"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "993e9b23-3ade-4fb1-bb27-f9270de48978",
@@ -383,28 +411,84 @@
         "ko": "폭정의 요새",
         "zh": "暴虐要塞"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "9bef33d0-15fa-49f8-ac91-42496470641d",
       "name": {
         "en": "Helhunt Lance"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "a634e475-384b-40cd-957d-cd99201ab3e4",
       "name": {
         "en": "Houndpack Lance"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "b40710c8-474d-402d-bb22-9903e280dcff",
       "name": {
         "en": "Traitoris Lance"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "c7d24ce3-acdf-414d-af2a-81c602983045",
@@ -418,7 +502,21 @@
         "ko": "성상파괴 영지군",
         "zh": "叛道封地"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "e2637679-6163-4ea2-93cb-8c5a263ecc33",
@@ -432,7 +530,21 @@
         "ko": "사냥에 나선 전투무리",
         "zh": "猎犬战群"
       },
-      "faction": "Chaos Knights"
+      "faction": "Chaos Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/adeptasororitas.json
+++ b/11th/gdc/combatpatrol/adeptasororitas.json
@@ -62,7 +62,21 @@
         "ko": "성지 수호대",
         "zh": "圣地铁卫"
       },
-      "faction": "Adepta Sororitas"
+      "faction": "Adepta Sororitas",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/adeptuscustodes.json
+++ b/11th/gdc/combatpatrol/adeptuscustodes.json
@@ -62,7 +62,21 @@
         "ko": "트리스트라엔의 금빛 검",
         "zh": "崔斯蒂安的鎏金之刃"
       },
-      "faction": "Adeptus Custodes"
+      "faction": "Adeptus Custodes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/adeptusmechanicus.json
+++ b/11th/gdc/combatpatrol/adeptusmechanicus.json
@@ -62,7 +62,21 @@
         "ko": "말살 군단 델틱-9",
         "zh": "净化军团德尔塔-9号"
       },
-      "faction": "Adeptus Mechanicus"
+      "faction": "Adeptus Mechanicus",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/agents.json
+++ b/11th/gdc/combatpatrol/agents.json
@@ -62,7 +62,21 @@
         "ko": "이단심문관의 오른팔",
         "zh": "审判官之手"
       },
-      "faction": "Agents of the Imperium"
+      "faction": "Agents of the Imperium",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/astramilitarum.json
+++ b/11th/gdc/combatpatrol/astramilitarum.json
@@ -62,7 +62,21 @@
         "ko": "드레이든의 창",
         "zh": "德雷登的骑兵队"
       },
-      "faction": "Astra Militarum"
+      "faction": "Astra Militarum",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/blacktemplar.json
+++ b/11th/gdc/combatpatrol/blacktemplar.json
@@ -62,7 +62,21 @@
         "ko": "베드렌의 맹약자",
         "zh": "维德伦的誓言战士"
       },
-      "faction": "Black Templars"
+      "faction": "Black Templars",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/bloodangels.json
+++ b/11th/gdc/combatpatrol/bloodangels.json
@@ -62,7 +62,21 @@
         "ko": "생귀너리 선봉대",
         "zh": "圣血先锋"
       },
-      "faction": "Blood Angels"
+      "faction": "Blood Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/chaos_spacemarines.json
+++ b/11th/gdc/combatpatrol/chaos_spacemarines.json
@@ -62,7 +62,21 @@
         "ko": "자르칸의 데몬일족",
         "zh": "扎坎魔裔"
       },
-      "faction": "Heretic Astartes"
+      "faction": "Heretic Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/darkangels.json
+++ b/11th/gdc/combatpatrol/darkangels.json
@@ -62,7 +62,21 @@
         "ko": "복수 형제회",
         "zh": "复仇兄弟会"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/deathguard.json
+++ b/11th/gdc/combatpatrol/deathguard.json
@@ -62,7 +62,21 @@
         "ko": "구더기 군주들",
         "zh": "蛆虫领主"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/drukhari.json
+++ b/11th/gdc/combatpatrol/drukhari.json
@@ -62,7 +62,21 @@
         "ko": "고통의 코븐",
         "zh": "折磨巫会"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/emperors_children.json
+++ b/11th/gdc/combatpatrol/emperors_children.json
@@ -62,7 +62,21 @@
         "ko": "무정한 칼날",
         "zh": "冷酷利刃"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/greyknights.json
+++ b/11th/gdc/combatpatrol/greyknights.json
@@ -62,7 +62,21 @@
         "ko": "크로우의 정화사역단",
         "zh": "克罗的净化者"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/gsc.json
+++ b/11th/gdc/combatpatrol/gsc.json
@@ -62,7 +62,21 @@
         "ko": "승천의 발톱",
         "zh": "飞升之爪"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/necrons.json
+++ b/11th/gdc/combatpatrol/necrons.json
@@ -62,7 +62,21 @@
         "ko": "아몬호테크의 근위대",
         "zh": "阿蒙霍泰克的卫队"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/orks.json
+++ b/11th/gdc/combatpatrol/orks.json
@@ -62,7 +62,21 @@
         "ko": "아드몹",
         "zh": "硬汉帮"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/space_marines.json
+++ b/11th/gdc/combatpatrol/space_marines.json
@@ -62,7 +62,21 @@
         "ko": "강습대",
         "zh": "突击分队"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/spacewolves.json
+++ b/11th/gdc/combatpatrol/spacewolves.json
@@ -62,7 +62,21 @@
         "ko": "아스카르의 늑대무리",
         "zh": "阿斯卡的狼群"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/tau.json
+++ b/11th/gdc/combatpatrol/tau.json
@@ -62,7 +62,21 @@
         "ko": "불시의 여명 무관대",
         "zh": "疾晓核心队"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/thousandsons.json
+++ b/11th/gdc/combatpatrol/thousandsons.json
@@ -62,7 +62,21 @@
         "ko": "자도폰의 프리즘",
         "zh": "扎多费恩的棱镜"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/tyranids.json
+++ b/11th/gdc/combatpatrol/tyranids.json
@@ -62,7 +62,21 @@
         "ko": "바르덴가스트 무리",
         "zh": "瓦尔登加斯特的虫群"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/votann.json
+++ b/11th/gdc/combatpatrol/votann.json
@@ -62,7 +62,21 @@
         "ko": "재앙살해자의 방벽",
         "zh": "弑敌壁垒"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/combatpatrol/worldeaters.json
+++ b/11th/gdc/combatpatrol/worldeaters.json
@@ -62,7 +62,21 @@
         "ko": "광란의 파괴자",
         "zh": "狂乱劫掠者"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/darkangels.json
+++ b/11th/gdc/darkangels.json
@@ -324,7 +324,21 @@
       "name": {
         "en": "Inner Circle Task Force"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "0b44b0ad-420b-4b4c-af5a-27f0a735042e",
@@ -338,7 +352,21 @@
         "ko": "추적 암비행",
         "zh": "黑暗追击队"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "2a38def8-f0d2-4f28-aeca-bc2b555172bb",
@@ -352,7 +380,21 @@
         "ko": "심문 콘클라베",
         "zh": "审讯者密会"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "2e1dbbe3-13ef-42cd-b3d8-6daae893ae82",
@@ -366,35 +408,105 @@
         "ko": "암흑시대 무기고",
         "zh": "黑暗时代兵器"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "410ea102-b63f-4b3e-b901-05c2c869c298",
       "name": {
         "en": "Unforgiven Task Force"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "6040c18f-09c2-4708-8e85-912f88949221",
       "name": {
         "en": "Lion’s Blade Task Force"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "88060204-d25c-4ed9-95c7-a4b58d530320",
       "name": {
         "en": "Company of Hunters"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "e5a06319-a071-4bb4-aaa6-07c98c07abc6",
       "name": {
         "en": "Wrath of the Rock"
       },
-      "faction": "Dark Angels"
+      "faction": "Dark Angels",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/deathguard.json
+++ b/11th/gdc/deathguard.json
@@ -406,21 +406,63 @@
         "ko": "부패의 전형",
         "zh": "腐坏楷模"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "51470653-e741-468c-a4c5-efc6110e46d0",
       "name": {
         "en": "Virulent Vectorium"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "73927182-408b-4119-a045-e3b21d35cc36",
       "name": {
         "en": "Tallyband Summoners"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "80f1f5cf-8331-4b71-87fa-fe4caaa92633",
@@ -434,7 +476,21 @@
         "ko": "전염 병기",
         "zh": "传瘟机械"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "9a41d668-c9ee-41c8-81e7-58585d6d8efb",
@@ -448,35 +504,105 @@
         "ko": "파리 군단",
         "zh": "吹蝇军"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "ac958d83-3ee2-4279-8115-2b164658da08",
       "name": {
         "en": "Champions of Contagion"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "b3a2a4b5-40a0-4875-8017-bc455d657040",
       "name": {
         "en": "Mortarion’s Hammer"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "bd9bf924-b054-47bf-9df6-a301a62b41c5",
       "name": {
         "en": "Shamblerot Vectorium"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "db1b2621-c7fc-4c1f-91ba-3f75779123b8",
       "name": {
         "en": "Death Lord’s Chosen"
       },
-      "faction": "Death Guard"
+      "faction": "Death Guard",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/deathwatch.json
+++ b/11th/gdc/deathwatch.json
@@ -131,7 +131,21 @@
       "name": {
         "en": "Black Spear Task Force"
       },
-      "faction": "Deathwatch"
+      "faction": "Deathwatch",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/drukhari.json
+++ b/11th/gdc/drukhari.json
@@ -485,7 +485,21 @@
       "name": {
         "en": "Spectacle of Spite"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "091a9dfa-59b6-43e9-957a-a211981c684e",
@@ -499,35 +513,105 @@
         "ko": "카발 격통 수확자",
         "zh": "阴谋团折磨使"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "6693dc93-0d9b-4364-8e5a-4882debb529b",
       "name": {
         "en": "Kabalite Cartel"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "6b2f4fd1-8411-4c4a-92f0-110bfe87ebb5",
       "name": {
         "en": "Skysplinter Assault"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "8205608c-1f2e-465f-854d-d6b99d455143",
       "name": {
         "en": "Reaper’s Wager"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "bad361ab-6952-46ab-97f5-921e8d8984a0",
       "name": {
         "en": "Realspace Raiders"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "cbe64aa9-4b35-42c6-8674-4d841cc6fcf9",
@@ -541,14 +625,42 @@
         "ko": "격통의 도구",
         "zh": "折磨工具"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "eaf6ced2-c21b-42fa-b442-ee7437cc3430",
       "name": {
         "en": "Covenite Coterie"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "ebd949cd-20a6-46be-929e-17421b92e77d",
@@ -562,7 +674,21 @@
         "ko": "살육 전람회",
         "zh": "杀戮表演"
       },
-      "faction": "Drukhari"
+      "faction": "Drukhari",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/emperors_children.json
+++ b/11th/gdc/emperors_children.json
@@ -345,7 +345,21 @@
       "name": {
         "en": "Slaanesh’s Chosen"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "235629e4-405f-40db-b393-9f71e1c6e3ea",
@@ -359,7 +373,21 @@
         "ko": "광기 어린 군단",
         "zh": "癫狂之军"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "29bc9dbe-2bac-48f6-a496-955ee9c377df",
@@ -373,14 +401,42 @@
         "ko": "도륙의 황홀함",
         "zh": "杀戮盛景"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "31349652-6a08-46a0-a5ec-5d4533f0a8ae",
       "name": {
         "en": "Carnival of Excess"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "3b9f3326-5025-4194-9a40-dec121410c32",
@@ -394,42 +450,126 @@
         "ko": "고상한 야수",
         "zh": "优雅暴徒"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "af3fd326-fe1e-4023-a354-ed0f546ae6ff",
       "name": {
         "en": "Peerless Bladesmen"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "b89874ea-c08b-40c4-891d-dcdd2277595d",
       "name": {
         "en": "Rapid Evisceration"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "bea6576c-a423-4a9d-b9c9-6b3a10703a99",
       "name": {
         "en": "Mercurial Host"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "e3a3d467-28af-4e25-938b-42f48c64e8f5",
       "name": {
         "en": "Court of the Phoenician"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "f4f83a5e-36a7-49fd-950b-0ceb188b5c94",
       "name": {
         "en": "Coterie of the Conceited"
       },
-      "faction": "Emperor’s Children"
+      "faction": "Emperor’s Children",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/greyknights.json
+++ b/11th/gdc/greyknights.json
@@ -297,7 +297,21 @@
       "name": {
         "en": "Augurium Task Force"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "6043077b-0e2f-4e4f-a0d7-8ebcec480131",
@@ -311,14 +325,42 @@
         "ko": "숙청의 불길",
         "zh": "洗罪之火"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "a756d7e9-6264-4d9f-9b2a-dd81e2aba304",
       "name": {
         "en": "Banishers"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "ad206ac1-4a33-4d1e-8b4e-2c21118303d9",
@@ -332,28 +374,84 @@
         "ko": "이마테리움 차단선",
         "zh": "次元拦截"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "b2c8df0c-e202-4230-a44b-5e9e23df9737",
       "name": {
         "en": "Warpbane Task Force"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "b7be5d8d-321e-4043-888f-83a09d1bf1ac",
       "name": {
         "en": "Brotherhood Strike"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "c82ee909-80d7-408a-9f67-a83e78b7d1a8",
       "name": {
         "en": "Hallowed Conclave"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "eced4532-3d3c-43ec-9c30-d2bf278514d0",
@@ -367,14 +465,42 @@
         "ko": "은빛 강습단",
         "zh": "圣银突袭"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "f225bc7e-c854-4487-81ed-d18d5b12c2ad",
       "name": {
         "en": "Sanctic Spearhead"
       },
-      "faction": "Grey Knights"
+      "faction": "Grey Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/gsc.json
+++ b/11th/gdc/gsc.json
@@ -355,7 +355,21 @@
       "name": {
         "en": "Brood Brothers Auxilia"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "23ea0315-37ef-410f-a0a2-a6cf622e609f",
@@ -369,35 +383,105 @@
         "ko": "순종 동류군집",
         "zh": "纯血虫群"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "37b534f4-135f-4d14-bfcb-3fa7ccf9469d",
       "name": {
         "en": "Biosanctic Broodsurge"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "4448633e-99cf-4ada-8651-76dbf12b61c6",
       "name": {
         "en": "Outlander Claw"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "68478a72-0983-4fef-8cdb-e4536134d56e",
       "name": {
         "en": "Final Day"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "71b5d36d-cfd6-48ee-b883-fbc73eac91cc",
       "name": {
         "en": "Xenocreed Congregation"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "e0e6a94f-b219-43ec-95d0-f694f701df09",
@@ -411,7 +495,21 @@
         "ko": "봉기의 영웅",
         "zh": "叛逆英雄"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "ef54b4ca-adca-4e8f-9427-ea1cd0e42ed5",
@@ -425,14 +523,42 @@
         "ko": "제노사교 회중",
         "zh": "异形教众"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "f8ab87bf-ffeb-4dae-8708-5e04ed4d45c6",
       "name": {
         "en": "Host of Ascension"
       },
-      "faction": "Genestealer Cults"
+      "faction": "Genestealer Cults",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/imperialknights.json
+++ b/11th/gdc/imperialknights.json
@@ -416,7 +416,21 @@
       "name": {
         "en": "Valourstrike Lance"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "05240064-5412-4911-a60b-229ff34c78c3",
@@ -430,28 +444,84 @@
         "ko": "퀘스토르 제련조약",
         "zh": "封臣铸造联盟"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "44cad685-2a76-4309-b842-3e356f75219d",
       "name": {
         "en": "Gate Warden Lance"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "9634aebe-95e3-412b-a881-e33a334ae495",
       "name": {
         "en": "Spearhead-at-Arms"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "9c41ff78-125e-402f-a9df-f408825e940b",
       "name": {
         "en": "Questoris Companions"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "a6ada922-2612-4ef6-b7ad-6020954ae038",
@@ -465,7 +535,21 @@
         "ko": "보좌로 연결된 선봉",
         "zh": "忠诚护卫"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "bf191d4b-5ac6-4e24-a6f6-d962c1a7b068",
@@ -479,14 +563,42 @@
         "ko": "도미누스 대적파쇄기",
         "zh": "碎敌统御者"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "c6d159b0-4062-4a44-944c-8e00ee4a7edc",
       "name": {
         "en": "Freeblade Company"
       },
-      "faction": "Imperial Knights"
+      "faction": "Imperial Knights",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/necrons.json
+++ b/11th/gdc/necrons.json
@@ -418,14 +418,42 @@
       "name": {
         "en": "Cryptek Conclave"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "225b9e9c-7ebe-413f-a079-087bc98f380a",
       "name": {
         "en": "Starshatter Arsenal"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "3818a5e4-5d1a-410b-a63f-9a850b923635",
@@ -439,28 +467,84 @@
         "ko": "파에론의 병기고",
         "zh": "法皇的军备"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "412b33ad-7e6f-45a3-8638-ae880be94b9f",
       "name": {
         "en": "Cursed Legion"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "4694ac41-4340-4e85-8824-5c47555f8c12",
       "name": {
         "en": "Annihilation Legion"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "489fc222-d9a1-4220-9ef2-9747c2fea283",
       "name": {
         "en": "Hypercrypt Legion"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "8e281a27-1d5a-415b-8b92-34cd0ed53b63",
@@ -474,14 +558,42 @@
         "ko": "왕조의 손아귀",
         "zh": "王朝之手"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "a7ec286c-a305-435b-b402-91140c67d809",
       "name": {
         "en": "Pantheon of Woe"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "cd5f7a63-6d73-4094-9977-e8b7530d1a8f",
@@ -495,28 +607,84 @@
         "ko": "하늘수의 선봉",
         "zh": "遮天先锋"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "df0e5858-2c4a-486b-b693-8971f837388d",
       "name": {
         "en": "Obeisance Phalanx"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "e40617a8-ec95-44e2-bc46-956a6fac4538",
       "name": {
         "en": "Canoptek Court"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "ef55259d-3884-4b3b-b215-08ab337d4a24",
       "name": {
         "en": "Awakened Dynasty"
       },
-      "faction": "Necrons"
+      "faction": "Necrons",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/orks.json
+++ b/11th/gdc/orks.json
@@ -366,28 +366,84 @@
       "name": {
         "en": "Blitz Brigade"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "41229cb5-ce01-4126-acdc-c658ecb9fe7e",
       "name": {
         "en": "Kult of Speed"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "495f699c-39b1-4ad2-9e31-624efbf8ff9a",
       "name": {
         "en": "Da Big Hunt"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "4fa77afa-6086-4703-b2e6-0f61e2b07a04",
       "name": {
         "en": "Dread Mob"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "50193e18-32f4-42d3-b64b-9dd2395d39c2",
@@ -401,14 +457,42 @@
         "ko": "탁티칼 브리게이드",
         "zh": "战术旅"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "7100d457-ec86-46aa-b323-934394530a9e",
       "name": {
         "en": "War Horde"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "7541781b-1b85-47a4-9dda-e1e284d5fdb5",
@@ -422,35 +506,105 @@
         "ko": "더 많은 다카!",
         "zh": "更多突突！"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "7a72a5a0-4ac8-40ea-8d31-d8fb2f14e97c",
       "name": {
         "en": "Speedwaaagh!"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "87313610-665a-4302-ac99-cd4b37608172",
       "name": {
         "en": "Bully Boyz"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "953d5dae-75e4-4f1c-a13d-9ec75a528187",
       "name": {
         "en": "Green Tide"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "b187c79e-2b20-46b3-94fc-51fadb86595f",
       "name": {
         "en": "Freebooter Krew"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "bf9ea326-64fe-4ded-82c7-093f96a4b619",
@@ -464,7 +618,21 @@
         "ko": "바퀴 달린 주금",
         "zh": "死亡摇滚"
       },
-      "faction": "Orks"
+      "faction": "Orks",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/space_marines.json
+++ b/11th/gdc/space_marines.json
@@ -760,70 +760,224 @@
       "name": {
         "en": "1st Company Task Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "047e97fc-2e78-4db6-b401-1f8bb65d9162",
       "name": {
         "en": "Gladius Task Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "0854459d-3909-4621-8073-46d54d1a0464",
       "name": {
         "en": "Stormlance Task Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      },
+      "detachmentPointsOverrides": [
+        {
+          "faction": "Black Templars",
+          "detachmentPoints": 2
+        },
+        {
+          "faction": "Blood Angels",
+          "detachmentPoints": 2
+        },
+        {
+          "faction": "Deathwatch",
+          "detachmentPoints": 2
+        }
+      ]
     },
     {
       "id": "114f009f-63b2-40bc-922a-83363eab24cc",
       "name": {
         "en": "Blade of Ultramar"
       },
-      "faction": "Ultramarines"
+      "faction": "Ultramarines",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "1ca178a4-0e04-4f18-ae3a-ecd0336131a6",
       "name": {
         "en": "Hammer of Avernii"
       },
-      "faction": "Iron Hands"
+      "faction": "Iron Hands",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "2816281c-0f5d-4c0c-a63b-9be13599e674",
       "name": {
         "en": "Armoured Speartip"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "2975ba73-73c1-4866-bbd9-c9ae1f66de97",
       "name": {
         "en": "Spearpoint Task Force"
       },
-      "faction": "White Scars"
+      "faction": "White Scars",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "3f2130dc-e858-45a7-b42c-4cd5953b9b43",
       "name": {
         "en": "Ceramite Sentinels"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "5e6fedf7-bfb7-4042-84ce-7644be942167",
       "name": {
         "en": "Emperor’s Shield"
       },
-      "faction": "Imperial Fists"
+      "faction": "Imperial Fists",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "720ee5b2-2412-43f4-b145-bec27a90b6d5",
       "name": {
         "en": "Vanguard Spearhead"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "9492c5aa-1baf-49d0-a587-c332d6119d10",
@@ -837,21 +991,63 @@
         "ko": "라이브러리우스 콘클라베",
         "zh": "智库密会"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "9c26c287-1ec3-4580-9106-82b7b054ce98",
       "name": {
         "en": "Forgefather’s Seekers"
       },
-      "faction": "Salamanders"
+      "faction": "Salamanders",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "a5da316c-604e-4aca-b5ac-53517dcd01b3",
       "name": {
         "en": "Headhunter Task Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "a65dba8d-ae69-4e3e-a72e-afeb748a98ca",
@@ -865,14 +1061,48 @@
         "ko": "풀구리스 특임대",
         "zh": "迅电特遣队"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "b0cdcaeb-2e58-46e3-83c5-a1ece9ad4e66",
       "name": {
         "en": "Bastion Task Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      },
+      "detachmentPointsOverrides": [
+        {
+          "faction": "Black Templars",
+          "detachmentPoints": 3
+        }
+      ]
     },
     {
       "id": "b87e2dfa-d598-4fbb-a4ac-e08fdba03391",
@@ -886,49 +1116,147 @@
         "ko": "자산 전복",
         "zh": "行动资源"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "b91b5421-b1fe-4b75-b088-f2615683410e",
       "name": {
         "en": "Shadowmark Talon"
       },
-      "faction": "Raven Guard"
+      "faction": "Raven Guard",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "dd0c31ee-65db-4143-b1f9-60aaea303b1c",
       "name": {
         "en": "Orbital Assault Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "e544168f-0535-4b58-ac04-c5f3793ea56b",
       "name": {
         "en": "Anvil Siege Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "f6429de4-1567-4ee9-8570-8c3d405e93f9",
       "name": {
         "en": "Reclamation Force"
       },
-      "faction": "Ultramarines"
+      "faction": "Ultramarines",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "fcc5de05-5825-4af5-9484-38af6358ff2b",
       "name": {
         "en": "Firestorm Assault Force"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "fe7ac957-dfdf-4025-bd77-c387cd6c62a5",
       "name": {
         "en": "Ironstorm Spearhead"
       },
-      "faction": "Adeptus Astartes"
+      "faction": "Adeptus Astartes",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/spacewolves.json
+++ b/11th/gdc/spacewolves.json
@@ -357,14 +357,42 @@
         "ko": "사가와 영웅가의 전승",
         "zh": "传奇之歌"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "41547c19-336b-4ea9-8161-bdbc8cb68343",
       "name": {
         "en": "Saga of the Beastslayer"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "74c4b04a-de7a-41a5-b015-97803080bf87",
@@ -378,14 +406,42 @@
         "ko": "송곳니의 백전노장들",
         "zh": "狼牙堡老兵"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "a6359296-90bd-4ec0-a70d-87813eaf9da9",
       "name": {
         "en": "Saga of the Hunter"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "cbfdd62b-fa52-4689-835b-0b881bb978fb",
@@ -399,21 +455,63 @@
         "ko": "펜리스의 대전사",
         "zh": "芬里斯的勇士"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "d8b12845-85b4-48db-8565-4771287a2fa7",
       "name": {
         "en": "Saga of the Great Wolf"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "fc3194f8-b96f-4158-9380-693ae00db4db",
       "name": {
         "en": "Saga of the Bold"
       },
-      "faction": "Space Wolves"
+      "faction": "Space Wolves",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/tau.json
+++ b/11th/gdc/tau.json
@@ -353,14 +353,42 @@
       "name": {
         "en": "Retaliation Cadre"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "24deeda2-032e-4f18-a7ce-d206044a1bd1",
       "name": {
         "en": "Mont’ka"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "5bdc7f35-d1cc-4c58-9888-81ee3f0ee8ab",
@@ -374,14 +402,42 @@
         "ko": "보조 무관대",
         "zh": "辅助核心队"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "5f9bd941-4904-4e4c-b880-35543f704f17",
       "name": {
         "en": "Kroot Hunting Pack"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "a45bd323-7d95-41b8-82ff-eba352aba663",
@@ -395,7 +451,21 @@
         "ko": "사전 획득 무관대",
         "zh": "先攻抢占核心队"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "c20f90be-bf55-4d26-97af-7bb642836256",
@@ -409,14 +479,42 @@
         "ko": "시험평가 무관대",
         "zh": "原型系统\n测试核心队"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "e1b3fdde-652c-40a6-953d-e34e4af44fe5",
       "name": {
         "en": "Kauyon"
       },
-      "faction": "T’au Empire"
+      "faction": "T’au Empire",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/thousandsons.json
+++ b/11th/gdc/thousandsons.json
@@ -442,7 +442,21 @@
       "name": {
         "en": "Changehost of Deceit"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "6bfd15ec-5723-410f-853c-092d82919512",
@@ -456,7 +470,21 @@
         "ko": "변화의 종복",
         "zh": "变化的仆从"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "8703803f-2be2-4862-8622-c729c12babca",
@@ -470,7 +498,21 @@
         "ko": "재생 의식",
         "zh": "再生仪式"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "9b8af121-ddff-4e4e-9928-37050a67b0a8",
@@ -484,42 +526,126 @@
         "ko": "세케타르 코호트",
         "zh": "塞克塔部队"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "baf498d8-40c2-4536-869c-0432cf6ec054",
       "name": {
         "en": "Warpforged Cabal"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "c4040e42-40b2-4df2-ba73-83a17dfe3e72",
       "name": {
         "en": "Hexwarp Thrallband"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "d7f54185-ca1d-4300-981d-84a28641ce14",
       "name": {
         "en": "Grand Coven"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "d8a383c5-a6a0-445a-b1ad-5a4858bc6265",
       "name": {
         "en": "Warpmeld Pact"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "da4b1448-5954-4083-a820-bc98d08b6672",
       "name": {
         "en": "Rubricae Phalanx"
       },
-      "faction": "Thousand Sons"
+      "faction": "Thousand Sons",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/tyranids.json
+++ b/11th/gdc/tyranids.json
@@ -380,7 +380,21 @@
       "name": {
         "en": "Synaptic Nexus"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "0d13e327-3ae5-4e76-8d7d-749ffe5e6476",
@@ -394,28 +408,84 @@
         "ko": "매복 포식자",
         "zh": "伏击捕食者"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "1589d16c-5e24-4e72-b352-b674041fdc84",
       "name": {
         "en": "Subterranean Assault"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "75814c70-8935-4305-8507-01c8f8b0d119",
       "name": {
         "en": "Crusher Stampede"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "7bba616f-e032-443b-8e27-55370028348c",
       "name": {
         "en": "Unending Swarm"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "c44ad21f-ef34-4d29-befb-3202706563f9",
@@ -429,14 +499,42 @@
         "ko": "노른 여왕의 갈퀴",
         "zh": "诺恩女王之爪"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "c8d42dc3-5901-4e96-90e8-254a8af33252",
       "name": {
         "en": "Vanguard Onslaught"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "dd488d53-7bfa-4778-8ff1-2a7468860747",
@@ -450,21 +548,63 @@
         "ko": "워리어 계통 맹공",
         "zh": "战斗生物总攻"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "f018a051-11c7-4aaf-a873-16acb8c4c38d",
       "name": {
         "en": "Invasion Fleet"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "f88d7c8d-3766-4623-9192-ff35ed729622",
       "name": {
         "en": "Assimilation Swarm"
       },
-      "faction": "Tyranids"
+      "faction": "Tyranids",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/votann.json
+++ b/11th/gdc/votann.json
@@ -365,28 +365,84 @@
       "name": {
         "en": "Hearthfyre Arsenal"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "2fd1ea69-ba73-4a60-b09b-672cefd4d6f2",
       "name": {
         "en": "Persecution Prospect"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "36ff5ede-1c67-4cdd-9a51-f81eb47e4626",
       "name": {
         "en": "Needgaârd Oathband"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "38b6d9b5-8bee-4832-ac4b-79eb7f43e4a7",
       "name": {
         "en": "Dêlve Assault Shift"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "513877e1-893c-41ab-b19b-7f84927ea8ed",
@@ -400,14 +456,42 @@
         "ko": "먼길수색자",
         "zh": "远行探索者"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "8698abd9-3176-4792-85f4-abdd6ad5b311",
       "name": {
         "en": "Hearthband"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "9e7516ff-e16f-4ad9-8e43-861ca9a6d955",
@@ -421,7 +505,21 @@
         "ko": "하스가드 언약 회중",
         "zh": "炉卫盟约"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "a752a222-2540-4e3b-9d70-423595d238e7",
@@ -435,21 +533,63 @@
         "ko": "기갑 선두",
         "zh": "装甲先驱"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "bd5bc3a7-76dd-4a49-a1ec-a9a8f25dfdd9",
       "name": {
         "en": "Mercenary Oathband"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "f36a7d83-dd08-461a-b4a1-58179deb7d96",
       "name": {
         "en": "Brandfast Oathband"
       },
-      "faction": "Leagues of Votann"
+      "faction": "Leagues of Votann",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     }
   ],
   "stratagems": [

--- a/11th/gdc/worldeaters.json
+++ b/11th/gdc/worldeaters.json
@@ -435,14 +435,42 @@
       "name": {
         "en": "Berzerker Warband"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 3,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "11575a4f-0e5c-46e2-9085-392f11226cab",
       "name": {
         "en": "Possessed Slaughterband"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "16d7618b-880a-4f47-97e2-385df44bc860",
@@ -456,28 +484,84 @@
         "ko": "코온의 도살자",
         "zh": "恐虐屠夫"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "6a24433b-0910-4386-8169-ac2b2ef9e377",
+        "name": {
+          "en": "Disruption",
+          "de": "Störangriff",
+          "es": "Disrupción",
+          "fr": "Perturbation",
+          "it": "Intralcio",
+          "ja": "撹乱",
+          "ko": "방해 작전",
+          "zh": "干扰"
+        }
+      }
     },
     {
       "id": "960c7ecf-3cc0-4d10-8d0c-5839273ea651",
       "name": {
         "en": "Khorne Daemonkin"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "cc033412-45dd-4f17-9ef6-700f5b96c213",
+        "name": {
+          "en": "Reconnaissance",
+          "de": "Auskundschaften",
+          "es": "Reconocimiento",
+          "fr": "Reconnaissance",
+          "it": "Ricognizione",
+          "ja": "偵察",
+          "ko": "수색과 소탕",
+          "zh": "侦察"
+        }
+      }
     },
     {
       "id": "ae5e755c-230d-46a9-ad1a-d3afaf3633ca",
       "name": {
         "en": "Cult of Blood"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     },
     {
       "id": "b21e5072-38d5-42b5-9143-9aabcbf499d8",
       "name": {
         "en": "Goretrack Onslaught"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 2,
+      "forceDisposition": {
+        "id": "27b26ab3-d5e3-450c-af69-829ca3229f7f",
+        "name": {
+          "en": "Take and Hold",
+          "de": "Einnehmen und halten",
+          "es": "Ocupar y mantener",
+          "fr": "Prendre et Tenir",
+          "it": "Conquista e Difendi",
+          "ja": "奪取と確保",
+          "ko": "점령과 유지",
+          "zh": "占领与坚守"
+        }
+      }
     },
     {
       "id": "b316e2f6-0b93-4805-9b5e-38f050875ad3",
@@ -491,7 +575,21 @@
         "ko": "황동 병기",
         "zh": "好战机械"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "c9572fd5-d8cd-41b6-b613-13265ac1c04f",
+        "name": {
+          "en": "Purge the Foe",
+          "de": "Lösche den Feind aus",
+          "es": "Purgar al enemigo",
+          "fr": "Éliminez l’Adversaire",
+          "it": "Annienta il nemico",
+          "ja": "敵を浄化せよ",
+          "ko": "적군 격멸",
+          "zh": "肃清敌人"
+        }
+      }
     },
     {
       "id": "e8136aea-8e9c-470a-aa7b-a33dfa33c9ea",
@@ -505,7 +603,21 @@
         "ko": "진노의 그릇",
         "zh": "怒火容器"
       },
-      "faction": "World Eaters"
+      "faction": "World Eaters",
+      "detachmentPoints": 1,
+      "forceDisposition": {
+        "id": "8989bd9e-4bd5-49f8-b4d9-7acb47fccf41",
+        "name": {
+          "en": "Priority Assets",
+          "de": "Prioritätsziele",
+          "es": "Activos prioritarios",
+          "fr": "Atouts Prioritaires",
+          "it": "Risorse prioritarie",
+          "ja": "優先資産",
+          "ko": "최우선 자산",
+          "zh": "重要资产"
+        }
+      }
     }
   ],
   "stratagems": [


### PR DESCRIPTION
## What

Adds the new 11th-edition detachment data to every faction and Combat Patrol file. Each `detachments[]` entry now carries:

- `detachmentPoints` — the detachment-points cost to field it (numeric)
- `forceDisposition` — the force disposition attached to it (`{ id, name: LocText }`)
- `detachmentPointsOverrides` — optional absolute per-chapter overrides, present only where they exist (a few shared Space Marine detachments)

Answers the request for force dispositions attached to detachments in the gdc data, plus the detachment point cost.

## Scope

- 51 files changed (31 faction files + 20 Combat Patrol files), 289 detachment entries.
- **Purely additive** — matched by detachment id; every existing field is preserved (the 289 "deletions" in the diff are `"faction"` lines gaining a trailing comma as each entry is extended).
- Prettier-formatted to match the repo; all files validate as JSON.

## How

The values are produced by the updated parser (see the companion `ronplanken/datasources-pipeline` PR) and backfilled onto the current published output by matching on the stable detachment `id`, so no other data version churn is introduced. They will be regenerated authoritatively on the next pipeline run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbwBJsWGQiz3JcBbrCXuQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbwBJsWGQiz3JcBbrCXuQa)_