### PR TITLE
Add attachment targets and de-collide ids across 11th data

### DIFF
--- a/11th/changelogs/895_changelog.txt
+++ b/11th/changelogs/895_changelog.txt
@@ -83,9 +83,9 @@ FACTION: Necrons (Combat Patrol)
 ================================================================================
 STATISTICS
 ================================================================================
-Total factions processed: 53
+Total factions processed: 54
 Factions with changes: 6
-Factions without changes: 47
+Factions without changes: 48
 
 Datasheets:    +0 added, -0 removed, ~13 modified
 Stratagems:    +0 added, -0 removed, ~1 modified

--- a/11th/changelogs/895_changelog.txt
+++ b/11th/changelogs/895_changelog.txt
@@ -19,6 +19,26 @@ FACTION: Tyranids
         - keywords: added: Frame
 
 ------------------------------------------------------------
+FACTION: Adeptus Astartes
+------------------------------------------------------------
+
+  DATASHEETS:
+    Modified (4):
+      ~ Apothecary Biologis
+        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Support)
+      ~ Captain in Gravis Armour
+        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
+      ~ Iron Father Feirros
+        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
+      ~ Tor Garadon
+        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
+
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Shadowmark Talon
+        - rules: Masters of Shadow: paragraph 1 text updated
+
+------------------------------------------------------------
 FACTION: Heretic Astartes
 ------------------------------------------------------------
 
@@ -64,13 +84,14 @@ FACTION: Necrons (Combat Patrol)
 STATISTICS
 ================================================================================
 Total factions processed: 53
-Factions with changes: 5
-Factions without changes: 48
+Factions with changes: 6
+Factions without changes: 47
 
-Datasheets:    +0 added, -0 removed, ~9 modified
+Datasheets:    +0 added, -0 removed, ~13 modified
 Stratagems:    +0 added, -0 removed, ~1 modified
 Enhancements:  +0 added, -0 removed, ~0 modified
 Detachments:   +0 added, -0 removed, ~0 modified
+Detach. Rules: +0 added, -0 removed, ~1 modified
 Army Rules:    +0 added, -0 removed, ~0 modified
 ================================================================================
 

--- a/11th/changelogs/909_changelog.txt
+++ b/11th/changelogs/909_changelog.txt
@@ -2064,9 +2064,9 @@ FACTION: Emperor’s Children (Combat Patrol)
 ================================================================================
 STATISTICS
 ================================================================================
-Total factions processed: 53
+Total factions processed: 54
 Factions with changes: 52
-Factions without changes: 1
+Factions without changes: 2
 
 Datasheets:    +0 added, -0 removed, ~417 modified
 Stratagems:    +7 added, -1 removed, ~31 modified

--- a/11th/changelogs/909_changelog.txt
+++ b/11th/changelogs/909_changelog.txt
@@ -12,7 +12,7 @@ FACTION: Dark Angels
   DATASHEETS:
     Modified (10):
       ~ Deathwing Knights
-        - additionalCost: Additional selection cost: +20 -> +20 pts
+        - additionalCost: Additional selection cost of +20 pts now applies after 2 selections (previously after 1 selection)
       ~ Inner Circle Companions
         - points: 6 models: 170 -> 160 pts
         - abilities.other: modified: Braziers of Judgement
@@ -63,6 +63,11 @@ FACTION: Dark Angels
       ~ Interrogation Conclave
         - forceDisposition: Purge the Foe -> Take and Hold
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Company of Hunters
+        - rules: Masters of Manoeuvre: paragraph 1 text updated
+
 ------------------------------------------------------------
 FACTION: Dark Angels (Combat Patrol)
 ------------------------------------------------------------
@@ -70,17 +75,17 @@ FACTION: Dark Angels (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Master Zacharial
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Vengeful Brethren Bladeguard Veteran Squad
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
         - abilities.other: modified: Bladeguard (Once per turn per unit)
       ~ Vengeful Brethren Hellblaster Squad
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Vengeful Brethren Intercessor Squad
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
 
 ------------------------------------------------------------
@@ -111,6 +116,11 @@ FACTION: Death Guard
       ~ Contagion Engines
         - forceDisposition: Purge the Foe -> Reconnaissance
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Virulent Vectorium
+        - rules: Worldblight: paragraph 1 text updated
+
 ------------------------------------------------------------
 FACTION: Death Guard (Combat Patrol)
 ------------------------------------------------------------
@@ -118,15 +128,15 @@ FACTION: Death Guard (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Maggot Lords Chaos Rhino
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Maggot Lords Deathshroud Terminators
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Plaguespurt Gauntlet: BS/WS: 6+ -> -
         - meleeWeapons: Manreaper – Sweep: A: 4 -> 8
       ~ Septimol Fulg, Maggot Lords Tallyman
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Sholgor the Putrid
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Twin Plague Spewer: BS/WS: 6+ -> -
 
 ------------------------------------------------------------
@@ -171,18 +181,21 @@ FACTION: Tyranids (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (5):
+    Modified (6):
       ~ Terror of Vardenghast
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Vardenghast Swarm Barbgaunts
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Vardenghast Swarm Psychophage
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Vardenghast Swarm Termagants
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
+        - abilities.other: modified: Skulking Horrors (Once per phase per unit)
+      ~ Vardenghast Swarm Termagants
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - abilities.other: modified: Skulking Horrors (Once per phase per unit)
       ~ Vardenghast Swarm Von Ryan's Leapers
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
         - abilities.other: modified: Pouncing Leap (Once per turn per unit)
 
 ------------------------------------------------------------
@@ -190,10 +203,14 @@ FACTION: Adeptus Astartes
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (33):
+    Modified (37):
       ~ Aggressor Squad
         - points: 6 models: 180 -> 165 pts
         - points: 3 models: 90 -> 80 pts
+      ~ Apothecary Biologis
+        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Support)
+      ~ Captain in Gravis Armour
+        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Captain Titus
         - points: 1 models: 90 -> 100 pts
       ~ Cato Sicarius
@@ -225,6 +242,8 @@ FACTION: Adeptus Astartes
       ~ Intercessor Squad
         - abilities.other: added: Hail of Bolts
         - abilities.other: removed: Target Elimination
+      ~ Iron Father Feirros
+        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Land Speeder
         - points: 1 models: 95 -> 105 pts
         - additionalCost: Removed additional selection cost (+10 pts)
@@ -264,8 +283,11 @@ FACTION: Adeptus Astartes
       ~ Thunderhawk Gunship
         - keywords: removed: Aircraft
         - keywords: removed: Frame
+      ~ Tor Garadon
+        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Uriel Ventris
         - points: 1 models: 95 -> 105 pts
+        - attachesTo: Can now be attached to Victrix Honour Guard (Leader)
         - leader: Changed
       ~ Vanguard Veteran Squad with Jump Packs
         - points: 10 models: 210 -> 220 pts
@@ -337,6 +359,10 @@ FACTION: Adeptus Astartes
       ~ Ironstorm Spearhead
         - forceDisposition: Purge the Foe -> Take and Hold
 
+  DETACHMENT RULES:
+    Added (1):
+      + Vengeful Hosts
+
   ARMY RULES:
     Modified (1):
       ~ Oath of Moment
@@ -349,26 +375,26 @@ FACTION: Adeptus Astartes (Combat Patrol)
   DATASHEETS:
     Modified (5):
       ~ Assault Force Captain
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
       ~ Assault Force Intercessor Squad
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Bolt Pistol: A: 2 -> 1; AP: -1 -> 0
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
       ~ Assault Force Land Speeder
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
         - loadout: Changed
       ~ Assault Force Librarian
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Bolt Pistol: AP: -1 -> 0
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
       ~ Assault Force Vanguard Veteran Squad With Jump Packs
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
 
@@ -386,20 +412,28 @@ FACTION: Blood Angels
       ~ Ordained Sacrifice
         - description: Changed
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ The Angelic Host
+        - rules: Upon Wings of Fire: paragraph 3 text updated
+
 ------------------------------------------------------------
 FACTION: Blood Angels (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (3):
+    Modified (4):
       ~ Captain Raldeo
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Sanguinary Spearhead Assault Intercessor Squad
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Sanguinary Spearhead Sanguinary Guard
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
+        - abilities.faction: removed: Oath of Moment
+      ~ Sanguinary Spearhead Sanguinary Guard
+        - points: 3 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
 
 ------------------------------------------------------------
@@ -423,7 +457,7 @@ FACTION: Black Templars
         - points: 1 models: 85 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Marshal
-        - additionalCost: Additional selection cost: +10 -> +10 pts
+        - additionalCost: Additional selection cost of +10 pts now applies after 2 selections (previously after 1 selection)
       ~ Repulsor Executioner
         - points: 1 models: 245 -> 255 pts
         - wargearOptions: Heavy laser destroyer: 0 -> 10 pts
@@ -447,14 +481,14 @@ FACTION: Black Templars (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Emperor's Champion Vedrenn
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Vow-Sworn Bladeguard Veteran Squad
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Vow-Sworn Crusader Squad
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Pyreblaster: BS/WS: 3+ -> -
       ~ Vow-Sworn Sword Brethren Squad
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Pyre Pistol: BS/WS: 3+ -> -
 
 ------------------------------------------------------------
@@ -474,7 +508,7 @@ FACTION: Space Wolves
       ~ Ragnar Blackmane
         - points: 1 models: 100 -> 90 pts
       ~ Wolf Guard Terminators
-        - additionalCost: Additional selection cost: +10 -> +15 pts
+        - additionalCost: Additional selection cost: +10 -> +15 pts; applies after 1 selection -> 2 selections
       ~ Wolf Scouts
         - points: 12 models: 190 -> 180 pts
         - points: 6 models: 95 -> 90 pts
@@ -505,18 +539,18 @@ FACTION: Space Wolves (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Askar's Wolfpack Blood Claws
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Askar's Wolfpack Wolf Guard Terminators
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Askar's Wolfpack Wulfen
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - wargearOptions: Added Frost Blades and Feral Claws at 0 pts
         - wargearOptions: Removed Feral Claws
         - abilities.faction: removed: Oath of Moment
       ~ Fyrri Askar
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
 
 ------------------------------------------------------------
@@ -603,13 +637,13 @@ FACTION: Thousand Sons (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Kaa'skrek
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Prism of Zadophon Rubric Marines
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Prism of Zadophon Tzaangor Enlightened
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Zadophon the Soul Eater
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: World Eaters
@@ -679,14 +713,14 @@ FACTION: World Eaters (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Frenzied Reavers Jakhals
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Frenzied Reavers Khorne Berzerkers
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Bolt Pistol: S: 3 -> 4
       ~ Frenzied Reavers Master of Executions
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Vorrakh, Lord of the Frenzied Reavers
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Heretic Astartes
@@ -697,7 +731,7 @@ FACTION: Heretic Astartes
       ~ Abaddon the Despoiler
         - points: 1 models: 285 -> 295 pts
       ~ Accursed Cultists
-        - additionalCost: Additional selection cost: +20 -> +20 pts
+        - additionalCost: Additional selection cost of +20 pts now applies after 2 selections (previously after 1 selection)
       ~ Chaos Lord with Jump Pack
         - points: 1 models: 90 -> 80 pts
       ~ Chaos Predator Annihilator
@@ -713,9 +747,9 @@ FACTION: Heretic Astartes
       ~ Chosen
         - points: 10 models: 250 -> 270 pts
         - points: 5 models: 125 -> 135 pts
-        - additionalCost: Additional selection cost: +10 -> +10 pts
+        - additionalCost: Additional selection cost of +10 pts now applies after 2 selections (previously after 1 selection)
       ~ Dark Commune
-        - additionalCost: Additional selection cost: +10 -> +10 pts
+        - additionalCost: Additional selection cost of +10 pts now applies after 2 selections (previously after 1 selection)
       ~ Defiler
         - additionalCost: Additional selection cost: +30 -> +40 pts
         - wargearOptions: Hades lascannon: 10 -> 15 pts
@@ -750,6 +784,11 @@ FACTION: Heretic Astartes
       ~ Soulforged Warpack
         - forceDisposition: Purge the Foe -> Take and Hold
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Cabal of Chaos
+        - rules: Empyric Wellspring: paragraph 1 text updated
+
 ------------------------------------------------------------
 FACTION: Heretic Astartes (Combat Patrol)
 ------------------------------------------------------------
@@ -757,13 +796,13 @@ FACTION: Heretic Astartes (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Aranis Zarkan
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Zarkan's Daemonkin Cultist Mob
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Zarkan's Daemonkin Legionaries
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Zarkan's Daemonkin Possessed
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Legiones Daemonica
@@ -897,7 +936,7 @@ FACTION: Astra Militarum
       ~ Leman Russ Demolisher
         - points: 1 models: 190 -> 180 pts
       ~ Militarum Tempestus Command Squad
-        - additionalCost: Additional selection cost: +10 -> +10 pts
+        - additionalCost: Additional selection cost of +10 pts now applies after 2 selections (previously after 1 selection)
       ~ Shadowsword
         - points: 1 models: 410 -> 375 pts
         - additionalCost: Additional selection cost: +20 -> +30 pts
@@ -937,20 +976,27 @@ FACTION: Astra Militarum
       ~ Mechanised Assault
         - forceDisposition: Purge the Foe -> Reconnaissance
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Recon Element
+        - rules: Masters of Camouflage: paragraph 1 text updated
+
 ------------------------------------------------------------
 FACTION: Astra Militarum (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (3):
+    Modified (4):
       ~ Drayden's Lance Attilan Rough Riders
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
+      ~ Drayden's Lance Attilan Rough Riders
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Drayden's Lance Command Squad
-        - points: 4 models: 0 -> null pts
+        - points: 4 models: Removed explicit points value (was 0 pts)
         - keywords: added: Officer
         - loadout: Changed
       ~ Drayden's Lance Kasrkin
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Flamer: BS/WS: 6+ -> -
         - abilities.other: modified: Melta Mine (Once per battle, per unit)
 
@@ -984,6 +1030,11 @@ FACTION: Imperial Knights
         - forceDisposition: Purge the Foe -> Priority Assets
       ~ Freeblade Company
         - forceDisposition: Purge the Foe -> Priority Assets
+
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Gate Warden Lance
+        - rules: Dauntless Defenders: paragraph 1 text updated
 
 ------------------------------------------------------------
 FACTION: Grey Knights
@@ -1040,6 +1091,11 @@ FACTION: Grey Knights
       ~ Argent Assault
         - forceDisposition: Purge the Foe -> Priority Assets
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Immaterial Interdiction
+        - rules: Echojump: paragraph 1 text updated
+
   ARMY RULES:
     Modified (1):
       ~ Gate of Infinity
@@ -1052,14 +1108,14 @@ FACTION: Grey Knights (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Crowe's Sanctifiers Brotherhood Terminator Squad
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Crowe's Sanctifiers Strike Squad
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Incinerator: BS/WS: 3+ -> -
       ~ Crowe's Sanctifiers Venerable Dreadnought
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Sanctifiers Castellan Crowe
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Adepta Sororitas
@@ -1068,7 +1124,7 @@ FACTION: Adepta Sororitas
   DATASHEETS:
     Modified (13):
       ~ Celestian Sacresants
-        - additionalCost: Additional selection cost: +15 -> +10 pts
+        - additionalCost: Additional selection cost: +15 -> +10 pts; applies after 1 selection -> 2 selections
       ~ Dominion Squad
         - points: 10 models: 100 -> 90 pts
       ~ Hospitaller
@@ -1141,15 +1197,15 @@ FACTION: Adepta Sororitas (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Sanctuary Canoness Adalya
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Sanctuary Guardians Arco-Flagellants
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Sanctuary Guardians Battle Sisters Squad
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Ministorum Flamer: BS/WS: 6+ -> -
         - rangedWeapons: Ministorum Heavy Flamer: BS/WS: 6+ -> -
       ~ Sanctuary Guardians Celestian Sacresants
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Adeptus Mechanicus
@@ -1189,6 +1245,13 @@ FACTION: Adeptus Mechanicus
       ~ Haloscreed Battle Clade
         - forceDisposition: Purge the Foe -> Priority Assets
 
+  DETACHMENT RULES:
+    Modified (2):
+      ~ Skitarii Hunter Cohort
+        - rules: Stealth Optimisation: paragraph 1 text updated
+      ~ Rad-Zone Corps
+        - rules: Rad-Bombardment: paragraph 3 text updated
+
 ------------------------------------------------------------
 FACTION: Adeptus Mechanicus (Combat Patrol)
 ------------------------------------------------------------
@@ -1196,16 +1259,16 @@ FACTION: Adeptus Mechanicus (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Manipulus Skand
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Transonic Cannon: BS/WS: 6+ -> -
       ~ Purge Corps Pteraxii Sterylizors
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Phosphor Torch: BS/WS: 6+ -> -
       ~ Purge Corps Serberys Sulphurhounds
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Sulphur breath: BS/WS: 6+ -> -
       ~ Purge Corps Skitarii Vanguard
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
 
   ENHANCEMENTS:
     Modified (1):
@@ -1262,16 +1325,16 @@ FACTION: Adeptus Custodes (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Gilded Blades Allarus Custodians
-        - points: 2 models: 0 -> null pts
+        - points: 2 models: Removed explicit points value (was 0 pts)
       ~ Gilded Blades Custodian Guard
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Sentinel Blade – Ranged: Added
         - meleeWeapons: Sentinel Blade – Melee: Added
         - meleeWeapons: Sentinel Blade: Removed
       ~ Gilded Blades Custodian Wardens
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Tristraen of the Gilded Blades
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Agents of the Imperium
@@ -1341,18 +1404,20 @@ FACTION: Agents of the Imperium (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (4):
+    Modified (5):
       ~ Inquisitor's Hand Eversor Assassin
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Inquisitor's Hand Inquisitorial Agents
-        - points: 6 models: 0 -> null pts
+        - points: 6 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Plasma Pistol – Standard: AP: -1 -> -2
         - rangedWeapons: Plasma Pistol – Supercharge: AP: -2 -> -3
         - abilities.other: modified: Tome Skull (Once per battle per unit)
       ~ Inquisitor's Hand Vigilant Squad
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
+      ~ Inquisitor's Hand Vigilant Squad
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Preacher Teguen
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Zealot's Vindictor: BS/WS: 3+ -> -
 
 ------------------------------------------------------------
@@ -1365,7 +1430,7 @@ FACTION: Orks
         - points: 1 models: 100 -> 115 pts
         - additionalCost: Removed additional selection cost (+10 pts)
       ~ Big Mek with Shokk Attack Gun
-        - additionalCost: Additional selection cost: +10 -> +10 pts
+        - additionalCost: Additional selection cost of +10 pts now applies after 1 selection (previously after 2 selections)
       ~ Blitza-bommer
         - keywords: removed: Frame
       ~ Boomdakka Snazzwagon
@@ -1453,22 +1518,28 @@ FACTION: Orks
       ~ Green Tide
         - detachmentPoints: 2 -> 3
 
+  DETACHMENT RULES:
+    Added (1):
+      + Equatorial Hordes
+
 ------------------------------------------------------------
 FACTION: Orks (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (5):
+    Modified (6):
       ~ ’Ardmob Boyz
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
+      ~ ’Ardmob Boyz
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ ’Ardmob Gretchin
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ ’Ardmob Warboss
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ ’Ardmob Wartrakk
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ 'Ardmob Weirdboy
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Leagues of Votann
@@ -1507,13 +1578,13 @@ FACTION: Leagues of Votann (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Bane Slayer's Bulwark Brokhyr Thunderkyn
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Bane-Slayer's Bulwark Einhyr Hearthguard
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Bane-Slayer's Bulwark Hearthkyn Warriors
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Vynn Bane-Slayer
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: T’au Empire
@@ -1574,13 +1645,13 @@ FACTION: T’au Empire (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Commander Cloudspear
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Sudden Dawn Cadre Breacher Team
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Sudden Dawn Cadre Devilfish
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Sudden Dawn Cadre Pathfinder Team
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Necrons
@@ -1646,6 +1717,11 @@ FACTION: Necrons
       ~ Pantheon of Woe
         - forceDisposition: Purge the Foe -> Disruption
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Pantheon of Woe
+        - rules: Cosmic Distortion: "Reletavistic Tether" text updated
+
   ARMY RULES:
     Modified (1):
       ~ Reanimation Protocols
@@ -1658,15 +1734,15 @@ FACTION: Necrons (Combat Patrol)
   DATASHEETS:
     Modified (5):
       ~ Amonhotekh's Guard Canoptek Doomstalker
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
       ~ Amonhotekh's Guard Canoptek Scarab Swarms
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Amonhotekh's Guard Necron Warriors
-        - points: 10 models: 0 -> null pts
+        - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Amonhotekh's Guard Skorpekh Destroyers
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Overlord Amonhotekh
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Asuryani
@@ -1779,17 +1855,19 @@ FACTION: Asuryani (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (4):
+    Modified (5):
       ~ Kygharil's Protectors Dire Avengers
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
+      ~ Kygharil's Protectors Dire Avengers
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Kygharil's Protectors Warp Spiders
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Death Spinner: BS/WS: 6+ -> -
         - rangedWeapons: Death Weavers: BS/WS: 6+ -> -
       ~ Kygharil's Protectors Wraithblades
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Spiritseer Kygharil
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - abilities.other: modified: Tears of Isha (Psychic)
 
 ------------------------------------------------------------
@@ -1835,17 +1913,19 @@ FACTION: Drukhari (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (4):
+    Modified (5):
       ~ Coven of Agonies Cronos
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Spirit Syphon: BS/WS: 6+ -> -
       ~ Coven of Agonies Talos
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Twin Liquifier Gun: BS/WS: 3+ -> -
       ~ Coven of Agonies Wracks
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
+      ~ Coven of Agonies Wracks
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Xatrophos Nuul
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Genestealer Cults
@@ -1902,20 +1982,23 @@ FACTION: Genestealer Cults (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (4):
+    Modified (5):
       ~ Claw of Ascension Achilles Ridgerunner
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Twin Heavy Stubber: Added
         - rangedWeapons: Missile Launcher: Added
         - meleeWeapons: Twin Heavy Stubber: Removed
         - meleeWeapons: Missile Launcher: Removed
       ~ Claw of Ascension Atalan Jackals
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Claw of Ascension Hybrid Metamorphs
-        - points: 5 models: 0 -> null pts
+        - points: 5 models: Removed explicit points value (was 0 pts)
+        - rangedWeapons: Hand Flamer: BS/WS: 6+ -> -
+      ~ Claw of Ascension Hybrid Metamorphs
+        - points: 5 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Hand Flamer: BS/WS: 6+ -> -
       ~ Shanus Daskovian
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Emperor’s Children
@@ -1968,13 +2051,15 @@ FACTION: Emperor’s Children (Combat Patrol)
 ------------------------------------------------------------
 
   DATASHEETS:
-    Modified (3):
+    Modified (4):
       ~ Callous Blades Flawless Blades
-        - points: 3 models: 0 -> null pts
+        - points: 3 models: Removed explicit points value (was 0 pts)
+      ~ Callous Blades Flawless Blades
+        - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Callous Blades Infractors
         - points: Added 10 models option at null pts
       ~ Lord Kaphrael of the Callous Blades
-        - points: 1 models: 0 -> null pts
+        - points: 1 models: Removed explicit points value (was 0 pts)
 
 ================================================================================
 STATISTICS
@@ -1983,10 +2068,11 @@ Total factions processed: 53
 Factions with changes: 52
 Factions without changes: 1
 
-Datasheets:    +0 added, -0 removed, ~404 modified
+Datasheets:    +0 added, -0 removed, ~417 modified
 Stratagems:    +7 added, -1 removed, ~31 modified
 Enhancements:  +4 added, -0 removed, ~47 modified
 Detachments:   +2 added, -0 removed, ~63 modified
+Detach. Rules: +2 added, -0 removed, ~10 modified
 Army Rules:    +0 added, -0 removed, ~6 modified
 ================================================================================
 

--- a/11th/changelogs/912_changelog.txt
+++ b/11th/changelogs/912_changelog.txt
@@ -58,9 +58,9 @@ FACTION: Adeptus Mechanicus (Combat Patrol)
 ================================================================================
 STATISTICS
 ================================================================================
-Total factions processed: 53
+Total factions processed: 54
 Factions with changes: 4
-Factions without changes: 49
+Factions without changes: 50
 
 Datasheets:    +0 added, -0 removed, ~2 modified
 Stratagems:    +0 added, -0 removed, ~0 modified

--- a/11th/changelogs/912_changelog.txt
+++ b/11th/changelogs/912_changelog.txt
@@ -31,6 +31,15 @@ FACTION: Astra Militarum (Combat Patrol)
         - keywords: removed: Kasrkin
 
 ------------------------------------------------------------
+FACTION: Grey Knights (Combat Patrol)
+------------------------------------------------------------
+
+  ENHANCEMENTS:
+    Modified (1):
+      ~ Sanctified Auspexes
+        - equipableByNonCharacter: Can now be given to non-Character units
+
+------------------------------------------------------------
 FACTION: Adeptus Mechanicus (Combat Patrol)
 ------------------------------------------------------------
 
@@ -44,17 +53,19 @@ FACTION: Adeptus Mechanicus (Combat Patrol)
         - keywords: added: Adeptus Mechanicus
         - keywords: removed: Serberys Sulphurhounds
         - keywords: removed: Purge Corps Deltic-9
+        - equipableByNonCharacter: Can now be given to non-Character units
 
 ================================================================================
 STATISTICS
 ================================================================================
 Total factions processed: 53
-Factions with changes: 3
-Factions without changes: 50
+Factions with changes: 4
+Factions without changes: 49
 
 Datasheets:    +0 added, -0 removed, ~2 modified
 Stratagems:    +0 added, -0 removed, ~0 modified
-Enhancements:  +0 added, -0 removed, ~3 modified
+Enhancements:  +0 added, -0 removed, ~4 modified
 Detachments:   +0 added, -0 removed, ~0 modified
+Detach. Rules: +0 added, -0 removed, ~0 modified
 Army Rules:    +0 added, -0 removed, ~0 modified
 ================================================================================

--- a/11th/changelogs/913_changelog.txt
+++ b/11th/changelogs/913_changelog.txt
@@ -53,6 +53,14 @@ FACTION: Agents of the Imperium
       ~ Vindicare Assassin
         - points: 1 models (Veiled Blade Elimination Force): 155 -> 130 pts
 
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Veiled Blade Elimination Force
+        - rules: Extremis Sanction: "Decoy Targets" cost: +40 points -> +15 points
+        - rules: Extremis Sanction: "Esoteric Explosives" cost: +40 points -> +10 points
+        - rules: Extremis Sanction: "Intraneural Biotech" cost: +35 points -> +15 points
+        - rules: Extremis Sanction: "Micromelta Rounds" cost: +45 points -> +20 points
+
 ------------------------------------------------------------
 FACTION: Necrons
 ------------------------------------------------------------
@@ -84,6 +92,7 @@ Datasheets:    +0 added, -0 removed, ~7 modified
 Stratagems:    +0 added, -0 removed, ~0 modified
 Enhancements:  +0 added, -0 removed, ~0 modified
 Detachments:   +0 added, -0 removed, ~0 modified
+Detach. Rules: +0 added, -0 removed, ~1 modified
 Army Rules:    +0 added, -0 removed, ~0 modified
 ================================================================================
 

--- a/11th/changelogs/913_changelog.txt
+++ b/11th/changelogs/913_changelog.txt
@@ -84,9 +84,9 @@ FACTION: Emperor’s Children (Combat Patrol)
 ================================================================================
 STATISTICS
 ================================================================================
-Total factions processed: 53
+Total factions processed: 54
 Factions with changes: 4
-Factions without changes: 49
+Factions without changes: 50
 
 Datasheets:    +0 added, -0 removed, ~7 modified
 Stratagems:    +0 added, -0 removed, ~0 modified

--- a/11th/gdc/adeptasororitas.json
+++ b/11th/gdc/adeptasororitas.json
@@ -7,7 +7,7 @@
     "header": "#570c0c"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.448Z",
+  "updated": "2026-07-28T17:03:06.772Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -1718,7 +1718,7 @@
   ],
   "enhancements": [
     {
-      "id": "0253ec95-6bfc-55ef-a3fe-42b8bf44d648",
+      "id": "99da3437-31b9-5850-9a52-e2892995922e",
       "name": {
         "en": "Symphonic Payload (Upgrade)",
         "de": "Symphonie der Vernichtung (Aufwertung)",
@@ -1732,6 +1732,7 @@
       "cost": "10",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Exorcist</k> unit only. This unit can re‑roll rolls to determine the <b>A</b> of a weapon.",
         "de": "Nur für eine <k>Exorzist</k>-Einheit. Diese Einheit kann Würfe zum Bestimmen der <b>A</b> einer Waffe wiederholen.",
@@ -1750,7 +1751,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6fc8cf78-2744-56ac-a514-6d81cc9d21e3",
+      "id": "60c5375e-0af0-54a8-923b-b7dc8c3b1b9c",
       "name": {
         "en": "Perfervid Haste",
         "de": "Leidenschaftliche Hast",
@@ -1764,6 +1765,7 @@
       "cost": "10",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adepta Sororitas</k> model only. This unit has +1\" <b>M</b>.",
         "de": "Nur für ein <k>Adepta-Sororitas</k>-Modell. Diese Einheit hat +1\" <b>B</b>.",
@@ -1782,7 +1784,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8a81500f-21a0-5ec4-9e3b-f775339e0d46",
+      "id": "c669fa05-fecf-5df5-9d58-b8e2dfd4ec19",
       "name": {
         "en": "Clarion of Urgency",
         "de": "Ruf zur Dringlichkeit",
@@ -1796,6 +1798,7 @@
       "cost": "15",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Canoness with Jump Pack</k> model only. At the end of your opponent’s Fight phase, if this unit is <b>unengaged</b>, you can place this unit in <b>strategic reserves</b>.",
         "de": "Nur für ein <k>Principalis-mit-Sprungmodul</k>-Modell. Wenn diese Einheit am Ende der Nahkampfphase deines Gegners <b>nicht im Nahkampf</b> ist, kannst du diese Einheit in <b>strategische Reserve</b> versetzen.",
@@ -1814,7 +1817,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "28134f7e-f27c-5561-9944-1ade735e6ca5",
+      "id": "e20b88e7-bd65-50b6-9991-eb8de145867f",
       "name": {
         "en": "Writ of Compunction (Upgrade)",
         "de": "Schrift der Reue (Aufwertung)",
@@ -1828,6 +1831,7 @@
       "cost": "20",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Celestian Sacresants</k> unit only. This unit has +1 <b>OC</b>.",
         "de": "Nur für eine <k>Celestia-Sacresantis</k>-Einheit. Diese Einheit hat +1 <b>MK</b>.",
@@ -1846,7 +1850,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "32558296-f764-5798-9be6-53b04123b31c",
+      "id": "b6e76426-aaf9-5236-beef-b6483c687ef1",
       "name": {
         "en": "Hagiomnifex (Upgrade)",
         "de": "Hagiomnifex (Aufwertung)",
@@ -1860,6 +1864,7 @@
       "cost": "25",
       "keywords": ["Character", "Adepta Sororitas"],
       "excludes": ["Penitent", "Penitent"],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Adepta Sororitas Character</k> model only (excluding <k>Penitent</k> units). (Once per turn, per unit) At the start of a phase, you can use this ability. If you do, select one of the abilities below:\n<ul><li><b>Rite of Revelation:</b> While this unit is shooting, enemy units have +6\" <b>detection range</b>.</li>\n<li><b>Sermon of Intolerance:</b> This unit’s <b>battle‑shock rolls</b> automatically succeed.</li>\n<li><b>Catechism of Raging Fervour:</b> This unit has +1\" <b>M</b>.</li>\n<li><b>Psalm of Righteous Smiting:</b> This unit’s attacks have +1 <b>S</b>.</li>\n<li><b>Chorus of Repudiation:</b> Attacks that target this unit with a <b>S</b> greater than this unit’s <b>T</b> have ‑1 to <b>wound rolls</b>.</li></ul>",
         "de": "Nur für ein <k>ADEPTA-SORORITAS-CHARAKTERMODELL</k> (ausgenommen <k>BÜSSER</k>-Einheiten). (Einmal pro Zug, pro Einheit) Zu Beginn einer Befehlsphase kannst du diese Fähigkeit einsetzen. Wenn du dies tust, wähle eine der folgenden Fähigkeiten:\r<ul><li><b>Ritus der Offenbarung:</b> Solange diese Einheit schießt, haben feindliche Einheiten +6\" <b>Entdeckungsreichweite</b>.</li>\r<li><b>Predigt der Intoleranz: Erschütterungswürfe</b> für diese Einheit sind automatisch erfolgreich.</li>\r<li><b>Katechismus des religiösen Eifers:</b> Diese Einheit hat bis +1\" <b>B</b>.</li>\r<li><b>Psalm der rechtschaffenen Niederwerfung:</b> Attacken dieser Einheit haben +1 <b>S</b>.</li>\r<li><b>Choral der Zurückweisung:</b> Attacken gegen diese Einheit, deren <b>S</b> höher ist als der <b>W</b> dieser Einheit, haben ‑1 auf <b>Verwundungswürfe</b>.</li></ul>",
@@ -1878,13 +1883,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "63bb8953-4986-5ef6-aea9-0d2bfe282e4e",
+      "id": "258998c0-1b1a-56f0-bcda-266e06d5e9d9",
       "name": {
         "en": "Saintly Example"
       },
       "cost": "10",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. When the bearer is destroyed, you gain an additional D3 Miracle dice."
       },
@@ -1896,13 +1902,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "534a93e2-6f50-592b-a3b6-03869ae3ff8c",
+      "id": "b3112641-8dcc-563b-8295-f6afdc1aca45",
       "name": {
         "en": "Through Suffering, Strength"
       },
       "cost": "25",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. Add 1 to the Attacks, Strength and Damage characteristics of the bearer’s melee weapons. If the bearer has lost one or more wounds, add 2 to the Attacks, Strength and Damage characteristics of the bearer’s melee weapons instead."
       },
@@ -1914,13 +1921,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3d84365d-494e-5fcd-80d7-67ec641134ab",
+      "id": "dbc93e34-9b18-5eda-bf54-fa44a06d98cb",
       "name": {
         "en": "Chaplet of Sacrifice"
       },
       "cost": "25",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. At the end of your Command phase, if the bearer is on the battlefield, you can re-roll 1 Miracle dice from your Miracle dice pool and return it to your Miracle dice pool showing the new result you rolled. When doing so, if the bearer’s unit is below its Starting Strength, you can re-roll up to 3 Miracle dice in this way instead."
       },
@@ -1932,13 +1940,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "375c7f23-0450-5684-87c3-6760fb4a1406",
+      "id": "b5b25e98-ca3a-567e-ba51-a0a6a0af5399",
       "name": {
         "en": "Mantle of Ophelia"
       },
       "cost": "20",
       "keywords": ["Palatine", "Canoness"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CANONESS** or **PALATINE** model only. Each time an attack is allocated to the bearer, change the Damage characteristic of that attack to 1."
       },
@@ -1950,13 +1959,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a164080f-f597-5058-a312-cea310b2cd39",
+      "id": "28bd915e-12f9-5b4e-a901-013bf4e71053",
       "name": {
         "en": "Psalm of Righteous Judgement"
       },
       "cost": "20",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. While the bearer is on the battlefield, each time an enemy unit is destroyed by a **PENITENT** unit from your army, you can discard 1 Miracle dice then gain 1 Miracle dice showing a value of 6."
       },
@@ -1968,13 +1978,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "77d5b6b6-ced6-5b96-83cd-602273799ae2",
+      "id": "656f7705-49ef-5d50-bb5a-7803683c72fa",
       "name": {
         "en": "Verse of Holy Piety"
       },
       "cost": "15",
       "keywords": ["Penitent"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**PENITENT** model only. Once per battle, at the start of the battle round, select one Vow of Atonement (see the Desperate for Redemption detachment rule). Until the start of the next battle round, that Vow of Atonement is active for the bearer’s unit in addition to any that is active for your army, even if you have already selected that Vow of Atonement this battle."
       },
@@ -1986,13 +1997,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f15c9936-e9d3-535e-8a8c-dcdcba855358",
+      "id": "4d5847dc-4a1b-5ab7-adf9-f0d504995de8",
       "name": {
         "en": "Refrain of Enduring Faith"
       },
       "cost": "15",
       "keywords": ["Penitent"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**PENITENT** model only. While the bearer is leading a unit, models in that unit have a 5+ invulnerable save."
       },
@@ -2004,13 +2016,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3b9275d5-311b-59d3-93e6-624d7e613ce3",
+      "id": "551843ea-c06f-5fb1-9301-c9dab0dcbb5b",
       "name": {
         "en": "Catechism of Divine Penitence"
       },
       "cost": "15",
       "keywords": ["Ministorum Priest", "Palatine", "Canoness"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CANONESS**, **PALATINE** or **MINISTORUM PRIEST** model only. The bearer gains the **PENITENT** keyword."
       },
@@ -2022,13 +2035,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "35e0f1a9-120f-5cdb-a7ec-7385e161c147",
+      "id": "a2123439-1480-5237-9dd7-8801ef044a03",
       "name": {
         "en": "Righteous Rage"
       },
       "cost": "15",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. Each time the bearer is selected to fight, you can first discard up to 3 Miracle dice. For each Miracle dice just discarded, until the end of the phase, add 1 to the Attacks and Strength characteristics of the bearer’s melee weapons."
       },
@@ -2040,13 +2054,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "42c58a27-030e-5e8d-9422-f70646e676dd",
+      "id": "2cbc0ee4-1b9a-544b-a55a-45c5cb401879",
       "name": {
         "en": "Manual of Saint Griselda"
       },
       "cost": "20",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. At the start of your Command phase, you can discard up to 2 Miracle dice. Then, add 1 Miracle dice to your Miracle Dice pool showing a value equal to the sum of the two Miracle dice you just discarded (to a maximum of 6)."
       },
@@ -2058,13 +2073,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "26b02b94-2639-5e25-abbf-bb72091588ac",
+      "id": "6fe83448-8c81-5994-ad03-f390ec81b4fd",
       "name": {
         "en": "Fire and Fury"
       },
       "cost": "30",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. While the bearer is leading a unit, add 1 to the Attacks characteristic of Torrent weapons equipped by models in that unit, and all other ranged weapons equipped by models in that unit have the **[SUSTAINED HITS 1]** ability."
       },
@@ -2076,13 +2092,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2dc255e5-0231-5904-b6cf-471c5155b118",
+      "id": "06bc7540-81a9-5d78-b941-5d04d1dc5508",
       "name": {
         "en": "Iron Surplice of Saint Istalela"
       },
       "cost": "10",
       "keywords": ["Palatine", "Canoness"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CANONESS** or **PALATINE** model only. The bearer has a Save characteristic of 2+ and the Feel No Pain 5+ ability."
       },
@@ -2094,13 +2111,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b457ebb3-da1b-51c2-944a-7176c6b0b20d",
+      "id": "9e75243b-b777-50ec-8967-4846e939516e",
       "name": {
         "en": "Litanies of Faith"
       },
       "cost": "10",
       "keywords": ["Canoness", "Palatine"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CANONESS** or **PALATINE** model only. At the start of your Command phase, if the bearer is on the battlefield, take a Leadership test for the bearer. If that test is passed, you gain 1 Miracle dice."
       },
@@ -2112,13 +2130,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e13dfa67-8e71-59ff-ba3c-b107149f2736",
+      "id": "4b900e67-33fc-5dd4-9930-54448af5791d",
       "name": {
         "en": "Blade of Saint Ellynor"
       },
       "cost": "15",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. Improve the Strength and Armour Penetration characteristics of the bearer’s melee weapons by 1, and those weapons have the **[PRECISION]** ability. In addition, each time the bearer fights, if one or more enemy models are destroyed by those attacks, you gain 1 Miracle dice."
       },
@@ -2130,13 +2149,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2f7d3dcf-fdab-53df-b664-66b4251e8e1e",
+      "id": "2711a479-61b8-52dc-969d-3eed2203d5f2",
       "name": {
         "en": "Divine Aspect"
       },
       "cost": "5",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. In your Movement phase, you can select one enemy unit within 12\" of the bearer; that unit must take a Battle-shock test. If that test is failed, you gain 1 Miracle dice."
       },
@@ -2148,13 +2168,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "922ffaf8-fae7-5adf-abc4-d574610adda2",
+      "id": "4eba52a6-1a06-518f-8def-91b40ec15be5",
       "name": {
         "en": "Triptych of the Macharian Crusade"
       },
       "cost": "20",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. Each time the bearer uses an Act of Faith to substitute a saving throw, that saving throw is successful, irrespective of the value of the Miracle dice used."
       },
@@ -2166,13 +2187,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "93c1efc0-65c8-5ac3-bf40-a0a38f721e4c",
+      "id": "89c4114e-691b-5d13-9e3e-52586248002c",
       "name": {
         "en": "Triptych of Judgement"
       },
       "cost": "15",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. Each time a model in the bearer’s unit makes an attack, you can ignore any or all modifiers to that attack’s Ballistic Skill or Weapon Skill characteristics and/or any or all modifiers to the Hit roll."
       },
@@ -2184,13 +2206,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a824556d-864f-5dc2-af18-851dbf5454e5",
+      "id": "48eeb0d1-a6a4-5827-beed-a69748dd860b",
       "name": {
         "en": "Mark of Devotion"
       },
       "cost": "30",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. Add 1 to the Attacks characteristic of the bearer’s melee weapons. While the bearer’s unit is Righteous, add 2 to the Attacks characteristic and add 1 to the Damage characteristic of the bearer’s melee weapons instead."
       },
@@ -2202,13 +2225,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fca5578e-70f5-5c60-9906-d49803c4db07",
+      "id": "692668cc-5f32-5324-8dcd-302357ccb900",
       "name": {
         "en": "Eyes of the Oracle"
       },
       "cost": "10",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. The bearer’s weapons have the **[PRECISION]** ability. Each time the bearer’s unit destroys an enemy **CHARACTER** model, you gain 1CP."
       },
@@ -2220,13 +2244,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "51d1d4c5-9135-5a90-b178-86f7e683cbaf",
+      "id": "c692bc8c-3b93-5ea2-a326-2bd1d67310b5",
       "name": {
         "en": "Sanctified Amulet"
       },
       "cost": "25",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTA SORORITAS** model only. Enemy units that are set up on the battlefield from Reserves cannot be set up within 12\" of the bearer."
       },
@@ -2464,7 +2489,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ ***CRUSADERS** ■ **BATTLE SISTERS SQUAD** ■ **CELESTIAN INSIDIANTS** ■ **CELESTIAN SACRESANTS** ■ **DOMINION SQUAD** ■ **RETRIBUTOR SQUAD** ■ **SISTERS NOVITIATE SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sisters Novitiate Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "88b82e4e-c012-50aa-976a-9b63482f25b2",
@@ -3587,7 +3644,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ ***CRUSADERS** ■ **BATTLE SISTERS SQUAD** ■ **CELESTIAN INSIDIANTS** ■ **CELESTIAN SACRESANTS** ■ **DOMINION SQUAD** ■ **RETRIBUTOR SQUAD** ■ **SISTERS NOVITIATE SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sisters Novitiate Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5e4d40c1-01c3-53c4-b5ac-9e63c0f5fc00",
@@ -3819,7 +3908,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SERAPHIM SQUAD** ■ **ZEPHYRIM SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Seraphim Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Zephyrim Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3741efa4-b45c-5588-bd3b-e34b7723c590",
@@ -5200,6 +5301,38 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sisters Novitiate Squad",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -5384,6 +5517,33 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -6340,7 +6500,39 @@
       "additionalCost": {
         "cost": "10",
         "afterSelections": 1
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sisters Novitiate Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6d7a9fea-15a3-566c-8893-f1996af06914",
@@ -6545,6 +6737,33 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -7241,7 +7460,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CRUSADERS** ■ **BATTLE SISTERS SQUAD** ■ **CELESTIAN INSIDIANTS** ■ **CELESTIAN SACRESANTS** ■ **DOMINION SQUAD** ■ **RETRIBUTOR SQUAD** ■ **SISTERS NOVITIATE SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sisters Novitiate Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "94fc8f61-aafe-53c9-9cad-e37a8a6dd614",
@@ -7466,7 +7717,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ ***CRUSADERS** ■ **ARCO-FLAGELLANTS** ■ **BATTLE SISTERS SQUAD** ■ **CELESTIAN INSIDIANTS** ■ **DOMINION SQUAD** ■ **SANCTIFIERS** ■ **SISTERS NOVITIATE SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Arco-flagellants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sanctifiers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sisters Novitiate Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "00f20888-3070-5238-b767-f35bc0fc216f",
@@ -8000,7 +8283,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PARAGON WARSUITS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Paragon Warsuits",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d283a405-4cbf-5ef3-8f5c-b863a879ba96",
@@ -8211,7 +8501,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ ***CRUSADERS** ■ **BATTLE SISTERS SQUAD** ■ **CELESTIAN INSIDIANTS** ■ **CELESTIAN SACRESANTS** ■ **DOMINION SQUAD** ■ **RETRIBUTOR SQUAD** ■ **SISTERS NOVITIATE SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Insidiants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Celestian Sacresants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Dominion Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Retributor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sisters Novitiate Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "da1adfbf-6de1-5432-bfa9-b9d3d95c4770",
@@ -9764,7 +10086,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SERAPHIM SQUAD** ■ **ZEPHYRIM SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Seraphim Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Zephyrim Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "fb25fb97-0644-5c52-ac27-40ba1170b23e",
@@ -11478,7 +11812,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ ***CRUSADERS** ■ **BATTLE SISTERS SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Battle Sisters Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d7f0b494-8805-52ab-99c7-6660b49c0763",

--- a/11th/gdc/adeptuscustodes.json
+++ b/11th/gdc/adeptuscustodes.json
@@ -7,7 +7,7 @@
     "header": "#6d5035"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.792Z",
+  "updated": "2026-07-28T17:03:07.474Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2089,7 +2089,7 @@
   ],
   "enhancements": [
     {
-      "id": "8cc04674-8027-5edb-9bcd-76286f4c53e6",
+      "id": "707e9e52-4358-50f0-8be9-facd4d9be75d",
       "name": {
         "en": "Psyk-out Grenades (Upgrade)",
         "de": "Anti-Psi-Granaten (Aufwertung)",
@@ -2103,6 +2103,7 @@
       "cost": "10",
       "keywords": ["Anathema Psykana"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Anathema Psykana</k> unit only.\n<ul><li>This unit has <k>Explosives</k>.</li>\n<li>When you target this unit with the <b>Explosives stratagem</b>, if you select an enemy <k>Psyker</k> unit, you can re-roll rolls to determine whether that enemy unit suffers a <b>mortal wound</b>.</li></ul>",
         "de": "Nur für eine <k>Anathema-Psikana</k>-Einheit.\r<ul><li>Diese Einheit hat <k>Sprengsätze</k>.</li>\r<li>Wenn du die <b>Gefechtsoption Sprengsätze</b> mit dieser Einheit als Ziel einsetzt und eine feindliche <k>Psioniker</k>-Einheit wählst, kannst du Würfe wiederholen, die bestimmen, ob jene feindliche Einheit eine <b>tödliche Verwundung</b> erleidet.</li></ul>",
@@ -2121,7 +2122,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fc4f2d82-b8c5-57f3-827e-69613da3a231",
+      "id": "8f36c5e3-72d9-534a-8837-f527f340b520",
       "name": {
         "en": "Auramite Sarcophagus (Upgrade)",
         "de": "Auramit-Sarcophagus (Aufwertung)",
@@ -2135,6 +2136,7 @@
       "cost": "15",
       "keywords": ["Walker", "Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Adeptus Custodes Walker</k> unit only. When you target this unit with the <b>Crushing Impact stratagem</b>, that use is -1 <b>CP</b>.",
         "de": "Nur für eine <k>Adeptus</k>-<k>Custodes</k>-<k>Läufer</k>-Einheit. Wenn du die <b>Gefechtsoption Zerschmetternder Aufprall</b> mit dieser Einheit als Ziel einsetzt, kostet jener Einsatz -1 <b>BP</b>.",
@@ -2153,7 +2155,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8ebff6d2-bd3d-50dc-b650-89c9a3a2c14c",
+      "id": "3eccfc9c-5adf-510a-b9a7-2d4c553f1570",
       "name": {
         "en": "Encircling Hunter",
         "de": "Kreisende Jägerin",
@@ -2167,6 +2169,7 @@
       "cost": "15",
       "keywords": ["Anathema Psykana"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Anathema Psykana</k> model only. When both players have deployed their armies, you can redeploy up to three friendly <k>Anathema Psykana Infantry</k> units. When doing so, you can set those units up in <b>strategic reserves</b>, regardless of how many units are already in <b>strategic reserves</b>.",
         "de": "Nur für ein <k>Anathema-Psikana</k>-Modell. Wenn beide Spieler ihre Armeen aufgestellt haben, kannst du bis zu drei befreundete <k>Anathema-Psikana</k>-­Einheiten neu aufstellen. Wenn du dies tust, kannst du jene Einheiten in die <b>strategische Reserve</b> versetzen, unabhängig davon, wie viele Einheiten sich bereits in der <b>strategischen Reserve</b> befinden.",
@@ -2185,7 +2188,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5d3843f0-2ecc-5c96-9266-fc9ea01a8b59",
+      "id": "c7bcb884-4712-5373-aafa-9a6793ad3272",
       "name": {
         "en": "Interred Expertise (Upgrade)",
         "de": "Eingebettetes Expertenwissen (Aufwertung)",
@@ -2199,6 +2202,7 @@
       "cost": "25",
       "keywords": ["Walker", "Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Adeptus Custodes Walker</k> unit only. This unit’s attacks can:\r<ul><li>Re‑roll <b>hit rolls</b> of 1.</li>\r<li>Re‑roll <b>wound rolls</b> of 1.</li></ul>",
         "de": "Nur für eine <k>Adeptus</k>-<k>Custodes</k>-<k>Läufer</k>-Einheit. Für die Attacken dieser Einheit können:\r<ul><li><b>Trefferwürfe</b> von 1 wiederholt werden.</li>\r<li><b>Verwundungswürfe</b> von 1 wiederholt werden.</li></ul>",
@@ -2217,7 +2221,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6ba75f58-5e8e-5935-b3f9-0223b2eb60a9",
+      "id": "953f9cab-45a7-50c9-afa5-51c69728b07e",
       "name": {
         "en": "Mnemo-locked Shrine Cipher",
         "de": "Gedächtnisverschlüsselter Schreincode",
@@ -2231,6 +2235,7 @@
       "cost": "25",
       "keywords": ["Terminator", "Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Custodes Terminator</k> model only. In your first Movement phase, this unit can make an <b>ingress move</b>.",
         "de": "Nur für ein <k>Adeptus</k>-<k>Custodes</k>-<k>Terminator</k>-Modell. Diese Einheit kann in deiner ersten Bewegungsphase eine <b>Einsatzbewegung</b> ausführen.",
@@ -2249,7 +2254,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "17c03464-b6f6-566b-8840-3eea7e149942",
+      "id": "e082ad4a-93de-5938-b02d-9eea54ae7add",
       "name": {
         "en": "Efficient Aggression",
         "de": "Effiziente Aggression",
@@ -2263,6 +2268,7 @@
       "cost": "25",
       "keywords": ["Terminator", "Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Custodes Terminator</k> model only. (Once per turn, per army) In your opponent’s Shooting phase, when an enemy unit has shot, if this unit lost a wound as a result of those attacks, this unit can make a <b>surge move</b> of up to D6+1\".",
         "de": "Nur für ein <k>Adeptus</k>-<k>Custodes</k>-<k>Terminator</k>-Modell. (Einmal pro Zug, pro Armee) In der Fernkampfphase deines Gegners kann diese Einheit, nachdem eine feindliche Einheit geschossen hat und diese Einheit durch jene Attacken mindestens einen Lebenspunkt verloren hat, eine <b>Ansturmbewegung</b> von bis zu W6+1\" ausführen.",
@@ -2281,13 +2287,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c48e7ca-4887-5e92-a257-2fea7f4c9c28",
+      "id": "5cb00a59-ae2a-5495-874d-a06b27776ec0",
       "name": {
         "en": "Radiant Mantle"
       },
       "cost": "30",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. Each time an attack targets the bearer’s unit, if the attacking model is within 12\", subtract 1 from the Hit roll."
       },
@@ -2299,13 +2306,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "66ed7f74-f5b7-5fbf-a0e8-4c579019f95d",
+      "id": "8dd94065-def4-5ce1-983c-fc400637f003",
       "name": {
         "en": "Gift of Terran Artifice"
       },
       "cost": "15",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. Each time the bearer makes a melee attack, add 1 to the Wound roll."
       },
@@ -2317,13 +2325,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e76461c8-f5e4-5de4-9ac1-a9eacaecfed4",
+      "id": "7b9c46ff-aacd-57fc-9a52-41b6bec07154",
       "name": {
         "en": "Champion of the Imperium"
       },
       "cost": "25",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. The range of the bearer’s Null Aegis or Deadly Unity ability is increased to 9\"."
       },
@@ -2335,13 +2344,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8cea8354-4ea2-5ee6-86b8-e152dd6b38cb",
+      "id": "f44df5b3-e3a9-5aa5-b0db-3b0a3745dc41",
       "name": {
         "en": "Aegis Projector"
       },
       "cost": "20",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. Once per turn, the first time a saving throw is failed for the bearer’s unit, change the Damage characteristic of that attack to 0."
       },
@@ -2353,13 +2363,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "20443bdc-0816-5747-8439-0be4e730b911",
+      "id": "203387f6-a018-5ec0-bb99-9580c67beab1",
       "name": {
         "en": "From the Hall of Armouries"
       },
       "cost": "20",
       "keywords": ["Shield-Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHIELD‑CAPTAIN** model only. Add 1 to the Strength and Damage characteristics of the bearer’s melee weapons."
       },
@@ -2371,13 +2382,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cee6f358-d49c-5211-a71b-9158da4e44a5",
+      "id": "df923fa6-dd97-5d40-9150-fd22ba7ad752",
       "name": {
         "en": "Castellan’s Mark"
       },
       "cost": "20",
       "keywords": ["Shield-Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHIELD‑CAPTAIN** model only. After both players have deployed their armies, you can select up to two **ADEPTUS CUSTODES** units from your army (excluding **ANATHEMA PSYKANA** units) and redeploy all of those units. When doing so, any of those units can be placed into Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -2389,13 +2401,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2895c197-59a2-5c74-97bd-6d2b2155e809",
+      "id": "0bb79ab9-de62-573c-b4c3-e5898a754e49",
       "name": {
         "en": "Auric Mantle"
       },
       "cost": "15",
       "keywords": ["Blade Champion", "Shield-Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHIELD‑CAPTAIN** or **BLADE CHAMPION** model only. Add 2 to the bearer’s Wounds characteristic."
       },
@@ -2407,13 +2420,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "391bdcad-e358-5f6f-9f2f-dd38ec95aaa0",
+      "id": "7dabdd0a-adbe-53a2-be12-92f2cc6ce2b5",
       "name": {
         "en": "Panoptispex"
       },
       "cost": "5",
       "keywords": ["Blade Champion", "Shield-Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHIELD‑CAPTAIN** or **BLADE CHAMPION** model only. While the bearer is leading a unit, ranged weapons equipped by models in that unit have the **[IGNORES COVER]** ability."
       },
@@ -2425,13 +2439,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ce4f2977-a0b3-5b3a-881e-beceed66f764",
+      "id": "5aab7b2b-e3dd-56f3-9b1d-b910c7ca5ed3",
       "name": {
         "en": "Raptor Blade"
       },
       "cost": "5",
       "keywords": ["Anathema Psykana"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ANATHEMA PSYKANA** model only. Add 1 to the Attacks, Strength and Damage characteristics of the bearer’s melee weapons. While the bearer is within Engagement Range of one or more enemy **PSYKER** units that are Battle‑shocked, add 2 to the Attacks, Strength and Damage characteristics of the bearer’s melee weapons instead."
       },
@@ -2443,13 +2458,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b55887df-591b-52f9-9531-7e02e9fb0cf7",
+      "id": "8b60bbc1-a155-5481-a6a1-d870caf744c5",
       "name": {
         "en": "Enhanced Voidsheen Cloak"
       },
       "cost": "10",
       "keywords": ["Anathema Psykana"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ANATHEMA PSYKANA** model only. Each time an attack is allocated to the bearer, subtract 1 from the Damage characteristic of that attack. If that attack was made by a **PSYKER** or Battle‑shocked model, change the Damage characteristic of that attack to 1 instead."
       },
@@ -2461,13 +2477,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "20710ec5-d85b-5c35-929f-44b851a1c88f",
+      "id": "034bdd57-8cd7-5586-8fbe-25049b19e6a8",
       "name": {
         "en": "Huntress’ Eye"
       },
       "cost": "15",
       "keywords": ["Anathema Psykana"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ANATHEMA PSYKANA** model only. In your Command phase, select one enemy unit within 12\" of the bearer. That unit must take a Battle‑shock test."
       },
@@ -2479,13 +2496,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ba327514-adfa-5f13-aec1-b490d2980529",
+      "id": "12ce10f7-dc0f-512a-9ae2-4a322f716f1c",
       "name": {
         "en": "Oblivion Knight"
       },
       "cost": "25",
       "keywords": ["Anathema Psykana"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ANATHEMA PSYKANA** model only. While the bearer is leading a unit, each time a model in that unit makes an attack, add 1 to the Hit roll. If that attack targeted an enemy **PSYKER** unit, add 1 to the Wound roll as well."
       },
@@ -2497,13 +2515,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c349a49-abca-5a86-8fcf-27aec55f8023",
+      "id": "07d424f8-5d64-5835-a079-eb1e3f9730a8",
       "name": {
         "en": "Blade Imperator"
       },
       "cost": "25",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. Each time the bearer’s unit ends a Charge move, select one enemy unit within Engagement Range of the bearer and roll one D6: on a 4+, that enemy unit suffers D3 mortal wounds. Once per battle, after the bearer’s unit ends a Charge move, all enemy units within 6\" of the bearer must take a Battle‑shock test."
       },
@@ -2515,13 +2534,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9cb3013e-8289-5361-9d34-952fbf0ed27c",
+      "id": "db009f0f-0475-5788-aa36-6bcecbb73af4",
       "name": {
         "en": "Inspirational Exemplar"
       },
       "cost": "10",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. The bearer has a Leadership characteristic of 5+. Once per battle, at the start of any phase, you can select one friendly **ADEPTUS CUSTODES** unit that is Battle‑shocked and within 12\" of the bearer; that unit is no longer Battle‑shocked."
       },
@@ -2533,13 +2553,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e5d9453b-6151-55f9-a5ad-ab0adda078f6",
+      "id": "7fdcb9e4-0655-5bca-aeaa-b8da629693ef",
       "name": {
         "en": "Veiled Blade"
       },
       "cost": "25",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. Add 2 to the Attacks characteristic of the bearer’s melee weapons. Once per battle, at the start of any Command phase, triple the bearer’s Objective Control characteristic until the end of the turn."
       },
@@ -2551,13 +2572,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d3a73051-27cb-5ad6-ba2c-b5c1d4ab121d",
+      "id": "a5906fc4-dad0-53cc-8d57-873f3b62382a",
       "name": {
         "en": "Martial Philosopher"
       },
       "cost": "30",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. The bearer’s unit is eligible to shoot and/or declare a charge in a turn in which it Fell Back. Once per battle, in your opponent's Movement phase, when an enemy unit ends a Normal, Advance or Fall Back move within 8\" of the bearer, if the bearer's unit is not within Engagement Range of one or more enemy units, it can make a Normal move of up to 6\"."
       },
@@ -2569,13 +2591,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "de87bd2a-5c6a-50dd-8b03-d8d49b19c3fd",
+      "id": "86b9af18-226e-55bc-812a-94adaf4e6bb7",
       "name": {
         "en": "Adamantine Talisman"
       },
       "cost": "25",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. Improve the Attacks, Strength and Damage characteristics of melee weapons equipped by the bearer by 1."
       },
@@ -2587,13 +2610,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5274b486-9020-5acf-8cd0-e90bf4c9feb5",
+      "id": "dafde617-f678-5e98-a999-d95231a375f5",
       "name": {
         "en": "Augury Uplink"
       },
       "cost": "35",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. The bearer has the Feel No Pain 5+ ability."
       },
@@ -2605,13 +2629,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "551da8bf-8c69-5faf-a328-0a03b9b99062",
+      "id": "3026d0fe-0fa4-51f3-ab38-e06f4dde7f7b",
       "name": {
         "en": "Honoured Fallen (Aura)"
       },
       "cost": "15",
       "keywords": ["Vehicle", "Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES VEHICLE** model only. While a friendly **ADEPTUS CUSTODES INFANTRY** or **ADEPTUS CUSTODES MOUNTED** unit is within 6\" of the bearer, each time a model in that unit makes an attack, re‑roll a Hit roll of 1."
       },
@@ -2623,13 +2648,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4671a39f-b2e8-5ace-b9db-054b51e2d070",
+      "id": "94375c4f-0b51-55d6-961a-c1fd462c3f27",
       "name": {
         "en": "Veteran of the Kataphraktoi"
       },
       "cost": "10",
       "keywords": ["Infantry", "Adeptus Custodes", "Mounted"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES INFANTRY** or **ADEPTUS CUSTODES MOUNTED** model only. In your Command phase, select one **ADEPTUS CUSTODES VEHICLE** or **ADEPTUS CUSTODES MOUNTED** unit within 6\" of the bearer. Until the start of your next Command phase, that unit is eligible to shoot in a turn in which it Fell Back."
       },
@@ -2641,13 +2667,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "58b4d1fc-d24b-5c86-aafd-077b643d9731",
+      "id": "c745e501-f0fb-5435-832d-f094c9490a38",
       "name": {
         "en": "Superior Creation"
       },
       "cost": "25",
       "keywords": ["Infantry", "Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES INFANTRY** model only. The first time the bearer is destroyed, roll one D6 at the end of the phase. On a 2+, set the bearer back up on the battlefield, as close as possible to where it was destroyed and not within Engagement Range of one or more enemy units, with its full wounds remaining."
       },
@@ -2659,13 +2686,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2004f402-89ce-5b07-943f-8f962b4ced1e",
+      "id": "2d728c47-9490-5678-b5ce-30a52e84163b",
       "name": {
         "en": "Praesidius"
       },
       "cost": "25",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS CUSTODES** model only. The bearer has the Lone Operative and Stealth abilities."
       },
@@ -2677,13 +2705,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dd505ad2-22e0-5e58-81fb-094afd364f0a",
+      "id": "521e3804-fae1-59ef-898a-82e6a3311823",
       "name": {
         "en": "Fierce Conqueror"
       },
       "cost": "15",
       "keywords": ["Shield-Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHIELD‐CAPTAIN** model only. At the start of the Fight phase, until the end of the phase, add 2 to the Attacks characteristic of melee weapons equipped by the bearer for every 5 enemy models within 6\" of the bearer (rounding down)."
       },
@@ -2695,13 +2724,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fd5868cf-6cf7-53c2-a264-57df9670413b",
+      "id": "f8832772-ff0c-54f2-9561-2250eb7049f8",
       "name": {
         "en": "Admonimortis"
       },
       "cost": "30",
       "keywords": ["Shield-Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHIELD‐CAPTAIN** model only. Improve the Strength characteristic of melee weapons equipped by the bearer by 3, and improve the Armour Penetration and Damage characteristics of those weapons by 1."
       },
@@ -3094,7 +3124,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PROSECUTORS** ■ **VIGILATORS** ■ **WITCHSEEKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Prosecutors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vigilators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Witchseekers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "1d52b4a3-4514-5a3e-adab-3594c2a60fa0",
@@ -4200,7 +4247,29 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CUSTODIAN GUARD** ■ **CUSTODIAN GUARD WITH ADRASITE AND PYRITHITE SPEARS** ■ **CUSTODIAN WARDENS** ■ **SAGITTARUM CUSTODIANS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Custodian Guard with Adrasite and Pyrithite Spears",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Wardens",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sagittarum Custodians",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "67a406c1-4870-58e0-a260-38b87888d4a1",
@@ -5931,7 +6000,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PROSECUTORS** ■ **VIGILATORS** ■ **WITCHSEEKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Prosecutors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vigilators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Witchseekers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "335a4762-5e7e-5012-9ff2-9d53d3f8a66d",
@@ -6951,7 +7037,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CUSTODIAN GUARD** ■ **CUSTODIAN GUARD WITH ADRASITE AND PYRITHITE SPEARS** ■ **CUSTODIAN WARDENS** ■ **SAGITTARUM CUSTODIANS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Custodian Guard with Adrasite and Pyrithite Spears",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Wardens",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sagittarum Custodians",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6dc40aca-5350-5393-b026-5fb29533920f",
@@ -7187,7 +7295,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ALLARUS CUSTODIANS** ■ **AQUILON CUSTODIANS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Allarus Custodians",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Aquilon Custodians",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "e9125c0a-5c67-588b-bdb5-bb08e977f9b5",
@@ -7389,7 +7509,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AGAMATUS CUSTODIANS** ■ **VERTUS PRAETORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Agamatus Custodians",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vertus Praetors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "20c06da2-729f-52ce-8989-b2b98ea909b3",
@@ -7851,7 +7983,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CUSTODIAN GUARD** ■ **CUSTODIAN GUARD WITH ADRASITE AND PYRITHITE SPEARS** ■ **CUSTODIAN WARDENS** ■ **SAGITTARUM CUSTODIANS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Custodian Guard with Adrasite and Pyrithite Spears",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Wardens",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sagittarum Custodians",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "12edb3d1-de71-5dce-8515-c95f86fa9b05",
@@ -8028,7 +8182,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CUSTODIAN GUARD** ■ **CUSTODIAN GUARD WITH ADRASITE AND PYRITHITE SPEARS** ■ **CUSTODIAN WARDENS** ■ **SAGITTARUM CUSTODIANS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Custodian Guard with Adrasite and Pyrithite Spears",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Custodian Wardens",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sagittarum Custodians",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d9fb2942-b113-5191-8a92-f7b99cce3504",

--- a/11th/gdc/adeptusmechanicus.json
+++ b/11th/gdc/adeptusmechanicus.json
@@ -7,7 +7,7 @@
     "header": "#9f2628"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.637Z",
+  "updated": "2026-07-28T17:03:07.153Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2406,7 +2406,7 @@
   ],
   "enhancements": [
     {
-      "id": "64bce0a8-04ca-5af9-8e12-77ee43c279af",
+      "id": "73f8c280-0740-5f56-9bfe-211338ef087a",
       "name": {
         "en": "Electromiasmic Brazier",
         "de": "Elektrosmogbehältnis",
@@ -2420,6 +2420,7 @@
       "cost": "10",
       "keywords": ["Tech-Priest", "Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Tech‑Priest</k> model only. This unit has <b>Stealth</b>.",
         "de": "Nur für ein <k>Techpriester</k>-Modell. Diese Einheit hat <b>Tarnung</b>.",
@@ -2438,7 +2439,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a893c500-dcc1-590f-87ec-2695afffb25a",
+      "id": "5d0a1650-f484-5831-a64f-5a15086c2a55",
       "name": {
         "en": "Voltagheist Reliquary",
         "de": "Voltageist-Reliquiar",
@@ -2452,6 +2453,7 @@
       "cost": "15",
       "keywords": ["Tech-Priest", "Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>TECH-PRIEST</k> model only. Enemy units cannot target this unit with <b>snap shooting</b> attacks.",
         "de": "Nur für ein <k>Techpriester</k>-Modell. Feindliche Einheiten können gegen diese Einheit keine <b>Eiliger-Beschuss</b>-Attacken ausführen.",
@@ -2470,7 +2472,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "650bb9af-61a8-52ab-8eaf-675e08605f21",
+      "id": "b06a9cc0-cf90-52fa-895d-25888fde7d80",
       "name": {
         "en": "Stealth-screened Cybercanids (Upgrade)",
         "de": "Tarnkappen-Cyberkaniden (Aufwertung)",
@@ -2484,6 +2486,7 @@
       "cost": "15",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Serberys Raiders</k> unit only. This unit has <b>Lone Operative 15\"</b>.",
         "de": "Nur für eine <k>Serberys-Husaren</k>-Einheit. Diese Einheit hat <b>Einsamer Wolf 15\"</b>.",
@@ -2502,7 +2505,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d1cdd1e8-fa8e-5edc-8ae6-881b41362528",
+      "id": "359740e1-1e73-5501-b14e-e8a477797b75",
       "name": {
         "en": "Explorator Dispensation",
         "de": "Explorator-Dispens",
@@ -2516,6 +2519,7 @@
       "cost": "20",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Skitarii Marshal</k> model only. This unit has <b>Infiltrators</b>.",
         "de": "Nur für ein <k>Skitarii-Marschall</k>-Modell. Diese Einheit hat <b>Infil­tratoren</b>.",
@@ -2534,7 +2538,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c70c45bc-7bf2-5e3a-adb5-8ac32b9479b8",
+      "id": "681a416f-628b-5227-a982-843c26ce274e",
       "name": {
         "en": "Vingh’s Wafers of Dynamism",
         "de": "Vinghs Disketten dynamischer Motorik",
@@ -2548,6 +2552,7 @@
       "cost": "25",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Cybernetica Datasmith</k> model only. At the start of the first battle round, if this unit is an <b>attached unit</b>, this unit has <k>Mobile</k> until the end of the battle.",
         "de": "Nur für ein <k>Cybernetica-Datenschmied</k>-Modell. Wenn diese Einheit zu Beginn der ersten Schlachtrunde eine <b>angeschlossene Einheit</b> ist, so hat diese Einheit bis zum Ende der Schlacht <k>Mobil</k>.",
@@ -2566,7 +2571,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b3452ed5-d508-54e0-8af5-09194ca864ce",
+      "id": "1260edbc-07ac-5262-9e28-5ba895b81bad",
       "name": {
         "en": "TL-4ø9",
         "de": "TL-4ø9",
@@ -2580,6 +2585,7 @@
       "cost": "30",
       "keywords": ["Tech-Priest", "Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Tech-Priest</k> model only. This model has the following weapon:",
         "de": "Nur für ein <k>Techpriester</k>-Modell. Dieses Modell hat die folgende Waffe:",
@@ -2598,13 +2604,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f1af52e9-c684-56bc-b1e2-5c16f9cb4a1e",
+      "id": "cd27aee1-4eb0-5695-a0b3-93165e389558",
       "name": {
         "en": "Radial Suffusion"
       },
       "cost": "25",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS MECHANICUS** model only. From the second battle round onwards, when resolving the Fallout effect of the Rad-bombardment Detachment rule, if the bearer is on the battlefield, roll one D6 for each enemy unit within 6\" of your opponent’s deployment zone, in addition to those that are within your opponent’s deployment zone."
       },
@@ -2616,13 +2623,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9bac5afd-ce02-5f13-b668-9833bf27adc2",
+      "id": "25bcf628-9264-586c-adde-9c07cd1d186b",
       "name": {
         "en": "Malphonic Susurrus"
       },
       "cost": "20",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS MECHANICUS** model only. While the bearer is leading a unit, models in that unit have the Stealth ability."
       },
@@ -2634,13 +2642,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d9d84590-d797-5336-95a0-0ae92dd0044e",
+      "id": "031e9d53-b366-5438-b7f2-1a1a1531b1b2",
       "name": {
         "en": "Peerless Eradicator"
       },
       "cost": "20",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS MECHANICUS** model only. While the bearer is leading a unit, ranged weapons equipped by models in that unit have the **[SUSTAINED HITS 1]** ability."
       },
@@ -2652,13 +2661,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b5d752f9-d763-5b87-8835-3e803b715c01",
+      "id": "ec15b168-0be9-5cca-9101-49d385fcc0b9",
       "name": {
         "en": "Autoclavic Denunciation"
       },
       "cost": "15",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS MECHANICUS** model only. Ranged weapons equipped by the bearer have the **[ANTI-INFANTRY 2+]** and **[ANTI-MONSTER 4+]** abilities."
       },
@@ -2670,13 +2680,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a5726d3e-a858-51bd-b068-37ad87c561db",
+      "id": "29533c45-5ac9-5017-9a11-b9e9d6a7f6fa",
       "name": {
         "en": "Cantic Thrallnet"
       },
       "cost": "25",
       "keywords": ["Marshal"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SKITARII MARSHAL** model only. At the start of the battle round, you can select one friendly **SKITARII** unit within 12\" of the bearer. Until the start of the next battle round, the Protector Imperative and the Conqueror Imperative are both active for that unit."
       },
@@ -2688,13 +2699,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4de0e30e-2b1a-586a-8497-356de1a140c5",
+      "id": "444487bb-2953-53fb-ba72-0db27ee30b70",
       "name": {
         "en": "Clandestine Infiltrator"
       },
       "cost": "15",
       "keywords": ["Skitarii"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SKITARII** model only. The bearer, and models in any unit they are leading, have the Infiltrators and Scouts 6\" abilities."
       },
@@ -2706,13 +2718,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9d105ffc-fa1a-52c8-a0a2-a8e3fec3d75b",
+      "id": "28254d08-497e-5759-a52f-61e38bc35dd7",
       "name": {
         "en": "Veiled Hunter"
       },
       "cost": "10",
       "keywords": ["Marshal"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SKITARII MARSHAL** model only. After both players have deployed their armies, you can select up to three **SKITARII INFANTRY** units from your army and redeploy all of those units. When doing so, any of those units can be placed into Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -2724,13 +2737,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5f2d683d-03c9-5976-8902-7b9ebebd40c1",
+      "id": "9485f4a4-92f9-5a36-b059-e9fd1f67f9b4",
       "name": {
         "en": "Battle-sphere Uplink"
       },
       "cost": "25",
       "keywords": ["Skitarii"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SKITARII** model only. In your Shooting phase, after the bearer’s unit has shot, if it is not within Engagement Range of one or more enemy units, that unit can make a Normal move of up to 6\". If it does, until the end of the turn, that unit is not eligible to declare a charge."
       },
@@ -2742,13 +2756,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f7ec200e-d3c0-5381-9664-a9789c6e15d9",
+      "id": "388d8fcb-af6c-5948-a8ad-767cfe0daba5",
       "name": {
         "en": "Mechanicus Locum"
       },
       "cost": "5",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. The bearer has a Leadership characteristic of 6+ and, once per battle, at the start of any phase, you can select one friendly **CULT MECHANICUS** unit that is Battle-shocked and within 12\" of the bearer. That unit is no longer Battle-shocked."
       },
@@ -2760,13 +2775,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c51b3d8e-8c5c-5de6-bd0b-dd416ee64aef",
+      "id": "fbebe6be-ffe7-5df8-8b9d-ac302cb60b25",
       "name": {
         "en": "Mantle of the Gnosticarch"
       },
       "cost": "10",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. Each time an attack is allocated to the bearer, change the Damage characteristic of that attack to 1."
       },
@@ -2778,13 +2794,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f7e5187f-b7f4-5c24-91e7-5f5103902a28",
+      "id": "dba5244d-a62e-515b-8254-6bee594810f7",
       "name": {
         "en": "Data-blessed Autosermon"
       },
       "cost": "15",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. Once per battle, at the start of your Command phase, you can select the Benediction of the Omnissiah you did not select at the start of the first battle round. Until the start of your next Command phase, that Benediction of the Omnissiah is active for the bearer’s unit in addition to the one that is currently active for your army."
       },
@@ -2796,13 +2813,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "43545342-e7ce-59d0-982f-45ac5434840b",
+      "id": "462314ea-589b-56e8-84ac-2490972d175e",
       "name": {
         "en": "Temporcopia"
       },
       "cost": "20",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. The bearer’s unit has the Fights First ability."
       },
@@ -2814,13 +2832,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "394dcff3-2435-574d-b68c-7fe82f9bac27",
+      "id": "91082c55-b9f8-59d2-8cf0-d2feeb9a84c3",
       "name": {
         "en": "Magos"
       },
       "cost": "10",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. At the end of your Command phase, if the bearer is within range of your Acquisition objective marker, roll one D6: on a 4+, you gain 1CP."
       },
@@ -2832,13 +2851,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "762dfcb0-bd4f-5e09-999b-57058b0398bc",
+      "id": "921da230-c6cd-50ff-9264-a734997a2568",
       "name": {
         "en": "Genetor"
       },
       "cost": "20",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. While the bearer is leading a unit that is within range of your Acquisition objective marker, models in that unit have a 4+ invulnerable save."
       },
@@ -2850,13 +2870,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5db57754-c8c4-5e2f-8264-61548a5d89d6",
+      "id": "42b7bc02-b938-59d3-b0ca-f1617c562e52",
       "name": {
         "en": "Logis"
       },
       "cost": "15",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. While the bearer is leading a unit, each time a model in that unit makes an attack that targets a unit within range of your Acquisition objective marker, add 1 to the Hit roll."
       },
@@ -2868,13 +2889,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f98641fb-e6d5-5e33-a861-6048141b126d",
+      "id": "bc85acc5-ea99-5315-b819-e0d975499852",
       "name": {
         "en": "Artisan"
       },
       "cost": "10",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. While the bearer is leading a unit that is within range of your Acquisition objective marker, once per phase, you can change the result of one Hit roll, one Wound roll or one saving throw made for that unit to an unmodified 6."
       },
@@ -2886,13 +2908,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c897db1-6e5c-51ee-af63-fe60d9c0c08a",
+      "id": "9a0482f9-53fb-55d1-9d29-da648b905ecd",
       "name": {
         "en": "Necromechanic"
       },
       "cost": "20",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. Once per battle round, when a saving throw made for a friendly **LEGIO CYBERNETICA** or **ADEPTUS MECHANICUS VEHICLE** model within 12\" of the bearer is failed, the bearer can use this Enhancement. If they do, change the Damage characteristic of that attack to 0."
       },
@@ -2904,13 +2927,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "681b864f-4807-5574-87d8-d4cf0e8101cf",
+      "id": "256987eb-9c6a-5eb7-aa13-3729b9e0ae4f",
       "name": {
         "en": "Lord of Machines"
       },
       "cost": "15",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. Once per turn, at the start of your opponent’s Shooting phase, select one enemy **VEHICLE** unit within 12\" of and visible to the bearer. That unit must take a Leadership test: if that test is passed, until the end of the phase, each time a model in that unit makes an attack, subtract 1 from the Hit roll; if that test is failed, that unit is not eligible to shoot this phase."
       },
@@ -2922,13 +2946,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7d4d9d04-8e14-5872-9bf8-c07a8616f217",
+      "id": "7e1dabc2-4432-5d35-bc98-34801054216c",
       "name": {
         "en": "Emotionless Clarity"
       },
       "cost": "10",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. Once per turn, when a friendly **LEGIO CYBERNETICA** or **ADEPTUS MECHANICUS VEHICLE** model with the Deadly Demise ability that is within 12\" of the bearer is destroyed, the bearer can use this Enhancement. If it does, do not roll to determine whether any mortal wounds are inflicted as a result of that model’s Deadly Demise ability. Instead, mortal wounds are automatically inflicted."
       },
@@ -2940,13 +2965,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ac840053-dfce-5ad7-99f1-e37adfe02b86",
+      "id": "ea352670-c330-5228-9c70-8cbdee1db70a",
       "name": {
         "en": "Arch-negator"
       },
       "cost": "5",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH-PRIEST** model only. Ranged weapons equipped by the bearer have the **[ANTI-VEHICLE 4+]** ability."
       },
@@ -2958,13 +2984,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "daab17ff-d650-5aa9-9e92-06a7f4e9cb9e",
+      "id": "bfdab3d4-94c0-5a26-91de-b4e1f539b463",
       "name": {
         "en": "Transoracular Dyad Wafers"
       },
       "cost": "15",
       "keywords": ["Cybernetica Datasmith"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CYBERNETICA DATASMITH** model only. When the bearer is attached to a **KASTELAN ROBOTS** unit, until the end of the battle, models in that unit gain the **HALO OVERRIDE** keyword. That unit cannot be selected when selecting units as part of the Noospheric Transference Detachment rule."
       },
@@ -2976,13 +3003,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f6dc034c-2b37-563c-a438-8661ef55f981",
+      "id": "49d1f2c3-7059-521f-9a65-d6dc3ba2df90",
       "name": {
         "en": "Cognitive Reinforcement"
       },
       "cost": "30",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": ["Cybernetica Datasmith"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS MECHANICUS** model only (excluding **CYBERNETICA DATASMITH** models). The Conqueror Imperative and Protector Imperative are both active for the bearer’s unit."
       },
@@ -2994,13 +3022,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8c8cb2e7-0895-5f02-ba75-d65cb1af7462",
+      "id": "62697234-3f53-5eb3-8153-dccc61514eca",
       "name": {
         "en": "Sanctified Ordnance"
       },
       "cost": "10",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS MECHANICUS** model only. Add 6\" to the range characteristic of ranged weapons equipped by models in the bearer’s unit and, each time a Hazardous test is taken for that unit, you can re‑roll the result."
       },
@@ -3012,13 +3041,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "631f8681-3917-5b14-bf9b-df3ff77b5227",
+      "id": "90d27e04-0aef-5ce2-aa57-0e9b66d1e713",
       "name": {
         "en": "Inloaded Lethality"
       },
       "cost": "15",
       "keywords": ["Manipulus", "Dominus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH‑PRIEST DOMINUS** or **TECH‑PRIEST MANIPULUS** model only. Add 3 to the Attacks characteristic of the bearer’s melee weapons and add 1 to the Damage characteristic of the bearer’s melee weapons."
       },
@@ -3030,13 +3060,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e3fcfe7f-a949-56b6-9cde-b535d8db146b",
+      "id": "4601a831-1424-5065-b032-291f1e519f91",
       "name": {
         "en": "Omnicogitator"
       },
       "cost": "25",
       "keywords": ["Skitarii", "Marshal"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SKITARII MARSHAL** model only. The Conqueror Imperative and Protector Imperative are both active for the bearer’s unit."
       },
@@ -3048,13 +3079,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3107a4d6-3900-5b03-aa50-9c20c87250a2",
+      "id": "fec2c887-eea9-5941-8782-0ef874c4fb4e",
       "name": {
         "en": "Martial Signatum Amplificator"
       },
       "cost": "15",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECH‑PRIEST** model only. Models in the bearer’s unit have the **SKITARII** keyword"
       },
@@ -3066,13 +3098,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "617347ba-c3cf-5e1f-a3ee-30cda4c6782f",
+      "id": "af511214-22ba-5abc-bf07-61ce0a936259",
       "name": {
         "en": "Belicosa-class Capacitor Vanes"
       },
       "cost": "25",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS MECHANICUS** model only. Add 6\" to the Range characteristic of ranged weapons equipped by models in the bearer’s unit, and add 1 to the Strength characteristic of those weapons."
       },
@@ -3084,13 +3117,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f1fac6ed-5641-5a33-a8f6-7e0131af7e43",
+      "id": "4a868ef1-6f4b-51e5-a606-a270a24c1ae6",
       "name": {
         "en": "Omnissiah’s Fury"
       },
       "cost": "10",
       "keywords": ["Skitarii", "Marshal"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SKITARII MARSHAL** model only. Add 2 to the Attacks characteristic of melee weapons equipped by the bearer, and improve the Armour Penetration and Damage characteristics of those weapons by 1."
       },
@@ -4331,6 +4365,13 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Kastelan Robots",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -8209,6 +8250,28 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Hastarii Exterminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hastarii Fusiliers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Skitarii Rangers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Skitarii Vanguard",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -10310,7 +10373,54 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CORPUSCARII ELECTRO-PRIESTS** ■ **FULGURITE ELECTRO-PRIESTS** ■ **HASTARII EXTERMINATORS** ■ **HASTARII FUSILIERS** ■ **KATAPHRON BREACHERS** ■ **KATAPHRON DESTROYERS** ■ **SECUTARII HOPLITES** ■ **SECUTARII PELTASTS** ■ **SERVITOR BATTLECLADE** ■ **SKITARII RANGERS** ■ **SKITARII VANGUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Corpuscarii Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fulgurite Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hastarii Exterminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hastarii Fusiliers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kataphron Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kataphron Destroyers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Servitor Battleclade",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Skitarii Rangers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Skitarii Vanguard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "abef589f-3101-5e59-97f0-5750fd04cdbf",
@@ -10513,7 +10623,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CORPUSCARII ELECTRO-PRIESTS** ■ **FULGURITE ELECTRO-PRIESTS** ■ **KATAPHRON BREACHERS** ■ **KATAPHRON DESTROYERS** ■ **SECUTARII HOPLITES** ■ **SECUTARII PELTASTS** ■ **SKITARII RANGERS** ■ **SKITARII VANGUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Corpuscarii Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fulgurite Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kataphron Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kataphron Destroyers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Skitarii Rangers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Skitarii Vanguard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6357b805-e2e2-5503-a6e9-bd1730c06c0a",
@@ -10715,7 +10857,54 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CORPUSCARII ELECTRO-PRIESTS** ■ **FULGURITE ELECTRO-PRIESTS** ■ **HASTARII EXTERMINATORS** ■ **HASTARII FUSILIERS** ■ **KATAPHRON BREACHERS** ■ **KATAPHRON DESTROYERS** ■ **SECUTARII HOPLITES** ■ **SECUTARII PELTASTS** ■ **SERVITOR BATTLECLADE** ■ **SKITARII RANGERS** ■ **SKITARII VANGUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Corpuscarii Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fulgurite Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hastarii Exterminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hastarii Fusiliers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kataphron Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kataphron Destroyers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Servitor Battleclade",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Skitarii Rangers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Skitarii Vanguard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0f22e6a2-5162-5a89-847d-54d8b9a931f1",
@@ -10901,6 +11090,53 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Corpuscarii Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Fulgurite Electro-Priests",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hastarii Exterminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hastarii Fusiliers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Kataphron Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Kataphron Destroyers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Servitor Battleclade",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Skitarii Rangers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Skitarii Vanguard",
+          "targetType": "datasheet"
         }
       ]
     },

--- a/11th/gdc/aeldari.json
+++ b/11th/gdc/aeldari.json
@@ -7,7 +7,7 @@
     "header": "#347379"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.248Z",
+  "updated": "2026-07-28T17:03:10.755Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -3488,7 +3488,7 @@
   ],
   "enhancements": [
     {
-      "id": "b8db8b8e-ec04-5248-982e-6202d412806c",
+      "id": "183adba3-812b-56ff-8530-ce730708cbb2",
       "name": {
         "en": "Camouflaged Snipers (Upgrade)",
         "de": "Getarnte Scharfschützen (Aufwertung)",
@@ -3502,6 +3502,7 @@
       "cost": "10",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Rangers</k> unit only. This unit’s ranged attacks do not prevent this unit from being <b>hidden</b>.",
         "de": "Nur für eine <k>Weltenläufer</k>-Einheit. Fernkampfattacken dieser Einheit verhindern nicht, dass diese Einheit <b>versteckt</b> ist.",
@@ -3520,7 +3521,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7f6cf6df-fc8b-556f-b51e-822158e0e8cc",
+      "id": "f346a86a-a29d-544b-ba0a-4d75d1b364c1",
       "name": {
         "en": "A Foot in the Future",
         "de": "Ein Fuß in der Zukunft",
@@ -3534,6 +3535,7 @@
       "cost": "15",
       "keywords": ["Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Troupe Master</k> model only. This unit can re‑roll <b>charge rolls</b>.",
         "de": "Nur für ein <k>Meistermime</k>-Modell. Für diese Einheit können <b>Angriffs­würfe</b> wiederholt werden.",
@@ -3552,7 +3554,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "03816a7c-2c9f-5ab6-a2d1-fc940fe90eb1",
+      "id": "fc758d4f-f386-5d84-9559-8296569e4044",
       "name": {
         "en": "Shadowfall Masks (Upgrade)",
         "de": "Schattenfallmasken (Aufwertung)",
@@ -3566,6 +3568,7 @@
       "cost": "15",
       "keywords": ["Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Troupe</k> unit only. This unit has <b>Fights First</b>.",
         "de": "Nur für eine <k>Ensemble</k>-Einheit. Diese Einheit hat <b>Erstschlag</b>.",
@@ -3584,7 +3587,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6d460b19-3058-58a8-b6f9-293a5b9ecd65",
+      "id": "a22e7f61-f769-58ee-b046-d2b0b03bd45d",
       "name": {
         "en": "Assassins' Eye (Upgrade)",
         "de": "Blick des Assassinen (Aufwertung)",
@@ -3598,6 +3601,7 @@
       "cost": "15",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Rangers/Shroud Runners</k> unit only. This unit’s ranged attacks that target a <k>CHARACTER</k> unit have +1 <b>AP</b>.",
         "de": "Nur für eine <k>Weltenläufer</k>-<k>/Windläufer</k>-Einheit. Fernkampfattacken dieser Einheit gegen eine <k>Charaktermodell</k>-Einheit haben +1 <b>DS</b>.",
@@ -3616,7 +3620,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "36161231-f974-52d7-958f-f61bd902282b",
+      "id": "abaedcb3-251b-51fe-a99d-62db77db4e89",
       "name": {
         "en": "Mistweave",
         "de": "Dunstschleier",
@@ -3630,6 +3634,7 @@
       "cost": "20",
       "keywords": ["Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Shadowseer</k> model only. This unit has <b>Infiltrators</b>.",
         "de": "Nur für ein <k>Schicksalsleser</k>-Modell. Diese Einheit hat <b>Infiltratoren</b>.",
@@ -3648,7 +3653,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "36044a0b-c996-5f92-b40c-afb37dd95968",
+      "id": "9d068447-3cc8-5235-abbc-86fde7f0001b",
       "name": {
         "en": "Prelude Performer",
         "de": "Prologkünstler",
@@ -3662,6 +3667,7 @@
       "cost": "20",
       "keywords": ["Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Harlequins</k> model only. This unit has <b>Scouts 6\"</b>.",
         "de": "Nur für ein <k>Harlekin</k>-Modell. Diese Einheit hat <b>Kundschafter 6\"</b>.",
@@ -3680,7 +3686,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a4eb62e4-dc85-5aca-aaa7-5ba2601ef021",
+      "id": "e5e2a9df-ae12-5a0f-b981-9583b9e51bdf",
       "name": {
         "en": "Spirit Stone of Raelyth",
         "de": "Seelenstein von Raelyth",
@@ -3694,6 +3700,7 @@
       "cost": "20",
       "keywords": ["Aeldari", "Psyker"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Aeldari Psyker</k> model only. \r<ul><li>While this model is within 3\" of a friendly <k>Aeldari Vehicle</k> unit, this model has <b>Lone Operative</b>.</li>\r<li>In your Movement phase, at the start or end of this unit’s move, you can select one friendly <k>Aeldari Vehicle</k> model within 3\" of this model. That <k>Vehicle</k> model <b>heals</b> D3 wounds.</li></ul>",
         "de": "Nur für ein <k>Aeldari</k>-<k>Psioniker</k>-Modell. \r<ul><li>Solange sich dieses Modell innerhalb von 3\" um eine befreundete <k>Aeldari</k>-<k>Fahrzeug</k>-Einheit befindet, hat dieses Modell <b>Einsamer Wolf</b>.</li>\r<li>In deiner Bewegungsphase kannst du zu Beginn oder am Ende der Bewegung dieser Einheit ein befreundetes <k>Aeldari</k>-<k>Fahrzeug</k>-Modell innerhalb von 3\" um dieses Modell wählen. Jenes <k>Fahrzeug</k>-Modell wird um bis zu W3 Lebenspunkte <b>geheilt</b>.</li></ul>",
@@ -3712,7 +3719,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c1e8b97b-a246-525f-8cb2-12a267ad05cc",
+      "id": "a948cce5-b375-56f9-9153-cbad4319d175",
       "name": {
         "en": "Guiding Presence",
         "de": "Leitender Geist",
@@ -3726,6 +3733,7 @@
       "cost": "25",
       "keywords": ["Aeldari", "Psyker"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Aeldari Psyker</k> model only. At the start of your Shooting phase, select one <b>visible</b> friendly <k>Aeldari Vehicle</k> unit within 6\" of this model. That <k>Vehicle</k> unit’s ranged attacks have +1 to <b>hit rolls</b>.",
         "de": "Nur für ein <k>Aeldari</k>-<k>Psioniker</k>-Modell. Wähle zu Beginn deiner Fernkampfphase eine für dieses Modell <b>sichtbare</b> befreundete <k>Aeldari</k>-<k>Fahrzeug</k>-Einheit innerhalb von 6\". Die Fernkampfattacken jener <k>Fahrzeug</k>-Einheit haben +1 auf <b>Trefferwürfe</b>.",
@@ -3744,13 +3752,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9593a9fc-9b36-51b2-95ed-a94ddfd4028e",
+      "id": "4d830d57-92e4-5064-bfd2-dbb383779be3",
       "name": {
         "en": "Firstdrawn Blade"
       },
       "cost": "10",
       "keywords": ["Mounted", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI MOUNTED** model only. Models in the bearer’s unit have the Scouts 9\" ability."
       },
@@ -3762,13 +3771,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1b9e8b71-6ea3-5a53-b1b3-9edcca7880c8",
+      "id": "657a693d-f57a-5be1-a6a3-bef24b8d4da4",
       "name": {
         "en": "Phoenix Gem"
       },
       "cost": "35",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI** model only. The first time the bearer is destroyed, remove it from play, then, at the end of the phase, roll one D6: on a 2+, set the bearer back up on the battlefield as close as possible to where it was destroyed and not within Engagement Range of one or more enemy units, with its full wounds remaining."
       },
@@ -3780,13 +3790,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2c2535ad-a9ad-59af-8529-edc796947653",
+      "id": "ee42b854-4529-5227-a60d-63f7501a2158",
       "name": {
         "en": "Mirage Field"
       },
       "cost": "25",
       "keywords": ["Mounted", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI MOUNTED** model only. Each time an attack targets the bearer’s unit, subtract 1 from the Hit roll."
       },
@@ -3798,13 +3809,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "481d5b74-2b7c-5076-a49a-ab5a9954843c",
+      "id": "c4ea3701-3e69-59b3-997f-5a39516a2125",
       "name": {
         "en": "Seersight Strike"
       },
       "cost": "15",
       "keywords": ["Mounted", "Psyker", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI MOUNTED PSYKER** model only. Psychic weapons equipped by the bearer have the **[ANTI‑MONSTER 2+]** and **[ANTI‑VEHICLE 2+]** abilities."
       },
@@ -3816,13 +3828,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c8a27a24-79f7-57b9-8304-91aeb91601ff",
+      "id": "c893bf2f-c929-5474-95c1-5f5cec5dad38",
       "name": {
         "en": "Echoes of Ulthanesh"
       },
       "cost": "20",
       "keywords": ["Mounted", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI MOUNTED** model only. In your Command phase, roll one D6, adding 1 to the result if the bearer is not within your deployment zone, and adding an additional 1 to the result if the bearer is within your opponent’s deployment zone: on a 5+, you gain 1CP."
       },
@@ -3834,13 +3847,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8e03ae19-8acc-5b38-bdd5-7506d94ded11",
+      "id": "4f875461-e788-5bab-b545-e86a8bd5671b",
       "name": {
         "en": "Light of Clarity"
       },
       "cost": "30",
       "keywords": ["Spiritseer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPIRITSEER** model only. In your Command phase, select one friendly **WRAITH CONSTRUCT** unit within 12\" of the bearer. Until the start of your next Command phase, add 1 to the Objective Control characteristic of **INFANTRY** models in that unit and add 3 to the Objective Control characteristic of **MONSTER** models in that unit."
       },
@@ -3852,13 +3866,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7e6affc9-2bcc-5991-948a-b47523556c64",
+      "id": "c9e99ad2-3ce8-52e6-b06c-f5b65e5ab86b",
       "name": {
         "en": "Stave of Kurnous"
       },
       "cost": "15",
       "keywords": ["Spiritseer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPIRITSEER** model only. In your Command phase, select one friendly **WRAITH CONSTRUCT** unit within 12\" of the bearer (excluding **TITANIC** units). Until the start of your next Command phase, each time a model in that unit makes an attack, on a Critical Wound, that attack has the **[PRECISION]** ability."
       },
@@ -3870,13 +3885,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9c71b3a2-c767-5694-b958-df9fe496a5bb",
+      "id": "5ba2120d-67ab-5ba6-a46f-d886b79464d4",
       "name": {
         "en": "Rune of Mists"
       },
       "cost": "10",
       "keywords": ["Spiritseer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPIRITSEER** model only. In your Command phase, select one friendly **WRAITH CONSTRUCT** unit within 12\" of the bearer. Until the start of your next Command phase, each time a ranged attack targets that unit, unless the attacking model is within 18\", models in that unit have the Benefit of Cover against that attack."
       },
@@ -3888,13 +3904,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "29d3f534-e610-59b5-9cfd-b2a2c0af0c02",
+      "id": "0ad238be-1d6d-5d3f-a4d5-0b6540832587",
       "name": {
         "en": "Higher Duty"
       },
       "cost": "25",
       "keywords": ["Spiritseer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPIRITSEER** model only. In your opponent's Movement phase, if an enemy unit ends a move within 8” of this unit, if this unit is not within Engagement Range of one or more enemy units, this unit can make a Normal move of up to 6”."
       },
@@ -3906,13 +3923,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c33d3763-7eb2-5e6a-8cd9-975cf4d8222a",
+      "id": "d2f4f362-9376-57a0-b82b-27a8354e0ffa",
       "name": {
         "en": "Cegorach’s Coil"
       },
       "cost": "25",
       "keywords": ["Troupe Master"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TROUPE MASTER** model only. Each time the bearer’s unit ends a Charge move, select one enemy unit within Engagement Range of the bearer’s unit, then roll one D6 for each model in the bearer’s unit that is within Engagement Range of that enemy unit: for each 4+, that enemy unit suffers 1 mortal wound (to a maximum of 6 mortal wounds)."
       },
@@ -3924,13 +3942,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "acdf1c28-dc0a-56bb-889b-dc44e5529de1",
+      "id": "27cb2ce6-0704-52c1-8d9e-ba302d0f5243",
       "name": {
         "en": "Mask of Secrets"
       },
       "cost": "15",
       "keywords": ["Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HARLEQUINS** model only. Each time an enemy unit (excluding **MONSTERS** and **VEHICLES**) within Engagement Range of the bearer’s unit Falls Back, all models in that enemy unit must take a Desperate Escape test. When doing so, if that enemy unit is Battle‑shocked, subtract 1 from each of those tests."
       },
@@ -3942,13 +3961,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "53463295-fc9f-5515-98ae-d45f8ec0430b",
+      "id": "cd459bd8-7b9f-5536-a60e-5bbd8174c87e",
       "name": {
         "en": "Murder’s Jest"
       },
       "cost": "20",
       "keywords": ["Death Jester"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH JESTER** model only. Each time the bearer makes an attack that targets a unit that is Below Half‑strength, each successful Hit roll scores a Critical Hit."
       },
@@ -3960,13 +3980,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "36161231-f974-52d7-958f-f61bd902282b",
+      "id": "04afb711-4711-5e17-b933-9cc5eeaaa77d",
       "name": {
         "en": "Mistweave"
       },
       "cost": "15",
       "keywords": ["Shadowseer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHADOWSEER** model only. While the bearer is leading a unit, models in that unit have the Infiltrators ability."
       },
@@ -3978,13 +3999,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cc704896-fc90-52fb-a477-98111b32a101",
+      "id": "be6ce130-98c3-5082-ac69-46f7c1c7274b",
       "name": {
         "en": "Timeless Strategist"
       },
       "cost": "15",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI** model only. At the start of the battle round, if the bearer is on the battlefield (or any **TRANSPORT** it is embarked within is on the battlefield), you receive 1 additional Battle Focus token."
       },
@@ -3996,13 +4018,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4b0d81cd-5507-5f07-bb4b-5eb74b25a561",
+      "id": "7cdc1938-3c02-516d-a639-235915d03975",
       "name": {
         "en": "Gift of Foresight"
       },
       "cost": "15",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI** model only. Once per battle round, you can target the bearer’s unit with the Command Re‑roll Stratagem for 0CP."
       },
@@ -4014,13 +4037,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1fd65654-3c4f-59f6-b938-f4bac3fae45c",
+      "id": "09137b36-b4cb-59f0-9aee-c108cec2860e",
       "name": {
         "en": "Psychic Destroyer"
       },
       "cost": "30",
       "keywords": ["Psyker", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI PSYKER** model only. Add 1 to the Damage characteristic of ranged Psychic weapons equipped by the bearer."
       },
@@ -4032,13 +4056,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "62d45d18-cef2-5cf9-a11d-983142ff5ad3",
+      "id": "675a6706-474b-5804-9935-6b66ab1b6564",
       "name": {
         "en": "Craftworld’s Champion"
       },
       "cost": "25",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI** model only. The bearer has an Objective Control characteristic of 5."
       },
@@ -4050,13 +4075,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c9ec1d00-556d-5e07-9094-6c3fa10758f7",
+      "id": "61a72592-1cd6-5bb9-9826-c4305bc9ab55",
       "name": {
         "en": "Ethereal Pathway"
       },
       "cost": "30",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI** model only. In the Deploy Armies step, select up to two **GUARDIANS** units from your army. Models in the selected units have the Infiltrators ability."
       },
@@ -4068,13 +4094,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e9ecb615-80ca-5b4d-aa94-0cfeef6c5901",
+      "id": "e71abc4a-a242-5cd5-8699-7c36a0bc845c",
       "name": {
         "en": "Protector of the Paths"
       },
       "cost": "20",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI** model only. While the bearer is leading a **DIRE AVENGERS** or **GUARDIANS** unit, once per battle round, you can target the bearer’s unit with the Fire Overwatch Stratagem for 0CP, and while resolving that Stratagem, hits are scored on unmodified Hit rolls of 5+, or unmodified Hit rolls of 4+ instead if the bearer’s unit is within range of an objective marker you control."
       },
@@ -4086,13 +4113,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "99bb3d3d-2c17-5d00-a8c5-8d4a3fdcc122",
+      "id": "2d12016e-bbbe-5486-828b-51ba88206bbd",
       "name": {
         "en": "Breath of Vaul"
       },
       "cost": "10",
       "keywords": ["Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI** model only. While the bearer is leading a **STORM GUARDIANS** unit, each time you roll to determine the number of attacks made with a flamer equipped by a model in that unit, you can re‑roll the result, and each time you make a Damage roll for a model equipped with a fusion gun in that unit, you can re‑roll the result."
       },
@@ -4104,13 +4132,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cceb01eb-b2c1-5e12-b53d-350f5d3a018c",
+      "id": "6e969fd4-a743-5bfe-8541-85aa43b0daad",
       "name": {
         "en": "Gaze of Ynnead"
       },
       "cost": "15",
       "keywords": ["Farseer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**FARSEER** model only. The bearer’s Eldritch Storm weapon has the **[DEVASTATING WOUNDS]** ability."
       },
@@ -4122,13 +4151,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "eec7d709-19b7-5022-9711-a835040a342d",
+      "id": "86f38f5a-417a-5041-ba7a-d669f6237060",
       "name": {
         "en": "Storm of Whispers"
       },
       "cost": "10",
       "keywords": ["Warlock"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WARLOCK** model only. In your Shooting phase, after the bearer has shot, select one enemy unit hit by one or more of those attacks. That unit must take a Battle‑shock test."
       },
@@ -4140,13 +4170,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2ea7a1c6-b217-5df8-9607-4024de471fcd",
+      "id": "a1ea6b6d-2b07-5070-acb6-49b7f76f3ce0",
       "name": {
         "en": "Borrowed Vigour"
       },
       "cost": "10",
       "keywords": ["Archon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ARCHON** model only. Add 2 to the Attacks characteristic of the bearer’s melee weapons."
       },
@@ -4158,13 +4189,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b430ada6-7f3f-5007-be6d-aa5ab6ad3cfd",
+      "id": "bef7a706-036a-5734-911a-6732ebdd5f97",
       "name": {
         "en": "Morbid Might"
       },
       "cost": "15",
       "keywords": ["Succubus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SUCCUBUS** model only. Each time the bearer makes a melee attack, you can re‑roll the Wound roll."
       },
@@ -4176,13 +4208,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6d0c88de-3e85-5bf7-9c60-92c868401395",
+      "id": "021c5fa4-4893-5d19-ba46-6d422ff758fc",
       "name": {
         "en": "Lucid Eye"
       },
       "cost": "30",
       "keywords": ["Psyker", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI PSYKER** model only. In your Command phase, you can add 1 to or subtract 1 from the value of one Fate dice in your Fate dice pool."
       },
@@ -4194,13 +4227,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0db73998-e51a-5e05-9836-03cba2b46ce6",
+      "id": "b04b1c2c-bda9-5f12-a73b-50b97e9a0c66",
       "name": {
         "en": "Runes of Warding"
       },
       "cost": "25",
       "keywords": ["Psyker", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI PSYKER** model only. Models in the bearer’s unit have the Feel No Pain 4+ ability against mortal wounds, Psychic Attacks and Critical Wounds caused by attacks with the **[DEVASTATING WOUNDS]** ability."
       },
@@ -4212,13 +4246,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a5e7d246-0c33-52d4-ae98-877e8403d30e",
+      "id": "3ae2bca2-7d57-509c-b8ed-e7e615157fef",
       "name": {
         "en": "Stone of Eldritch Fury"
       },
       "cost": "15",
       "keywords": ["Psyker", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI PSYKER** model only. Add 12\" to the Range characteristic of ranged Psychic weapons equipped by the bearer."
       },
@@ -4230,13 +4265,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f336ed87-795c-5958-b45a-6021986607f2",
+      "id": "8c644daa-ee8e-5929-bfa6-b51405ffcc36",
       "name": {
         "en": "Torc of Morai-Heg"
       },
       "cost": "20",
       "keywords": ["Psyker", "Asuryani"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASURYANI PSYKER** model only. Once per turn, when your opponent targets a unit from their army within 12\" of the bearer with a Stratagem, the bearer can use this Enhancement. If it does, increase the CP cost of that usage of that Stratagem by 1CP."
       },
@@ -4248,13 +4284,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "98de73dc-cb6f-5640-8e82-5bc7d2d4a5df",
+      "id": "2c49e215-8d97-5eaf-99b9-a47b1199037e",
       "name": {
         "en": "Aspect of Murder"
       },
       "cost": "15",
       "keywords": ["Autarch", "Autarch Wayleaper"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AUTARCH** or **AUTARCH WAYLEAPER** model only. Add 1 to the Damage characteristic of melee weapons equipped by the bearer, and those weapons have the **[PRECISION]** ability."
       },
@@ -4266,13 +4303,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5e69cd67-37e9-5cb0-a6f5-4c72965467b6",
+      "id": "dd73ff97-f6da-5bf6-a62f-098bc8eae319",
       "name": {
         "en": "Mantle of Wisdom"
       },
       "cost": "20",
       "keywords": ["Autarch Wayleaper", "Autarch"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AUTARCH** or **AUTARCH WAYLEAPER** model only. While the bearer is leading an **ASPECT WARRIORS** unit, each time that unit is selected to shoot or fight, until the end of the phase, models in that unit gain both of the abilities from the Path of the Warrior Detachment rule."
       },
@@ -4284,13 +4322,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "825e3da1-88fa-5bb3-ba40-a480ef6f7454",
+      "id": "e37071e9-6464-567f-b6d4-fc388c82324a",
       "name": {
         "en": "Shimmerstone"
       },
       "cost": "10",
       "keywords": ["Autarch Wayleaper", "Autarch"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AUTARCH** or **AUTARCH WAYLEAPER** model only. While the bearer is leading an **ASPECT WARRIORS** unit, each time a ranged attack targets that unit, subtract 1 from the Wound roll."
       },
@@ -4302,13 +4341,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "aefc4a79-6fff-599f-8cbb-14a89ac845e5",
+      "id": "6c73d18d-ac39-5278-94b9-55e7177975fc",
       "name": {
         "en": "Strategic Savant"
       },
       "cost": "10",
       "keywords": ["Autarch Wayleaper", "Autarch"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AUTARCH** or **AUTARCH WAYLEAPER** model only. While the bearer is leading an **ASPECT WARRIORS** unit, add 1 to the Objective Control characteristic of models in that unit."
       },
@@ -4320,13 +4360,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "57697090-fab2-5cd3-b349-27ff2a6f795a",
+      "id": "be8d73f0-d43c-57b2-b6ec-4c2fcfa4a21a",
       "name": {
         "en": "Key of Ghosts"
       },
       "cost": "20",
       "keywords": ["Harlequins"],
       "excludes": ["Solitaire"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HARLEQUINS** model only (excluding **SOLITAIRE** models). Models in the bearer’s unit have the Scouts 6\" ability."
       },
@@ -4338,13 +4379,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b99471e3-a263-5931-b62d-8848dd18fc43",
+      "id": "a50d96e3-be0e-5d29-8b52-4cf131e62c33",
       "name": {
         "en": "Weavers' Wail"
       },
       "cost": "20",
       "keywords": ["Troupe Master"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TROUPE MASTER** model only. Add 3 to the Strength and add 1 to the Attacks characteristics of the bearer’s melee weapons."
       },
@@ -4356,13 +4398,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4daa4f28-00ff-5975-9407-f3502f23afd8",
+      "id": "253eeae3-4a54-5d08-b194-8233757c53d0",
       "name": {
         "en": "Fanged Leer"
       },
       "cost": "10",
       "keywords": ["Death Jester"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH JESTER** model only. When using the bearer’s Cruel Amusement ability, you can select two of the abilities for its shrieker cannon to gain, instead of one."
       },
@@ -4374,13 +4417,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a9969ade-b77f-5fe4-9e29-0ba7383d47d3",
+      "id": "bbfa3df8-630b-5a6c-94d9-16afd73a5f39",
       "name": {
         "en": "Shedskin Raiment"
       },
       "cost": "25",
       "keywords": ["Shadowseer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHADOWSEER** model only. After both players have deployed their armies, select up to three **HARLEQUINS** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -4392,13 +4436,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "36873415-b7ff-52c5-a4ce-889cdf8c9d63",
+      "id": "308679b6-4c85-5487-8f1c-cbc9378997cf",
       "name": {
         "en": "Pirate Prince"
       },
       "cost": "15",
       "keywords": ["Prince Yriel"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**PRINCE YRIEL** unit only. Each time you spend a Battle Focus token to enable this unit to perform an Agile Manoeuvre, roll one D6: on a 3+, you gain 1 Battle Focus token."
       },
@@ -4410,13 +4455,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fc3ef2e0-44d1-58ad-b0c7-b47830cb4778",
+      "id": "64e4827d-be8c-5daf-97e8-bfd359eb9f49",
       "name": {
         "en": "Alacritous Assault"
       },
       "cost": "20",
       "keywords": ["Anhrathe"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "**ANHRATHE** unit only. Melee weapons equipped by models in this unit have the **[LANCE]** ability."
       },
@@ -4428,13 +4474,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "776109a0-95ee-5c9b-97d0-2c721957a6db",
+      "id": "a120f0dd-6c8c-5fd3-b08c-7e6196717f49",
       "name": {
         "en": "Exotic Munitions"
       },
       "cost": "15",
       "keywords": ["Anhrathe"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "**ANHRATHE** unit only. Ranged weapons equipped by models in this unit have the **[ANTI‑MONSTER 5+]** and **[ANTI‑VEHICLE 5+]** abilities."
       },
@@ -4446,13 +4493,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c20351ee-69da-5836-9e27-82203daba636",
+      "id": "7dd44d35-1fce-5225-ba30-2967e312dd83",
       "name": {
         "en": "Adrenal Infusions"
       },
       "cost": "20",
       "keywords": ["Anhrathe", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "**ANHRATHE INFANTRY** unit only. This unit can perform the Fade Back Agile Manoeuvre without spending a Battle Focus token to do so. It can do so even if other units have done so in the same phase, and doing so does not prevent other units from performing the same Agile Manoeuvre in the same phase."
       },
@@ -4464,13 +4512,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8267f019-bfd4-57c7-83aa-adcf8a8753cb",
+      "id": "28e3eafa-354d-5dc6-a682-da25de3dd291",
       "name": {
         "en": "Infamy (Aura)"
       },
       "cost": "25",
       "keywords": ["Anhrathe"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "**ANHRATHE** unit only. While an enemy unit is within 3\" of this unit, subtract 1 from the Objective Control characteristic of models in that unit (to a minimum of 1)."
       },
@@ -4482,13 +4531,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1f67f34c-083b-51fe-b8a2-a078b9b9bca3",
+      "id": "8193c288-5d08-5642-814e-1d77b3561489",
       "name": {
         "en": "Webway Pathstone"
       },
       "cost": "25",
       "keywords": ["Anhrathe"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "**ANHRATHE** unit only. Models in this unit have the Deep Strike ability. In addition, once per battle, at the end of your opponent’s turn, if this unit is not within Engagement Range of one or more enemy units, it can use this ability. If it does, remove this unit from the battlefield and place it into Strategic Reserves."
       },
@@ -4500,13 +4550,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "299ed59c-451b-57ec-9517-9579aa162279",
+      "id": "73ea0ea2-34a4-5d6e-95b2-f3407609d394",
       "name": {
         "en": "Archraider"
       },
       "cost": "35",
       "keywords": ["Anhrathe", "Character"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "**ANHRATHE CHARACTER** unit only. At the start of the battle, select one **CHARACTER** model in this unit. That model has the following ability:\n\n**Lord of Deceit (Aura):** Once per turn, when your opponent targets a unit from their army within 12” of this model with a stratagem, you can use this ability. If you do, increase the CP cost of that use of that stratagem by 1CP."
       },
@@ -4518,13 +4569,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "68dc5624-afac-505d-bf00-c4a2e0a15a51",
+      "id": "5e3d9be9-98d2-5cf1-9d03-876d0554cdcc",
       "name": {
         "en": "Voidstone"
       },
       "cost": "15",
       "keywords": ["Anhrathe", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "**ANHRATHE INFANTRY** unit only. Models in this unit have a 5+ invulnerable save."
       },
@@ -4714,7 +4766,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DIRE AVENGERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Dire Avengers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0debaad1-ddae-5650-8b46-e72bf0dcf222",
@@ -5055,7 +5114,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DARK REAPERS** ■ **DIRE AVENGERS** ■ **FIRE DRAGONS** ■ **GUARDIAN DEFENDERS** ■ **HOWLING BANSHEES** ■ **STORM GUARDIANS** ■ **STRIKING SCORPIONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Dark Reapers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Dire Avengers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fire Dragons",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Guardian Defenders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Howling Banshees",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Storm Guardians",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Striking Scorpions",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "78b09f0d-6943-5caa-9c6f-683f9ddfe3c5",
@@ -5397,7 +5493,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SWOOPING HAWKS** ■ **WARP SPIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Swooping Hawks",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Warp Spiders",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "1d6fbd02-6561-5fdb-b508-d72fe040c550",
@@ -5773,7 +5881,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SWOOPING HAWKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Swooping Hawks",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "c260bf10-7228-56f7-8635-42e695ef0878",
@@ -8590,7 +8705,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **GUARDIAN DEFENDERS** ■ **STORM GUARDIANS** ■ **WARLOCK CONCLAVE**  If this model is not already attached to a unit, you can attach this model to a unit, even if one **WARLOCKS** unit has already been attached to it."
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Guardian Defenders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Storm Guardians",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Warlock Conclave",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2ece8450-cd96-54db-9eea-f29ec2b1616d",
@@ -9165,7 +9297,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **GUARDIAN DEFENDERS** ■ **STORM GUARDIANS** ■ **WARLOCK CONCLAVE**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Guardian Defenders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Storm Guardians",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Warlock Conclave",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "08f7afa4-1e01-54f1-a3ac-854d1be37640",
@@ -9432,7 +9581,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WARLOCK SKYRUNNERS** ■ **WINDRIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Warlock Skyrunners",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Windriders",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "dd651ab0-2c1d-548b-bfc2-9720ebf428ed",
@@ -10181,7 +10342,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **FIRE DRAGONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Fire Dragons",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "dff35a09-3399-56d0-8c16-3801f800357d",
@@ -11150,7 +11318,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **HOWLING BANSHEES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Howling Banshees",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "70ee16c6-66dd-5be5-9775-2ff0dc380f27",
@@ -11339,7 +11514,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CORSAIR REAVER BAND** ■ **CORSAIR VOIDREAVERS** ■ **CORSAIR VOIDSCARRED**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Corsair Voidreavers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Corsair Voidscarred",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "39ec1ea5-25d2-5049-b59b-d49b9e17d20d",
@@ -11548,7 +11735,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WARP SPIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Warp Spiders",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a3dff7ee-a03f-5c56-b1fb-259bc952131e",
@@ -11718,7 +11912,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DARK REAPERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Dark Reapers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d06e11cd-84bf-5174-8f23-096d8322ee71",
@@ -12509,7 +12710,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CORSAIR REAVER BAND** ■ **CORSAIR VOIDREAVERS** ■ **CORSAIR VOIDSCARRED**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Corsair Voidreavers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Corsair Voidscarred",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "854a02eb-6a01-5734-a1b6-43a5de76571f",
@@ -13374,7 +13587,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **TROUPE**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Troupe",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f5f48c3a-78bc-5ecc-81f1-9de5a9b5bd12",
@@ -16019,7 +16239,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CORSAIR REAVER BAND** ■ **CORSAIR VOIDREAVERS** ■ **CORSAIR VOIDSCARRED** ■ **GUARDIAN DEFENDERS** ■ **STORM GUARDIANS** ■ **YNNARI INCUBI** ■ **YNNARI KABALITE WARRIORS** ■ **YNNARI WYCHES**  You can attach this unit to one of the above units, even if **YVRAINE** has already been attached to it. If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths."
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Corsair Voidreavers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Corsair Voidscarred",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Guardian Defenders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Storm Guardians",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ynnari Incubi",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ynnari Kabalite Warriors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ynnari Wyches",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2906941e-fa4b-5aa4-bb53-72cf83da47f1",
@@ -16871,7 +17128,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **TROUPE**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Troupe",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f43d8589-7c91-5d94-88ed-641032febd5a",
@@ -18055,6 +18319,18 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Guardian Defenders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Storm Guardians",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -18293,7 +18569,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **GUARDIAN DEFENDERS** ■ **STORM GUARDIANS**  At the start of the Declare Battle Formations step, if this unit is not an Attached unit, this unit can join one **GUARDIAN DEFENDERS** or **STORM GUARDIANS** unit from your army (a unit cannot have more than one **WARLOCK CONCLAVE** unit joined to it). If it does, until the end of the battle, every model in this unit counts as being part of that Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased accordingly."
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Guardian Defenders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Storm Guardians",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "df03cabd-1f69-527a-9cc0-54db4c434d27",
@@ -18556,7 +18844,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WINDRIDERS**  At the start of the Declare Battle Formations step, if this unit is not an Attached unit, this unit can join one **WINDRIDERS** unit from your army (a unit cannot have more than one **WARLOCK SKYRUNNERS** unit joined to it). If it does, until the end of the battle, every model in this unit counts as being part of that Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased accordingly."
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Windriders",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2e5ac6c6-6fa1-5004-b268-249397354dd6",
@@ -20925,7 +21220,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **YNNARI INCUBI** ■ **YNNARI KABALITE WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Ynnari Incubi",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ynnari Kabalite Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "bbfc6817-e5b3-5182-96b8-a51ef0485629",
@@ -22315,7 +22622,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **YNNARI WYCHES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Ynnari Wyches",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9633aba8-242a-5c78-b093-7f8353cf09c5",
@@ -22941,7 +23255,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CORSAIR REAVER BAND** ■ **CORSAIR VOIDREAVERS** ■ **CORSAIR VOIDSCARRED** ■ **GUARDIAN DEFENDERS** ■ **STORM GUARDIANS** ■ **YNNARI INCUBI** ■ **YNNARI KABALITE WARRIORS** ■ **YNNARI WYCHES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Corsair Voidreavers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Corsair Voidscarred",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Guardian Defenders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Storm Guardians",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ynnari Incubi",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ynnari Kabalite Warriors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ynnari Wyches",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/agents.json
+++ b/11th/gdc/agents.json
@@ -7,7 +7,7 @@
     "header": "#244b6a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.007Z",
+  "updated": "2026-07-28T17:03:07.949Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -1223,13 +1223,14 @@
   ],
   "enhancements": [
     {
-      "id": "afa07ceb-8a9b-56e2-a9e5-b8bf7c5c0775",
+      "id": "14cde654-2053-5e3e-890f-2fd449e71fc1",
       "name": {
         "en": "Universal Anathema"
       },
       "cost": "10",
       "keywords": ["Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AGENTS OF THE IMPERIUM** model only. Melee weapons equipped by the bearer have the **[ANTI‐INFANTRY 2+]** and **[ANTI‐MONSTER 4+]** abilities."
       },
@@ -1241,13 +1242,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5136adfb-d212-58db-9c91-75e6ecf97b4f",
+      "id": "db1732e0-4465-5030-8124-a2d9602a7a9f",
       "name": {
         "en": "Blackweave Shroud"
       },
       "cost": "15",
       "keywords": ["Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AGENTS OF THE IMPERIUM** model only. The bearer has the Feel No Pain 4+ ability."
       },
@@ -1259,13 +1261,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2c66d7b1-c513-567b-91e3-cf1be40a31c5",
+      "id": "74463ff6-8aed-52c4-8002-18cfee44f146",
       "name": {
         "en": "Beacon Angelis"
       },
       "cost": "30",
       "keywords": ["Watch Master"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WATCH MASTER** model only. Models in the bearer’s unit have the Deep Strike ability. In addition, you can target the bearer’s unit with the Rapid Ingress Stratagem for 0CP."
       },
@@ -1277,13 +1280,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bc6b8892-a3e6-55d5-b84b-67f8da693436",
+      "id": "b1204c97-7243-5e55-a1b3-b6dc5bfe3084",
       "name": {
         "en": "Amulet of Auto-chastisement"
       },
       "cost": "25",
       "keywords": ["Watch Master"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WATCH MASTER** model only. At the start of your opponent’s Shooting phase, select one enemy **VEHICLE** unit (excluding **TITANIC** units) within 12\" of and visible to the bearer. That unit must take a Leadership test. If that test is passed, until the end of the phase, each time a model in that unit makes an attack, subtract 1 from the Hit roll; if that test is failed, that unit is not eligible to shoot this phase."
       },
@@ -1295,13 +1299,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bef157b4-3c09-5304-848b-18fd4ca3a1b6",
+      "id": "9d7e276c-69e5-5ef8-b24b-cb540d791ad4",
       "name": {
         "en": "Liber Heresius"
       },
       "cost": "10",
       "keywords": ["Inquisitor", "Ministorum Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** or **MINISTORUM PRIEST** model only. After both players have deployed their armies, select up to three **AGENTS OF THE IMPERIUM** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -1313,13 +1318,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c4c67874-4cd7-59c5-8000-8bd56f362b92",
+      "id": "f2ed4b86-198d-5b62-89ed-8b3e20503495",
       "name": {
         "en": "No Escape (Aura)"
       },
       "cost": "25",
       "keywords": ["Inquisitor"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** model only. While an enemy unit is within 6\" of the bearer, each time it is selected to Fall Back it must first take a Leadership test. If that test is failed, that unit must Remain Stationary this phase instead."
       },
@@ -1331,13 +1337,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ea5f97ec-d3c2-5323-ab70-97d6840b4049",
+      "id": "5f36aac7-da18-5a32-b691-08a24a0e5440",
       "name": {
         "en": "Witch Hunter"
       },
       "cost": "15",
       "keywords": ["Inquisitor", "Ministorum Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** or **MINISTORUM PRIEST** model only. While the bearer is leading a unit, each time a model in that unit makes an attack that targets a **PSYKER** unit, you can re‐roll the Hit roll."
       },
@@ -1349,13 +1356,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a7c37343-b942-571a-b4b7-47ce8be3c6c1",
+      "id": "cc758be0-9577-57e1-ba54-70cabb4f43f0",
       "name": {
         "en": "Ignis Judicium"
       },
       "cost": "10",
       "keywords": ["Inquisitor", "Ministorum Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** or **MINISTORUM PRIEST** model only. The bearer’s ranged weapons have the **[DEVASTATING WOUNDS]**, **[MELTA 1]** and **[PRECISION]** abilities."
       },
@@ -1367,13 +1375,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0f4b5f4a-6d2f-519a-93ac-7f2c60115730",
+      "id": "1bd7b78e-429c-5334-beba-fc36458bdd74",
       "name": {
         "en": "Formidable Resolve"
       },
       "cost": "5",
       "keywords": ["Inquisitor"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** model only. Improve the bearer’s Leadership and Wounds characteristics by 1. Once per battle, at the start of any phase, you can select one friendly Battle‐shocked unit within 12\" of the bearer. That unit is no longer Battle‐shocked."
       },
@@ -1385,13 +1394,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2b652cb3-8d1b-5f30-98a9-e51c222681e9",
+      "id": "af90b804-2a7e-5c1d-a6e0-ebea9d3ec096",
       "name": {
         "en": "Daemon Slayer"
       },
       "cost": "10",
       "keywords": ["Inquisitor"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** model only. Add 1 to the Attacks characteristic of the bearer’s melee weapons, and those weapons have the **[ANTI‐DAEMON 3+]** ability."
       },
@@ -1403,13 +1413,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "11417767-da2f-5ce7-b56b-fc5644179e9d",
+      "id": "74b09029-0b70-52f5-943c-53feb96128fc",
       "name": {
         "en": "Grimoire of True Names (Aura)"
       },
       "cost": "10",
       "keywords": ["Inquisitor"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** model only. While an enemy unit is within 9\" of the bearer, worsen the Leadership characteristic of models in that unit by 1. In addition, while an enemy **DAEMON** unit is within 9\" of the bearer, each time a model in that **DAEMON** unit makes an attack, subtract 1 from the Hit roll and subtract 1 from the Wound roll."
       },
@@ -1421,13 +1432,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e6f4379a-1116-5e2d-9804-581f77694606",
+      "id": "ed6c82d5-530f-58d2-8ff9-cdec3a41140b",
       "name": {
         "en": "Gift of the Prescient"
       },
       "cost": "20",
       "keywords": ["Inquisitor"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INQUISITOR** model only. Once per battle, if the bearer is on the battlefield, you can use the Rapid Ingress Stratagem for 0CP. When doing so, you must target a **GREY KNIGHTS TERMINATOR SQUAD** unit from your army, and when using that Stratagem, that unit can be set up anywhere on the battlefield that is more than 6\" away from all enemy units."
       },
@@ -1439,13 +1451,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "41d09187-a96b-51b9-8767-d6d9299b17f8",
+      "id": "6cc82a93-0a69-505f-a938-b80aeb24eaa4",
       "name": {
         "en": "Digital Weapons"
       },
       "cost": "10",
       "keywords": ["Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AGENTS OF THE IMPERIUM** model only. Each time the bearer is selected to fight, roll three D6: for each 4+, one enemy unit within Engagement Range of the bearer suffers 1 mortal wound. Mortal wounds inflicted by this Enhancement are allocated as if they had the **[PRECISION]** ability."
       },
@@ -1457,13 +1470,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "42f3220d-b2ca-5cd0-b50f-65e2262bd9ab",
+      "id": "5e85cad3-5c88-510d-995a-d9b5666aeb06",
       "name": {
         "en": "Clandestine Operation"
       },
       "cost": "15",
       "keywords": ["Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**AGENTS OF THE IMPERIUM** model only. At the start of the Declare Battle Formations step, you can select up to three **AGENTS OF THE IMPERIUM INFANTRY** units from your army (excluding **GREY KNIGHTS TERMINATOR SQUAD** units) – those units gain the Infiltrators ability."
       },
@@ -1475,13 +1489,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3ce80120-311f-51a8-8f60-3cd52ec3ef90",
+      "id": "a24a7bc0-ca9b-528c-8e44-e70888795b85",
       "name": {
         "en": "Fleetmaster"
       },
       "cost": "20",
       "keywords": ["Voidfarers"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VOIDFARERS** model only. Once per battle round, you can target the bearer’s unit with the Violent Acquisition, Masters of the Void or Close‐quarters Barrage Stratagems for 0CP."
       },
@@ -1493,13 +1508,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "688e00a1-014c-5cc6-83e3-3ed58413877e",
+      "id": "2d5ae2a8-099a-5133-a9b9-bb819dc2e1b4",
       "name": {
         "en": "Combat Landers"
       },
       "cost": "10",
       "keywords": ["Voidfarers"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VOIDFARERS** model only. At the start of the Declare Battle Formations step, you can select up to three **VOIDFARERS** units from your army – those units gain the Deep Strike ability."
       },
@@ -1511,13 +1527,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b950dca7-d0a1-5c8e-ba53-68c18344c967",
+      "id": "cf0ce861-586b-559c-b6e2-4faf7b29737b",
       "name": {
         "en": "Decoy Targets"
       },
       "cost": "15",
       "keywords": ["DNU", "Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CALLIDUS ASSASSIN** models only. Twice per battle, in your Movement phase, you can select one other friendly **INFANTRY** model that is on the battlefield and not within Engagement Range of one or more enemy units. The selected model is destroyed (ignoring any rules that are triggered when a model is destroyed) and this model is removed from the battlefield and set up again as close as possible to where that destroyed model was and not within Engagement Range of one or more enemy units. This ability cannot be used more than once in the same battle round."
       },
@@ -1529,13 +1546,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9a1efad6-f5f5-5c92-85c1-d57eed0813d6",
+      "id": "caa1c720-c2c2-5a44-9209-c6b1312dec36",
       "name": {
         "en": "Esoteric Explosives"
       },
       "cost": "10",
       "keywords": ["DNU", "Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CULEXUS ASSASSIN** models only. Each time this model is targeted with the Grenades Stratagem, 1 mortal wound is inflicted for each D6 roll of 3+ instead of for each 4+."
       },
@@ -1547,13 +1565,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "423a620e-bea2-5744-a356-120e4cc3d7b8",
+      "id": "e2a928d6-7bb5-557b-8d68-bdb177ac3198",
       "name": {
         "en": "Intraneural Biotech"
       },
       "cost": "15",
       "keywords": ["DNU", "Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EVERSOR ASSASSIN** models only. Once per battle round, you can target this model with the Heroic Intervention or Counter‑offensive Stratagem for 0CP, and can do so even if you have already used that Stratagem on a different unit this phase."
       },
@@ -1565,13 +1584,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9b7eebbe-7110-59ae-af96-82fd05897ced",
+      "id": "2ec5ab1e-2e87-5527-bc1b-e8c1405020e3",
       "name": {
         "en": "Micromelta Rounds"
       },
       "cost": "20",
       "keywords": ["DNU", "Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VINDICARE ASSASSIN** models only. This model’s exitus rifle has the **[ANTI‑MONSTER 4+]** and **[ANTI‑VEHICLE 4+]** abilities."
       },
@@ -5787,7 +5807,69 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AQUILA KILL TEAM** ■ **EXACTION SQUAD** ■ **GREY KNIGHTS TERMINATOR SQUAD** ■ **IMPERIAL NAVY BREACHERS** ■ **IMPERIUM BATTLELINE INFANTRY** ■ **INQUISITORIAL AGENTS** ■ **SANCTIFIERS** ■ **SISTERS OF BATTLE SQUAD** ■ **SUBDUCTOR SQUAD** ■ **VIGILANT SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aquila Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Battleline",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Exaction Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Grey Knights Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperial Navy Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperium",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Infantry",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Inquisitorial Agents",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sanctifiers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sisters of Battle Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Subductor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vigilant Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0a6dcec2-75d1-555e-9372-d49a60189f2e",
@@ -6026,7 +6108,54 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EXACTION SQUAD** ■ **GREY KNIGHTS TERMINATOR SQUAD** ■ **IMPERIAL NAVY BREACHERS** ■ **IMPERIUM BATTLELINE INFANTRY** ■ **INQUISITORIAL AGENTS** ■ **SUBDUCTOR SQUAD** ■ **VIGILANT SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Battleline",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Exaction Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Grey Knights Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperial Navy Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperium",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Infantry",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Inquisitorial Agents",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Subductor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vigilant Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3b88d74a-0438-5fd2-8d0f-302a1bc91f04",
@@ -6247,7 +6376,54 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AQUILA KILL TEAM** ■ **EXACTION SQUAD** ■ **IMPERIAL NAVY BREACHERS** ■ **IMPERIUM BATTLELINE INFANTRY** ■ **INQUISITORIAL AGENTS** ■ **SUBDUCTOR SQUAD** ■ **VIGILANT SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aquila Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Battleline",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Exaction Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperial Navy Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperium",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Infantry",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Inquisitorial Agents",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Subductor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vigilant Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "23ba73f2-1cfd-5bf9-9409-0adf6fbe3e45",
@@ -6477,7 +6653,59 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EXACTION SQUAD** ■ **IMPERIAL NAVY BREACHERS** ■ **IMPERIUM BATTLELINE INFANTRY** ■ **INQUISITORIAL AGENTS** ■ **SANCTIFIERS** ■ **SISTERS OF BATTLE SQUAD** ■ **SUBDUCTOR SQUAD** ■ **VIGILANT SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Battleline",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Exaction Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperial Navy Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Imperium",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Infantry",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Inquisitorial Agents",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sanctifiers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sisters of Battle Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Subductor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vigilant Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a2e60945-f476-5506-add2-c58e48d3ae64",
@@ -7723,6 +7951,43 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Exaction Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Imperial Navy Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Inquisitorial Agents",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sanctifiers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sisters of Battle Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Subductor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Vigilant Squad",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -7906,7 +8171,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IMPERIAL NAVY BREACHERS** ■ **VOIDSMEN-AT-ARMS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Imperial Navy Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Voidsmen-at-Arms",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3782157e-f35b-531b-b70f-b0bbf33c1915",
@@ -8262,7 +8539,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IMPERIAL NAVY BREACHERS** ■ **VOIDSMEN-AT-ARMS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Imperial Navy Breachers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Voidsmen-at-Arms",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "fb25fb97-0644-5c52-ac27-40ba1170b23e",
@@ -11036,7 +11325,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AQUILA KILL TEAM** ■ **DEATHWATCH KILL TEAM** ■ **DEATHWATCH TERMINATOR SQUAD** ■ **FORTIS KILL TEAM** ■ **INDOMITOR KILL TEAM** ■ **PROTEUS KILL TEAM** ■ **SPECTRUS KILL TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aquila Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwatch Kill Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "10af0717-f94a-5ae6-90f3-427da01cbe73",
@@ -11214,7 +11515,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AQUILA KILL TEAM** ■ **DEATHWATCH KILL TEAM** ■ **DEATHWATCH TERMINATOR SQUAD** ■ **FORTIS KILL TEAM** ■ **INDOMITOR KILL TEAM** ■ **PROTEUS KILL TEAM** ■ **SPECTRUS KILL TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aquila Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwatch Kill Team",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/astramilitarum.json
+++ b/11th/gdc/astramilitarum.json
@@ -7,7 +7,7 @@
     "header": "#324935"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:51.911Z",
+  "updated": "2026-07-28T17:03:05.711Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2556,7 +2556,7 @@
   ],
   "enhancements": [
     {
-      "id": "02668ccd-903b-5b25-b1f0-4ce5666475e0",
+      "id": "6eba97fc-8a3f-5d75-abbd-421a3e482a50",
       "name": {
         "en": "Sharp Eyes (Upgrade)",
         "de": "Scharfe Augen (Aufwertung)",
@@ -2570,6 +2570,7 @@
       "cost": "10",
       "keywords": ["Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Ratlings</k> unit only. When this unit is <b>selected to shoot</b>, enemy units have +6\" <b>detection range</b> until this unit has shot.",
         "de": "Nur für eine <k>Rattling</k>-Einheit. Wenn diese Einheit <b>zum Schießen gewählt wird</b>, haben feindliche Einheiten +6\" <b>Entdeckungsreichweite</b>, bis diese Einheit geschossen hat.",
@@ -2588,7 +2589,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "22507d49-4e09-58d2-983b-2867c9472937",
+      "id": "7d93fed0-1354-5999-8360-e1cdab736114",
       "name": {
         "en": "Exemplar of Duty (Upgrade)",
         "de": "Mustergültige Pflichterfüllung (Aufwertung)",
@@ -2602,6 +2603,7 @@
       "cost": "10",
       "keywords": ["Commissar"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Commissar</k> model only. This model has <b>Feel No Pain 4+</b>.",
         "de": "Nur für ein <k>Kommissar</k>-Modell. Dieses Modell hat <b>Verletzungen ­ignorieren 4+</b>.",
@@ -2620,7 +2622,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "36074c65-dce1-561c-ba04-7ed19864a9e4",
+      "id": "82ea91a3-c3bc-5db8-bd8c-b8ddff6670ac",
       "name": {
         "en": "Long-range Scout (Upgrade)",
         "de": "Kundschafter im Feindesland (Aufwertung)",
@@ -2634,6 +2636,7 @@
       "cost": "10",
       "keywords": ["Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Scout Sentinel</k> unit only. This unit has <b>Infiltrators</b>.",
         "de": "Nur für eine <k>Wächter-Spähläufer</k>-Einheit. Diese Einheit hat <b>Infiltratoren</b>.",
@@ -2652,7 +2655,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f338b7a1-fe0c-593a-b74a-9f5ee35f448a",
+      "id": "bc5565ac-1d43-5e0b-8ae0-94df2b72a8f9",
       "name": {
         "en": "Recon Star (Upgrade)",
         "de": "Späher-Stern (Aufwertung)",
@@ -2666,6 +2669,7 @@
       "cost": "10",
       "keywords": ["Platoon", "Infantry", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Astra Militarum Infantry Platoon</k> unit only. In your first Movement phase, this unit can make an <b>ingress move</b>.",
         "de": "Nur für eine <k>Astra-Militarum-Infanterie-Zug</k>-Einheit. In deiner ersten Bewegungsphase kann diese Einheit eine <b>Einsatzbewegung</b> ausführen.",
@@ -2684,7 +2688,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c2d05008-ffb8-55cd-9309-6fda99566903",
+      "id": "105fd254-0ecd-5382-ba41-23884391193f",
       "name": {
         "en": "Bombast-class Vox-array",
         "de": "Voxanlage des Bombastus-Schemas",
@@ -2698,6 +2702,7 @@
       "cost": "15",
       "keywords": ["Militarum Tempestus", "Officer", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Militarum Tempestus Officer</k> model only. When this model issues an <b>Order</b>, if this unit has the <b>Master Vox</b> wargear ability, this model can issue that <b>Order</b> to up to three different <k>Regiment</k> units, instead of only one.",
         "de": "Nur für ein <k>Militarum</k>-<k>Tempestus</k>-<k>Offizier</k>-Modell. Wenn dieses Modell einen <b>Befehl</b> erteilt und diese Einheit die Ausrüstungsfähigkeit <b>Hochleistungsfunkgerät</b> hat, kann dieses Modell jenen <b>Befehl</b> bis zu drei verschiedenen <k>Regiment</k>-Einheiten statt nur einer erteilen.",
@@ -2716,7 +2721,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3e824aea-c633-53df-ad66-cca6b7acfeec",
+      "id": "8b3cf4b7-33f8-5fa4-8b9c-072fd359c1ed",
       "name": {
         "en": "Priority Drop Beacon",
         "de": "Prioritätsziel-Landesignal",
@@ -2730,6 +2735,7 @@
       "cost": "25",
       "keywords": ["Militarum Tempestus", "Officer", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Militarum Tempestus Officer</k> model only. In your first Movement phase, this unit can make an <b>ingress move</b>.",
         "de": "Nur für ein <k>Militarum</k>-<k>Tempestus</k>-<k>Offizier</k>-Modell. In deiner ersten Bewegungsphase kann diese Einheit eine <b>Einsatzbewegung</b> ausführen.",
@@ -2748,13 +2754,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "66c1fcaa-895f-53ff-8e9e-b937637095d1",
+      "id": "24cf6f99-8b7e-54e8-ad6e-c15a789b8a47",
       "name": {
         "en": "Death Mask of Ollanius"
       },
       "cost": "10",
       "keywords": ["Officer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OFFICER** model only. While the bearer’s unit is Battle-shocked, subtract 1 from the Objective Control characteristic of models in that unit, instead of changing it to 0."
       },
@@ -2766,13 +2773,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "15a0c050-9352-525f-91bf-5a11f75ce10f",
+      "id": "990db79d-246b-5027-b909-3052c6fbcb99",
       "name": {
         "en": "Drill Commander"
       },
       "cost": "20",
       "keywords": ["Officer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OFFICER** model only. While the bearer is leading a unit, each time a model in that unit makes a ranged attack, if that unit Remained Stationary this turn, a Critical Hit is scored on a successful unmodified Hit roll of 5+."
       },
@@ -2784,13 +2792,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0e1413aa-5cde-5106-b971-584a1e490b10",
+      "id": "ba70897e-a461-56ad-85c2-3e69199a52bd",
       "name": {
         "en": "Grand Strategist"
       },
       "cost": "15",
       "keywords": ["Officer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OFFICER** model only. In your Command phase, the bearer can issue one additional Order."
       },
@@ -2802,13 +2811,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1d709469-8521-5958-9049-a77bb0537af7",
+      "id": "1725f9d6-a8af-5d8d-9a2e-25f77ecbb9bf",
       "name": {
         "en": "Reactive Command"
       },
       "cost": "15",
       "keywords": ["Officer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OFFICER** model only. Each time an enemy unit is set up within 8\" of the bearer’s unit, the bearer can issue one Order. This is not counted towards the number of Orders the bearer can issue in a battle round."
       },
@@ -2820,13 +2830,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "aa645613-714b-585d-999a-da5b86336898",
+      "id": "1d1ad92f-6ddd-587b-8e8a-8cabce404328",
       "name": {
         "en": "Eager Advance"
       },
       "cost": "20",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. While the bearer is leading a **REGIMENT** unit, that unit has the Scouts 6\" ability."
       },
@@ -2838,13 +2849,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6d2471a1-3209-5824-bfa0-359b29d9fb78",
+      "id": "10678653-f18c-5c6a-bf4d-559e85232d39",
       "name": {
         "en": "Flash Grenades"
       },
       "cost": "20",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. Enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2856,13 +2868,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cbef5365-4f65-5e8a-9702-9143faa404e8",
+      "id": "35f01e21-5a69-515d-aef4-6c5a7ecb50fe",
       "name": {
         "en": "Legacy Sidearm"
       },
       "cost": "10",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. Add 2 to the Attacks characteristics of the bearer’s Pistols."
       },
@@ -2874,13 +2887,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "df4d4f9a-bf29-5977-9974-084425081fbd",
+      "id": "3f421d65-c6ce-5c32-a21f-a9b995fcfc51",
       "name": {
         "en": "Stalwart’s Honours"
       },
       "cost": "15",
       "keywords": ["Officer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OFFICER** model only. While the bearer is leading a unit, when that unit is issued an Order, it is also affected by the Take Cover! Order."
       },
@@ -2892,13 +2906,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "83968b47-293b-5631-b09b-34a32c6ae526",
+      "id": "755ea521-2f15-5ea2-ae3a-6830ef01d1e5",
       "name": {
         "en": "Bold Leadership"
       },
       "cost": "25",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. If you control an objective marker at the end of your Command phase, and the bearer’s unit (or any **TRANSPORT** it is embarked within) is within range of that objective marker, that objective marker remains under you control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn."
       },
@@ -2910,13 +2925,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1df06dd8-90da-598a-a98b-6eb258e61b05",
+      "id": "163fdd01-51e7-5487-a9f5-0c584a37d23f",
       "name": {
         "en": "Sacred Unguents"
       },
       "cost": "10",
       "keywords": ["Tech-Priest Enginseer", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM TECH-PRIEST ENGINSEER** model only. At the start of your Shooting phase, select one **TRANSPORT** from your army (excluding **AIRCRAFT** and **TITANIC** units) within 3\" of the bearer. Until the end of the phase, each time that **TRANSPORT** makes an attack, you can re-roll the Hit roll."
       },
@@ -2928,13 +2944,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "10169339-b2b0-5813-a6d9-238ead8cacfc",
+      "id": "ea6eafe7-b44b-545f-b41e-c7e45228d552",
       "name": {
         "en": "Smoke Grenades"
       },
       "cost": "10",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. The bearer’s unit has the Benefit of Cover and the Stealth ability while the bearer’s unit is wholly within 3\" of one or more friendly **TRANSPORT** models."
       },
@@ -2946,13 +2963,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c7de2d92-6e2d-56b9-985c-e78bac7db9d7",
+      "id": "977c10b3-8095-512a-bc0d-b46ca40eba81",
       "name": {
         "en": "Vanguard Honours"
       },
       "cost": "15",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. The bearer’s unit can disembark from a **TRANSPORT** after it has Advanced. If it does, it counts as having made a Normal move that phase, and cannot declare a charge in the same turn, but can otherwise act normally in the remainder of the turn."
       },
@@ -2964,13 +2982,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1f64770e-996f-568e-ada8-3219534f9484",
+      "id": "f819f4b1-a8c5-5629-8d3a-b177592b18ff",
       "name": {
         "en": "Calm Under Fire"
       },
       "cost": "15",
       "keywords": ["Officer", "Vehicle"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VEHICLE OFFICER** model only. Once per turn, after the bearer issues an Order to a **SQUADRON** unit from your army, it can issue the same Order to another **SQUADRON** unit from your army."
       },
@@ -2982,13 +3001,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ab9dafb3-e55c-5b03-95b1-456bd7cb77ae",
+      "id": "64b060dc-f623-562f-98ec-9543949af4b2",
       "name": {
         "en": "Indomitable Steed"
       },
       "cost": "15",
       "keywords": ["Officer", "Vehicle"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VEHICLE OFFICER** model only. The bearer has the Feel No Pain 6+ ability."
       },
@@ -3000,13 +3020,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b08424be-d373-5031-a262-e00444bc25be",
+      "id": "1d750753-9bfd-5377-9025-fe4aede759d9",
       "name": {
         "en": "Regimental Banner"
       },
       "cost": "20",
       "keywords": ["Officer", "Vehicle"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VEHICLE OFFICER** model only. Add 3 to the bearer’s Objective Control characteristic."
       },
@@ -3018,13 +3039,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b51babfc-1daf-57c0-b96a-1d504c5d9b85",
+      "id": "9c317d1e-47e5-5067-85d1-486c6196631d",
       "name": {
         "en": "Veteran Crew"
       },
       "cost": "20",
       "keywords": ["Officer", "Vehicle"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VEHICLE OFFICER** model only. Each time a model in the bearer’s unit makes a ranged attack, re-roll a Hit roll of 1."
       },
@@ -3036,13 +3058,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fd81e204-849a-589a-96e3-b43c1f4449b3",
+      "id": "fb0621e3-0b44-553c-a37f-deeb2ffa42f9",
       "name": {
         "en": "Guerrilla Honours"
       },
       "cost": "25",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. After both players have deployed their armies, if the bearer is on the battlefield, select up to three other **ASTRA MILITARUM INFANTRY** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -3054,13 +3077,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d374dac3-62bc-5615-88ea-887aaac8cdc8",
+      "id": "53cb76e4-0c08-57dc-b2f9-b622d1517aeb",
       "name": {
         "en": "Scare Gas Grenades"
       },
       "cost": "5",
       "keywords": ["Infantry", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM INFANTRY** model only. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, select one enemy unit within 8\" of the bearer’s unit (excluding **MONSTER** and **VEHICLE** units); that unit must take a Battle-shock test."
       },
@@ -3072,13 +3096,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7fc692cb-4236-5697-b7ff-e50ec4aee109",
+      "id": "545c2d3c-e991-57e5-866c-b877ef0254f9",
       "name": {
         "en": "Survival Gear"
       },
       "cost": "5",
       "keywords": ["Infantry", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM INFANTRY** model only. The bearer has the Scouts 6\" ability."
       },
@@ -3090,13 +3115,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "96a4bc52-40bf-5ff0-9057-3bc01a70928e",
+      "id": "9f4868dd-e35c-5de1-9ba4-145e28feadbd",
       "name": {
         "en": "Tripwires"
       },
       "cost": "20",
       "keywords": ["Infantry", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM INFANTRY** model only. Each time an enemy **INFANTRY** or **MOUNTED** unit ends a Normal, Advance, Charge or Fall Back move within 8\" of the bearer’s unit, roll one D6: on a 4+, until the start of your next turn, that enemy unit is stunned. While a unit is stunned, each time a model in that unit makes an attack, subtract 1 from the Hit roll."
       },
@@ -3108,13 +3134,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "46d87cf5-17df-5457-bf3f-dfbe7eaeea00",
+      "id": "b8d6a7a1-522a-5b10-a0c0-97a085d36901",
       "name": {
         "en": "Abhuman Detail"
       },
       "cost": "20",
       "keywords": ["Commissar"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**COMMISSAR** model only. Add the **OGRYN** keyword to the list of units this model can issue Orders too (as stated on its datasheet).\n\nIn the Declare Battle Formations step, the bearer can be attached to an **OGRYN SQUAD** or **BULLGRYN SQUAD** unit."
       },
@@ -3126,13 +3153,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "af135840-b62c-55b0-9f16-c4db80105a25",
+      "id": "a22d7f00-ce18-570a-bfd0-9a21b268ee16",
       "name": {
         "en": "Aquilan Eye"
       },
       "cost": "20",
       "keywords": ["Officer", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM OFFICER** model only. Each time you select an Order for the bearer to issue, you can select the Order below:\n\n**Target Weak Spot (Order):** Each time a model in this unit makes a ranged attack that targets an enemy unit within 12\", improve the Armour Penetration characteristic of that attack by 1."
       },
@@ -3144,13 +3172,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9a751742-4c76-59a7-8235-0e466a06a580",
+      "id": "556c2065-9ea8-5e93-9122-6632652a61aa",
       "name": {
         "en": "Spec Ops Veteran"
       },
       "cost": "15",
       "keywords": ["Officer", "Infantry", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM INFANTRY OFFICER** model only. Each time you select an Order for the bearer to issue, you can select the Order below:\n\n**Move to the Shadows (Order):** Each time a ranged attack targets this unit, until those attacks are resolved, models in this unit have the Stealth ability."
       },
@@ -3162,13 +3191,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b953bc13-843e-51ef-8883-c15ed17635dd",
+      "id": "09975d63-0c88-50b3-a078-a4e365fca185",
       "name": {
         "en": "Laud Hailer"
       },
       "cost": "10",
       "keywords": ["Officer", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM OFFICER** model only. Each time you select a unit for this **OFFICER** model to issue an Order to, that unit can be within 12\" instead of within 6\"."
       },
@@ -3180,13 +3210,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7479e92f-82c3-52d2-8cd7-69e657ee7f4c",
+      "id": "7b579832-1e86-54cd-b513-697f0746b35e",
       "name": {
         "en": "Battalion Commander"
       },
       "cost": "30",
       "keywords": ["Titanic", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM TITANIC CHARACTER** model only. The bearer has the Voice of Command ability and the Officer keyword, and can issue up to 2 Orders to **ASTRA MILITARUM TITANIC** and **SQUADRON** units."
       },
@@ -3198,13 +3229,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "89d637c8-188d-5a48-9ea4-03d3365ddfc3",
+      "id": "20ef606a-55e0-5155-867f-a477f4b6de35",
       "name": {
         "en": "Titan Killer"
       },
       "cost": "20",
       "keywords": ["Titanic", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM TITANIC CHARACTER** model only. Each time the bearer makes a ranged attack, you can re‑roll the Damage roll."
       },
@@ -3216,13 +3248,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "98073809-7773-5c4d-983b-9ba4956b05e5",
+      "id": "6e98c6a9-0463-5f78-8023-f84f88ec2454",
       "name": {
         "en": "Engine Speaker"
       },
       "cost": "15",
       "keywords": ["Tech-Priest Enginseer", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM TECH‑PRIEST ENGINSEER** model only. Each time the bearer uses its Omnissiah’s Blessing ability, until the start of your next Command phase, add 3\" to the Move characteristic of the selected **VEHICLE** model."
       },
@@ -3234,13 +3267,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9dfcac80-6922-5724-b1c0-7f5f704b27b1",
+      "id": "220d6fd0-ee4d-56d3-8c47-f1539826f9ea",
       "name": {
         "en": "Assault Hatches"
       },
       "cost": "25",
       "keywords": ["Titanic", "Transport", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM TITANIC CHARACTER TRANSPORT** model only. Each time a unit disembarks from the bearer after it has made a Normal move, that unit is still eligible to declare a charge this turn."
       },
@@ -3252,13 +3286,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "109ff180-f258-5591-8c3c-4d0c13375e32",
+      "id": "493ab73b-7abd-5b82-83ee-3578570af1ee",
       "name": {
         "en": "Exemplary Officer"
       },
       "cost": "20",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. Each time the bearer issues an Order to its own unit, you can select up to two other **PLATOON** units within 3\" of the bearer’s unit. That Order is also issued to each of those units."
       },
@@ -3270,13 +3305,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "62609408-0c4e-5ee6-8c51-2e8922799229",
+      "id": "a85a976e-82a8-5690-aef4-cd55a53d5ed6",
       "name": {
         "en": "Master Manoeuvrist"
       },
       "cost": "15",
       "keywords": ["Officer", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY OFFICER** model only. At the end of your opponent’s Fight phase, if the bearer’s unit is not within Engagement Range of one or more enemy units and every model in that unit is within 3\" of an **ASTRA MILITARUM TRANSPORT** from your army, it can embark within that **TRANSPORT.**"
       },
@@ -3288,13 +3324,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ac92249c-07c1-57de-b206-f6ddd367cecf",
+      "id": "77124a70-8e3a-52af-a063-9ff099e578bd",
       "name": {
         "en": "Omnissian Unguents (Aura)"
       },
       "cost": "35",
       "keywords": ["Tech-Priest Enginseer", "Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ASTRA MILITARUM TECH‑PRIEST ENGINSEER** model only. While a friendly **ARMOURED SKIRMISHER** unit is within 3\" of the bearer, that unit has the Feel No Pain 5+ ability."
       },
@@ -3306,13 +3343,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0e1413aa-5cde-5106-b971-584a1e490b10",
+      "id": "8e28cb8e-0b4b-520c-9ef8-c26374ff1b46",
       "name": {
         "en": "Grand Strategist"
       },
       "cost": "25",
       "keywords": ["Officer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OFFICER** model only. After both players have deployed their armies, if the bearer’s unit (or any **TRANSPORT** it is embarked within) is on the battlefield, select up to two units with the **REGIMENT** or **SQUADRON** keywords from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -6273,7 +6311,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **KASRKIN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d2188f5b-7080-5831-93c3-f438a73d11aa",
@@ -6932,7 +6982,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f8b64e14-3439-5df0-b49f-2342c986062b",
@@ -8686,7 +8743,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CATACHAN JUNGLE FIGHTERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "671dd354-8bc0-5fe7-a3b6-b1a9425b911f",
@@ -9982,7 +10046,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **CATACHAN JUNGLE FIGHTERS** ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **KASRKIN** ■ **KRIEG COMBAT ENGINEERS** ■ **TEMPESTUS SCIONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tempestus Scions",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d6e0574d-479c-59c8-b70a-3ee28f2a1c8e",
@@ -10435,7 +10531,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **CATACHAN JUNGLE FIGHTERS** ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **KASRKIN** ■ **KRIEG COMBAT ENGINEERS** ■ **TEMPESTUS SCIONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tempestus Scions",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "10f08b04-0bec-52f5-8dd8-f99fe05388f6",
@@ -10717,7 +10845,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **CATACHAN JUNGLE FIGHTERS** ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **KASRKIN** ■ **KRIEG COMBAT ENGINEERS** ■ **TEMPESTUS SCIONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tempestus Scions",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "cf709a8d-a7dd-54f5-b4a6-c6e7e3a8599a",
@@ -15627,7 +15787,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **KRIEG COMBAT ENGINEERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "77991ca9-eacf-58a8-9e77-ec05a1d9729b",
@@ -19457,7 +19629,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATH RIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Death Riders",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b09f212d-318a-5a0b-94af-8e39dfd2542a",
@@ -19670,7 +19849,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ATTILAN ROUGH RIDERS** ■ **CADIAN SHOCK TROOPS** ■ **CATACHAN JUNGLE FIGHTERS** ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **DEATH RIDERS** ■ **KASRKIN** ■ **KRIEG COMBAT ENGINEERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Attilan Rough Riders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Riders",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f3aaebf4-bb38-5594-a348-bb06ce8bd406",
@@ -20472,7 +20688,14 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **TEMPESTUS SCIONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Tempestus Scions",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "94fc8f61-aafe-53c9-9cad-e37a8a6dd614",
@@ -20680,7 +20903,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **CATACHAN JUNGLE FIGHTERS** ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **KASRKIN** ■ **KRIEG COMBAT ENGINEERS** ■ **TEMPESTUS SCIONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tempestus Scions",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2aa9ed72-e758-5a5e-9316-80096aa9f049",
@@ -21510,7 +21765,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **CATACHAN JUNGLE FIGHTERS** ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **KASRKIN** ■ **KRIEG COMBAT ENGINEERS** ■ **TEMPESTUS SCIONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tempestus Scions",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "c595da04-ffdb-5f27-9ce7-6c700ef6e32a",
@@ -24578,7 +24865,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **CATACHAN JUNGLE FIGHTERS** ■ **DEATH KORPS GRENADIER SQUAD** ■ **DEATH KORPS OF KRIEG** ■ **KASRKIN** ■ **KRIEG COMBAT ENGINEERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Catachan Jungle Fighters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Korps of Krieg",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Krieg Combat Engineers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a6fd5472-e582-5453-9ae8-c3ff63a18738",
@@ -25791,7 +26105,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CADIAN SHOCK TROOPS** ■ **KASRKIN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cadian Shock Troops",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kasrkin",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "e13c0399-951f-5348-9403-5b088ba94d19",

--- a/11th/gdc/blacktemplar.json
+++ b/11th/gdc/blacktemplar.json
@@ -7,7 +7,7 @@
     "header": "#142637"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.174Z",
+  "updated": "2026-07-28T17:03:02.512Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "rules": {
@@ -1326,7 +1326,7 @@
   ],
   "enhancements": [
     {
-      "id": "8a4c4518-2192-5b0d-a35e-f7782049edd6",
+      "id": "ce675efa-9206-5651-b8ab-06f43f6d444a",
       "name": {
         "en": "Fervent Exemplars (Upgrade)",
         "de": "Vorbildhafte Eiferer (Aufwertung)",
@@ -1340,6 +1340,7 @@
       "cost": "10",
       "keywords": ["Black Templars"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Sword Brethren squad</k> unit only. This unit has +1 to <b>charge rolls</b>.",
         "de": "Nur für eine <k>Schwertbrudertrupp</k>-Einheit. Diese Einheit hat +1 auf <b>Angriffs­würfe</b>.",
@@ -1358,7 +1359,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dbaf4f57-8e69-517e-9e4d-af58bb2cc827",
+      "id": "21eb063a-d439-5b04-9009-bd2babd89a96",
       "name": {
         "en": "Guiding Omens",
         "de": "Leitende Visionen",
@@ -1372,6 +1373,7 @@
       "cost": "15",
       "keywords": ["Black Templars"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>EMPEROR’S CHAMPION</k> model only. At the start of the first battle round, you can select up to three of the following abilities. This model has those abilities until the end of the battle:\n<ul><li><b>Instrument of the God‑Emperor (Once per battle, per army): </b>In the Fight phase, when this unit is <b>selected to fight</b>, if this unit is <b>engaged</b> with an enemy <k>CHARACTER</k> unit, you can use this ability. If you do, this model’s melee attacks have <k>[DEVASTATING WOUNDS]</k>. </li>\n<li><b>Foreseen Paths of the Unholy:</b> This unit has ‑3\" <b>detection range</b>. </li>\n<li><b>Vision of Momentous Brutality:</b> This model’s melee attacks have +2 <b>A</b>. </li>\n<li><b>Augury of Retribution:</b> Melee attacks that target this unit have <k>[HAZARDOUS]</k>. </li>\n<li><b>Omen of Sacred Intervention:</b> When you target this unit with the <b>Heroic Intervention stratagem</b>, that use is ‑1 CP. </li>\n<li><b>Harbinger of Judgement:</b> When an enemy unit (excluding <k>MONSTER/VEHICLE</k> units) <b>engaged</b> with this model is selected to make a <b>fall‑back move</b>, roll one D6: </li>\n<ul><li>On a 2+, that enemy unit suffers D6 <b>mortal wounds</b>.</li></ul></ul>",
         "de": "Nur für ein <k>CHAMPION-DES-IMPERATORS</k>-Modell. Zu Beginn der ersten Schlachtrunde kannst du bis zu drei der folgenden Fähigkeiten wählen. Dieses Modell hat jene Fähigkeiten bis zum Ende der Schlacht.\n<ul><li><b>Werkzeug des Gottimperators:</b> (Einmal pro Schlacht, pro Armee) </b> Wenn diese Einheit in der Nahkampfphase <b>zum Kämpfen gewählt wird</b> und sich <b>im Nahkampf</b> mit einer feindlichen <k>CHARAKTERMODELL</k>-Einheit befindet, kannst du diese Fähigkeit einsetzen. Wenn du dies tust, haben die Nahkampfattacken dieses Modells <k>[VERHEERENDE VERWUNDUNGEN]</k>. <li>\n<li><b>Kenne die Pfade der Entweihten:</b> Diese Einheit hat -3\" <b>Entdeckungsreichweite</b>. </li>\n<li><b>Visionen einschneidender Gewalt:</b> Die Nahkampfwaffen dieses Modells haben +2 <b>A</b>. </li>\n<li><b>Omen der Vergeltung:</b> Nahkampfattacken gegen diese Einheit haben <k>[RISKANT]</k>. </li>\n<li><b>Prophezeiung der heiligen Intervention:</b> Wenn du die <b>Gefechtsoption Heroische Intervention</b> mit dieser Einheit als Ziel einsetzt, kostet jener Einsatz ‑1 BP. </li>\n<li><b>Überbringer des Richtspruchs:</b> Wenn eine feindliche Einheit (ausgenommen <k>MONSTER-/FAHRZEUG</k>-Einheiten) <b>im Nahkampf</b> mit diesem Modell zum Ausführen einer <b>Rückzugsbewegung</b> gewählt wird, wirf einen W6: </li>\n<ul><li>Bei 2+ erleidet jene feindliche Einheit W6 <b>tödliche Verwundungen</b>.</li></ul></ul>",
@@ -1390,7 +1392,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "01413b10-4b2b-5c5a-aced-17c61a04483f",
+      "id": "d34da3e1-8af5-5a77-955e-3944dddb7e79",
       "name": {
         "en": "Benediction of Fury",
         "de": "Segnung der Wut",
@@ -1404,6 +1406,7 @@
       "cost": "15",
       "keywords": ["Chaplain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Chaplain</k> model only. This model’s melee attacks have <k>[Devastating Wounds]</k>.",
         "de": "Nur für ein <k>Ordenspriester</k>-Modell. Nahkampfattacken dieses Modells haben <k>[Verheerende Verwundungen]</k>.",
@@ -1422,7 +1425,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5d6d2340-fc89-5ee2-99c3-4d1236dd66f2",
+      "id": "2bd8b180-5732-5d7b-9c57-7ed103d261fd",
       "name": {
         "en": "Inheritors of Sigismund (Upgrade)",
         "de": "Erben des Sigismund (Aufwertung)",
@@ -1436,6 +1439,7 @@
       "cost": "15",
       "keywords": ["Black Templars"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Sword Brethren squad</k> unit only. This unit has <b>Fights First</b>.",
         "de": "Nur für eine <k>Schwertbrudertrupp</k>-Einheit. Diese Einheit hat <b>Erstschlag</b>.",
@@ -1454,7 +1458,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5fc8419b-5c48-5e2d-8ee0-8ae8dbcaa2f4",
+      "id": "52ca6132-f694-57a7-a829-ce71da88f51a",
       "name": {
         "en": "Adaptable Executioner",
         "de": "Anpassungsfähiger Henker",
@@ -1468,6 +1472,7 @@
       "cost": "20",
       "keywords": ["Black Templars"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Execrator</k> model only. When this unit is <b>selected to fight</b>, this model’s melee attacks have:\r<ul><li><k>[Cleave 1]</k>.</li>\r<li><u>Or:</u> <k>[Precision]</k>.</li></ul>",
         "de": "Nur für ein <k>Execrator</k>-Modell. Wenn diese Einheit <b>zum Kämpfen gewählt wird</b>, haben die Nahkampfattacken dieses Modells:\n<ul><li><k>[Spalten 1]</k>.</li>\n<li><u>Oder:</u> <k>[Präzision]</k>.</li></ul>",
@@ -1486,13 +1491,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3637b902-b95a-5aec-bc77-0080847fba1c",
+      "id": "aa69a4bf-5391-5596-9e1e-43b72e6b082f",
       "name": {
         "en": "Incendiary Animus"
       },
       "cost": "25",
       "keywords": ["Judiciar", "Chaplain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAPLAIN** or **JUDICIAR** model only. Improve the Armour Penetration characteristic of melee weapons equipped by models in the bearer’s unit by 1."
       },
@@ -1504,13 +1510,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "946f0f9d-c545-5f03-a969-4f7ff974dff5",
+      "id": "a5b886f0-8b31-5dbe-870c-cafe41be9580",
       "name": {
         "en": "Oathbound Exemplar"
       },
       "cost": "15",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES INFANTRY** model only. Add 1 to Advance rolls made for the bearer’s unit. If the mission pack you are playing features Actions, the bearer’s unit is eligible to start to perform an Action in a turn in which it Advanced."
       },
@@ -1522,13 +1529,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f794f03b-abad-52c0-80fe-9b64db1cdb34",
+      "id": "dabaf609-4cb3-5cf6-84b9-0b86bdb4c790",
       "name": {
         "en": "Merciless Denunciation"
       },
       "cost": "25",
       "keywords": ["Judiciar", "Chaplain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAPLAIN** or **JUDICIAR** model only. Each time a model in the bearer’s unit makes a melee attack, you can re-roll the Hit roll."
       },
@@ -1540,13 +1548,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "116217ea-110c-5219-bbd6-f00d2ebd171c",
+      "id": "579b60e9-3f68-5591-b073-ba4adecd8367",
       "name": {
         "en": "Zealous Vanguard"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Models in the bearer’s unit have the Scouts 6\" ability."
       },
@@ -1558,13 +1567,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6b8d8116-954d-59b3-8f2d-f92a42128d58",
+      "id": "0878c3f7-5b2d-58e5-b6d3-05247cce225d",
       "name": {
         "en": "Imperialis of the Eternal Crusade"
       },
       "cost": "15",
       "keywords": ["Ancient"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ANCIENT** model only. Each time an enemy unit selects the bearer’s unit as a target of a charge, subtract 2 from the Charge roll (this is not cumulative with any other negative modifiers to that Charge roll)."
       },
@@ -1576,13 +1586,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "66f69032-a37b-5526-808c-6d0fb50d99a0",
+      "id": "2d861f6c-0528-547b-8f98-f368f9adc16a",
       "name": {
         "en": "Consecrating Aura"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Models in the bearer’s unit have a 5+ invulnerable save."
       },
@@ -1594,13 +1605,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fc646585-16f1-5b82-a3d6-6e3849386f22",
+      "id": "787df805-76e1-51f9-bdf2-922241ab97b0",
       "name": {
         "en": "Orb of the Emperor’s Aegis"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Models in the bearer’s unit have the Deep Strike ability."
       },
@@ -1612,13 +1624,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cc12d535-e5c1-55db-b612-3808af1cdc68",
+      "id": "f58740bb-8ff1-58a2-9a1b-cc7356acb81a",
       "name": {
         "en": "Warden of Honour"
       },
       "cost": "20",
       "keywords": ["Crusade Ancient"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRUSADE ANCIENT** model only. While the bearer is leading a unit, each time you roll one D6 for the bearer’s Vengeful Exhortation ability, add 1 to the result."
       },
@@ -1630,13 +1643,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ddd401eb-0ccf-500d-b348-71c812ae3932",
+      "id": "27199e29-dd1f-5264-9afe-f83e8dfe95ab",
       "name": {
         "en": "Paragon of Fury"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 2 to the Strength characteristic of melee weapons equipped by the bearer. Each time a melee attack made by the bearer is allocated to an enemy model, if the bearer disembarked from a **TRANSPORT** this turn, add 1 to the Damage characteristic of that attack."
       },
@@ -1648,13 +1662,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a32f4c80-27d5-5671-bf20-904f8e64dad8",
+      "id": "a7ce95b7-7a6b-5aa2-8723-61d4e4aead37",
       "name": {
         "en": "Battle-Psalm Precentor"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time the bearer’s unit declares a charge, if an enemy unit takes a Battle-shock test as a result of the Shock and Awe Detachment rule, subtract 1 from that Battle-shock test."
       },
@@ -1666,13 +1681,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ec59ba09-3384-5729-a826-45b98a47e19d",
+      "id": "38cec381-e35a-5616-a3de-936782208797",
       "name": {
         "en": "Augury Servo-Host"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. At the start of your Shooting phase, select one enemy unit within 12\" of and visible to the bearer. Until the end of the phase, models in that unit cannot have the Benefit of Cover."
       },
@@ -1684,13 +1700,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "74a28ae7-4194-5e1b-80a7-db455d9a9795",
+      "id": "f5c8911c-59fd-5831-b65b-2aaeb6bcefdf",
       "name": {
         "en": "Herald of Sacred Slaughter"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. In the Declare Battle Formations step, if the bearer starts the battle embarked within a **DEDICATED TRANSPORT,** that **DEDICATED TRANSPORT** has the Scouts 9\" ability."
       },
@@ -1952,6 +1969,38 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "support",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -2227,7 +2276,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **CRUSADER SQUAD** ■ **INFERNUS SQUAD** ■ **INTERCESSOR SQUAD** ■ **SWORD BRETHREN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "fa08a5d9-66a1-5a17-b171-59927398f279",
@@ -2416,6 +2492,18 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -3061,7 +3149,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **CRUSADER SQUAD** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **SWORD BRETHREN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "86a2b728-d20e-55ce-baf0-ce61b0d6449c",
@@ -3298,7 +3413,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CRUSADER SQUAD** ■ **SWORD BRETHREN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b22e3ef7-6afa-5dda-8637-067fc98a4e31",
@@ -4306,7 +4433,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **CRUSADER SQUAD** ■ **INTERCESSOR SQUAD** ■ **SWORD BRETHREN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5fe8f17a-a8fb-5a0a-9b91-d61114df7d56",
@@ -5189,7 +5338,39 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **CRUSADER SQUAD** ■ **INFERNUS SQUAD** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **SWORD BRETHREN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5ae6c5e7-c11c-54a7-8232-22219c6e66df",

--- a/11th/gdc/bloodangels.json
+++ b/11th/gdc/bloodangels.json
@@ -7,7 +7,7 @@
     "header": "#72191c"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.030Z",
+  "updated": "2026-07-28T17:03:02.272Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "rules": {
@@ -1870,7 +1870,7 @@
   ],
   "enhancements": [
     {
-      "id": "204c17e6-18bc-5ac3-bf61-c4b2f7f6d2c8",
+      "id": "ae262eb1-3791-5704-a0bc-083f627456de",
       "name": {
         "en": "Blood Boil",
         "de": "Siedendes Blut",
@@ -1884,6 +1884,7 @@
       "cost": "10",
       "keywords": ["Psyker", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Psyker</k> model only. This model’s <k>[Psychic]</k> attacks:\r<ul><li>Have <k>[Anti:</k> non‑<k>Monster/Vehicle 5+]</k>.</li>\r<li>Can re‑roll <b>damage rolls</b>.</li></ul>",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Psioniker</k>-Modell. Die <k>[psionischen]</k> Attacken dieses Modells:\r<ul><li>haben <k>[Anti:</k> kein <k>Monster/Fahrzeug 5+]</k>.</li>\r<li>Für jene Attacken können <b>Schadenswürfe</b> wiederholt werden.</li></ul>",
@@ -1902,7 +1903,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a742ec8a-2501-5974-9efc-e052277c9318",
+      "id": "cd8d2866-45c2-5069-9156-a2fe94acb66b",
       "name": {
         "en": "Instinctive Interception",
         "de": "Instinktives Eingreifen",
@@ -1916,6 +1917,7 @@
       "cost": "10",
       "keywords": ["Death Company"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Death Company</k> model only. When you target this unit with the <b>Heroic Intervention stratagem</b>, that use is ‑1 <b>CP</b>.",
         "de": "Nur für ein <k>Todeskompanie</k>-Modell. Wenn du die  <b>Gefechtsoption Heroische Intervention</b> mit dieser Einheit als Ziel einsetzt, kostet jener Einsatz -1 <b>BP</b>.",
@@ -1934,7 +1936,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4f7d2b5f-d26a-5a75-b4b6-ab50320cf5b5",
+      "id": "3416a6f4-cef1-51cd-93cb-af7a7829c88d",
       "name": {
         "en": "Aureole of the Angel",
         "de": "Strahlenkranz des Engels",
@@ -1948,6 +1950,7 @@
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes</k> model only. This unit has ‑3\" <b>detection range</b>.",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-Modell. Diese Einheit hat ‑3\" <b>Entdeckungsreichweite</b>.",
@@ -1966,7 +1969,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "82f9610b-e566-56e7-9f02-59f09e2c2649",
+      "id": "51383e5a-5ae4-5a47-bf28-76826585e08d",
       "name": {
         "en": "On the Archtraitor's Bridge",
         "de": "Auf der Brücke des Erzverräters",
@@ -1980,6 +1983,7 @@
       "cost": "20",
       "keywords": ["Death Company"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Death Company</k> model only. This model’s melee attacks have +2 <b>A</b>.",
         "de": "Nur für ein <k>Todeskompanie</k>-Modell. Die Nahkampfattacken dieses Modells haben +2 <b>A</b>.",
@@ -1998,7 +2002,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "46b9a87e-0183-565d-b40f-dc6a4bf286ef",
+      "id": "22e76857-6271-526f-9577-7972408ca469",
       "name": {
         "en": "Angelic Executioner",
         "de": "Engelsgleicher Scharfrichter",
@@ -2012,6 +2016,7 @@
       "cost": "25",
       "keywords": ["Jump Pack", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Jump Pack</k> model only. When this unit is <b>selected to fight</b>, this unit’s melee attacks have:\r<ul><li><k>[Lethal Hits]</k>.</li>\r<li><u>Or:</u> <k>[Sustained Hits 1]</k>.</li></ul>",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Sprungmodul</k>-Modell. Wenn diese Einheit <b>zum Kämpfen gewählt wird</b>, haben ihre Nahkampfattacken:\r<ul><li><k>[Tödliche Treffer]</k>.</li>\r<li><u>Oder:</u> <k>[Trefferhagel 1]</k>.</li></ul>",
@@ -2030,7 +2035,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "28c82a5f-ec43-5036-bc55-85581db7092b",
+      "id": "ab1166fd-7f63-5a1d-b69b-46c8abcd6bd5",
       "name": {
         "en": "Shadow of Abomination",
         "de": "Der Schatten des Bösen",
@@ -2044,6 +2049,7 @@
       "cost": "25",
       "keywords": ["Jump Pack", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Jump Pack</k> model only. (Once per battle, per army) When this unit is <b>selected to fight</b> you can use this ability. If you do, this model’s melee attacks have +1 <b>D</b>.",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Sprungmodul</k>-Modell. (Einmal pro Schlacht, pro Armee) Wenn diese Einheit <b>zum Kämpfen gewählt wird</b>, kannst du diese Fähigkeit einsetzen. Wenn du dies tust, haben die Nahkampfattacken dieses Modells +1 <b>SW</b>.",
@@ -2062,13 +2068,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fdd19406-65b8-5a6e-8cf0-c7b4069f3001",
+      "id": "f8e69dcd-dc9e-543c-b7b9-0b67e8186f38",
       "name": {
         "en": "Sanguinius’ Grace"
       },
       "cost": "20",
       "keywords": ["Death Company"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH COMPANY** model only. Once per battle, at the end of the Fight phase, if the bearer is within Engagement Range of three or more enemy models, the bearer can fight one additional time."
       },
@@ -2080,13 +2087,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "693067b1-947f-5300-aa5a-d9f72a86f6bf",
+      "id": "355d2262-0fa5-58f5-bb8b-02abac22ffeb",
       "name": {
         "en": "Speed of the Primarch"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Once per battle, at the start of the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, models in the bearer’s unit have the Fights First ability."
       },
@@ -2098,13 +2106,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d0074b36-0968-515b-80bb-d50db265d0b7",
+      "id": "06c42e88-5252-5db9-a370-811304aedc15",
       "name": {
         "en": "Blood Shard"
       },
       "cost": "25",
       "keywords": ["Death Company"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH COMPANY** model only. The first time the bearer is destroyed, at the end of the phase, roll one D6: on a 2+, set the bearer back up on the battlefield as close as possible to where it was destroyed and not within Engagement Range of any enemy units, with 3 wounds remaining."
       },
@@ -2116,13 +2125,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1ccd0a44-393d-540f-9131-5c07f8c69730",
+      "id": "fdb19bb7-62de-5af8-a333-8c512d9fd6c7",
       "name": {
         "en": "Rage-fuelled Warrior"
       },
       "cost": "35",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Once per battle, at the start of the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, the bearer’s melee weapons have the **[SUSTAINED HITS 3]** ability."
       },
@@ -2134,13 +2144,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d616af6a-5247-5cb2-a521-7362f36c15f1",
+      "id": "8f334b43-d0da-5563-9ffd-827cbb419e09",
       "name": {
         "en": "To Slay The Warmaster"
       },
       "cost": "15",
       "keywords": ["Death Company"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH COMPANY** model only. Once per battle, at the start of the Fight phase, if the bearer is within Engagement Range of one or more enemy **CHARACTER** units, you can select one of those **CHARACTER** units and roll six D6: for each 4+, one **CHARACTER** model in that unit suffers 1 mortal wound."
       },
@@ -2152,13 +2163,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "468e8afd-a173-5e50-bada-c65bd01a085b",
+      "id": "f593953f-074b-521b-893d-709adf67ddee",
       "name": {
         "en": "Icon of the Angel"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time an enemy unit (excluding **MONSTERS** and **VEHICLES**) within Engagement Range of the bearer’s unit is selected to Fall Back, models in that enemy unit must take Desperate Escape tests as if their unit was Battle‐shocked. When doing so, if that enemy unit is also Battle‐shocked by other means, subtract 1 from each of those Desperate Escape tests."
       },
@@ -2170,13 +2182,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a15a03c6-813d-5d79-b7f1-b078c032be69",
+      "id": "459b0d6b-3aa8-5f58-b22c-d0602d7c8582",
       "name": {
         "en": "Vengeful Onslaught"
       },
       "cost": "10",
       "keywords": ["Death Company"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH COMPANY** model only. If the bearer is destroyed, until the end of your next turn, each time a friendly **DEATH COMPANY** model makes an attack, add 1 to the Hit roll."
       },
@@ -2188,13 +2201,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4b0d81cd-5507-5f07-bb4b-5eb74b25a561",
+      "id": "1f27dad8-83ca-5fd1-81ac-cce8cf7f716c",
       "name": {
         "en": "Gift of Foresight"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Once per battle round, just after making a Hit roll, a Wound roll or a saving throw for the bearer, you can treat the result as an unmodified roll of 6 instead."
       },
@@ -2206,13 +2220,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "deb9caaa-5e11-533b-b53b-cd3f632d7756",
+      "id": "cd34aca0-53bd-5e1f-b013-9d0307432390",
       "name": {
         "en": "Artisan of War"
       },
       "cost": "20",
       "keywords": ["Jump Pack", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES JUMP PACK** model only. Improve the Armour Penetration characteristic of the bearer’s weapons by 1, and the bearer has a Save characteristic of 2+."
       },
@@ -2224,13 +2239,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2294b3f3-2844-550b-ad52-0c6cffb0d68d",
+      "id": "86f39bda-92d7-56fd-a1f0-9d635131b915",
       "name": {
         "en": "Visage of Death"
       },
       "cost": "15",
       "keywords": ["Jump Pack", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES JUMP PACK** model only. In the Battle‐shock step of your opponent’s Command phase, each enemy unit (excluding **MONSTERS** and **VEHICLES**) within Engagement Range of the bearer must take a Battle‐shock test."
       },
@@ -2242,13 +2258,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8f627182-ef5d-583d-b3e5-4d2bf31cf6be",
+      "id": "8b70874a-ac5f-58ee-85c4-1fff4a032699",
       "name": {
         "en": "Archangel’s Shard"
       },
       "cost": "15",
       "keywords": ["Jump Pack", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES JUMP PACK** model only. The bearer’s melee weapons have the **[ANTI-CHAOS 5+]** and **[LANCE]** abilities."
       },
@@ -2260,13 +2277,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "14ea8d89-e2db-5a20-80b5-8323ad8f6b9f",
+      "id": "17ef9bfc-6f32-5e1d-9f56-b5772ad7f0a1",
       "name": {
         "en": "Gleaming Pinions"
       },
       "cost": "25",
       "keywords": ["Jump Pack", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES JUMP PACK** model only. In your opponent's Movement phase, if an enemy unit ends a move within 8” of this unit, if this unit is not within Engagement Range of one or more enemy units, this unit can make a Normal move of up to 6”."
       },
@@ -2278,13 +2296,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e52bf420-3cfe-5234-9edd-33be67989247",
+      "id": "6c6dbbba-ae06-5fe6-b07f-41fcf8472832",
       "name": {
         "en": "Prescient Flash"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Models in the bearer’s unit have the Scouts 6\" ability."
       },
@@ -2296,13 +2315,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "be5b7f41-49cb-5d15-b5b5-10b46da662ba",
+      "id": "cea417ff-df1e-53be-a1fb-6976516f416b",
       "name": {
         "en": "Troubling Visions"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Once per battle, in your Command phase, the bearer can use this Enhancement. When it does, until the start of your next Command phase, all Angelic Legacy abilities (see Legacy of the Angel Detachment Rule) are active for the bearer’s unit, instead of only two of them."
       },
@@ -2314,13 +2334,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fe9ae358-083d-5bd9-a486-65853870fc80",
+      "id": "3fa7a310-b6ea-51f7-be47-84c42077d5cc",
       "name": {
         "en": "Blazing Icon"
       },
       "cost": "20",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES INFANTRY** model only. Enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2332,13 +2353,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "451e75dc-1a1a-55a1-ac5f-bdf7c4083c15",
+      "id": "f39fc1d9-5ea6-5563-9cb9-10baeefb02ec",
       "name": {
         "en": "Ordained Sacrifice"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. The first time the bearer is **destroyed**, roll one D6 at the end of the phase:\n▫ On a 2+, set up this model on the battlefield, **unengaged** and as close as possible to where it was **destroyed**. This model is not part of an **attached** unit and its unit has a **starting strength** of 1. This model has 3 wounds remaining."
       },
@@ -2350,13 +2372,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6a494532-f48c-5090-9f0c-de213253846a",
+      "id": "98b5e6f0-fa5e-54f7-86a7-412c21133022",
       "name": {
         "en": "Carmine Reliquary"
       },
       "cost": "30",
       "keywords": ["Chaplain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAPLAIN** model only. Models in the bearer’s unit have the Scouts 6\" ability. Each time you take a Battle-shock test for an **ADEPTUS ASTARTES** unit within 6\" of the bearer, you can re-roll the result."
       },
@@ -2368,13 +2391,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ceed6b5e-f290-5d28-81f1-fc4abe5a93a5",
+      "id": "42b95b5d-41aa-50ad-9483-5d2d23897378",
       "name": {
         "en": "Master of the Red Thirst"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Once per battle, at the start of the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, models in the bearer’s unit have the Fights First ability."
       },
@@ -2386,13 +2410,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2f568096-fb2b-502c-8562-d08daa641e5b",
+      "id": "57215127-bace-52e5-ac12-7ee6be747f2e",
       "name": {
         "en": "Sanguinary Tear (Aura)"
       },
       "cost": "35",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While a friendly **DEATH COMPANY** unit is within 6\" of the bearer, add 1 to the Strength characteristic of weapons equipped by models in that unit."
       },
@@ -2404,13 +2429,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fd792905-ddc8-5a21-b2f3-db92dc9e2791",
+      "id": "a2c85e14-2bb6-5057-8f32-b44e1f263412",
       "name": {
         "en": "Angel’s Fang"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time the bearer makes a melee attack that targets a **CHARACTER**, **MONSTER** or **VEHICLE** unit, that attack has the **[SUSTAINED HITS 2]** ability."
       },
@@ -2585,7 +2611,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATH COMPANY MARINES WITH BOLTGUNS AND JUMP PACKS** ■ **DEATH COMPANY MARINES WITH JUMP PACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Death Company Marines with Jump Packs",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9ce6d8b7-7943-518e-be4d-d89fd9f9a057",
@@ -3150,7 +3183,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **COMPANY HEROES** ■ **INFERNUS SQUAD** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "dc788dd1-8d00-5724-a0df-a5ab92a159c6",
@@ -3575,7 +3640,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSORS WITH JUMP PACKS** ■ **SANGUINARY GUARD** ■ **VANGUARD VETERAN SQUAD WITH JUMP PACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessors with Jump Packs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sanguinary Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vanguard Veteran Squad with Jump Packs",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "21a7f88a-f5d9-58a9-bd4a-44dc8202dd22",
@@ -3847,7 +3929,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATH COMPANY MARINES** ■ **DEATH COMPANY MARINES WITH BOLT RIFLES** ■ **DEATH COMPANY MARINES WITH BOLTGUNS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Death Company Marines with Bolt Rifles",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Company Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "19ebaa29-6ec3-5cb7-9644-e15bbb5060b3",
@@ -4164,7 +4258,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATH COMPANY MARINES WITH BOLTGUNS AND JUMP PACKS** ■ **DEATH COMPANY MARINES WITH JUMP PACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Death Company Marines with Jump Packs",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3ee2094c-aa41-580b-bc63-43da2b51f238",
@@ -5890,7 +5991,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATH COMPANY MARINES WITH BOLTGUNS AND JUMP PACKS** ■ **DEATH COMPANY MARINES WITH JUMP PACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Death Company Marines with Jump Packs",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3ba1b185-c189-5eec-8440-679398e4b683",
@@ -6351,7 +6459,54 @@
       "additionalCost": {
         "cost": "10",
         "afterSelections": 2
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Desolation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Devastator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "support",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "ea9e7286-4775-5e55-b2e0-b1c2c7c63b12",

--- a/11th/gdc/chaos_spacemarines.json
+++ b/11th/gdc/chaos_spacemarines.json
@@ -7,7 +7,7 @@
     "header": "#222a2f"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:51.073Z",
+  "updated": "2026-07-28T17:03:04.212Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -3802,7 +3802,7 @@
   ],
   "enhancements": [
     {
-      "id": "f980a238-d0e0-5017-90e4-91c45ebd91eb",
+      "id": "a1afa5f2-84e2-57f2-b344-770e75a9fe51",
       "name": {
         "en": "Touched by the Warp",
         "de": "Vom Warp berührt",
@@ -3816,6 +3816,7 @@
       "cost": "10",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Khorne"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Heretic Astartes</k> model only (excluding <k>Khorne</k> models).\r<ul><li>This model has <k>Psyker</k>.</li>\r<li>This model’s weapons have <k>[Psychic]</k>.</li></ul>",
         "de": "Nur für ein <k>Häretiker-Astartes</k>-Modell (ausgenommen <k>Khorne</k>-Modelle).\n<ul><li>Dieses Modell hat <k>Psioniker</k>.</li>\n<li>Die Waffen dieses Modells haben <k>[Psionisch]</k>.</li></ul>",
@@ -3834,7 +3835,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ffcc4a37-3bcd-5db0-a545-78cb621dc1b3",
+      "id": "88648717-ec06-5297-8ff5-6b26ea6922ef",
       "name": {
         "en": "Pact of Destruction",
         "de": "Pakt der Verwüstung",
@@ -3848,6 +3849,7 @@
       "cost": "15",
       "keywords": ["Warpsmith"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Warpsmith</k> model only.\r<ul><li>When this unit uses its <b>Dark Pacts</b> ability, this unit can re‑roll <b>Leadership rolls</b>.</li>\r<li>In your Shooting phase, when this unit has shot, if this unit used its <b>Dark Pacts</b> ability and if those attacks <b>destroyed</b> an enemy model, this unit <b>heals</b> 3 wounds.</li></ul>",
         "de": "Nur für ein <k>Warpschmied</k>-Modell.\n<ul><li>Wenn diese Einheit ihre Fähigkeit <b>Dunkle Pakte</b> einsetzt, können <b>Moralwertwürfe</b> für sie wiederholt werden.</li>\n<li>Nachdem diese Einheit in deiner Fernkampfphase geschossen hat, wenn sie ihre Fähigkeit <b>Dunkle Pakte</b> eingesetzt hat und durch jene Attacken mindestens ein feindliches Modell <b>zerstört</b> wurde, wird diese Einheit um 3 Lebenspunkte <b>geheilt</b>.</li></ul>",
@@ -3866,7 +3868,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c916841e-1a6b-500b-8256-974d4b032a77",
+      "id": "ee90cec5-7b71-5410-a400-6663642b1597",
       "name": {
         "en": "Shadowcowl Talisman",
         "de": "Talisman der wallenden Schatten",
@@ -3880,6 +3882,7 @@
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Chaos Lord with Jump Pack</k> model only. This unit has 5+ <b>InSv</b>.",
         "de": "Nur für ein <k>Chaoslord</k>-<k>mit</k>-<k>Sprungmodul</k>-Modell. Diese Einheit hat 5+ <b>RE</b>.",
@@ -3898,7 +3901,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b2cffab4-3d30-5363-af5b-9d8c6d91f6b1",
+      "id": "020e79f4-7d7b-5e84-b396-0f7c4a296651",
       "name": {
         "en": "Pact of Cursed Pinions",
         "de": "Fluchschwingenpakt",
@@ -3912,6 +3915,7 @@
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Chaos Lord with Jump Pack</k> model only.\r<ul><li>This model has <k>Daemon</k>.</li>\r<li>This model’s melee attacks have +1 <b>A</b>.</li></ul>",
         "de": "Nur für ein <k>Chaoslord</k>-<k>mit</k>-<k>Sprungmodul</k>-Modell.\r<ul><li>Dieses Modell hat <k>Dämon</k>.</li>\r<li>Die Nahkampfattacken dieses Modells haben +1 <b>A</b>.</li></ul>",
@@ -3930,7 +3934,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "77ba559c-ac8d-5727-b456-2a3b69a9edb0",
+      "id": "281ebd7b-daa3-59f1-ae94-5d759a6d30f5",
       "name": {
         "en": "Eye of Oblivion",
         "de": "Auge der Vergessenheit",
@@ -3944,6 +3948,7 @@
       "cost": "20",
       "keywords": ["Warpsmith"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Warpsmith</k> model only. When this unit is <b>selected to shoot</b>, select one enemy unit within 24\" of this unit. That enemy unit has +6\" <b>detection range</b> until this unit has shot.",
         "de": "Nur für ein <k>Warpschmied</k>-Modell. Wenn diese Einheit <b>zum Schießen gewählt wird</b>, wähle eine feindliche Einheit innerhalb von 24\" um diese Einheit. Jene feindliche Einheit hat +6\" <b>Entdeckungsreichweite</b>, bis diese Einheit geschossen hat.",
@@ -3962,7 +3967,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7ee50d59-a8ed-5681-ad27-777a6d44352c",
+      "id": "7f540ca6-107c-5827-b8a2-aed3b5a94324",
       "name": {
         "en": "Conduit of Chaos",
         "de": "Gefäß des Chaos",
@@ -3976,6 +3981,7 @@
       "cost": "20",
       "keywords": ["Daemon", "Heretic Astartes"],
       "excludes": ["Khorne"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Heretic Astartes Daemon</k> model only (excluding <k>Khorne</k> models). This model’s melee attacks have <k>[Lance]</k>.",
         "de": "Nur für ein <k>Häretiker-Astartes</k>-<k>Dämon</k>-Modell (ausgenommen <k>Khorne</k>-­Modelle). Die Nahkampfattacken dieses Modells haben <k>[­Lanze]</k>.",
@@ -3994,13 +4000,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4cd0135e-4155-5abe-8098-ae43060e5398",
+      "id": "ed0bd884-8288-5067-b03c-bf76317d845b",
       "name": {
         "en": "Warmaster’s Gift"
       },
       "cost": "15",
       "keywords": ["Chaos Lord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD** model only. Each time the bearer makes an attack that targets your focus of hatred, an unmodified successful Wound roll of 5+ scores a Critical Wound."
       },
@@ -4012,13 +4019,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7ebac329-f10a-5e6f-af69-12e95fc0d81f",
+      "id": "7d123c70-9338-51a2-9b5b-73780fa22ec1",
       "name": {
         "en": "Talisman of Burning Blood"
       },
       "cost": "15",
       "keywords": ["Khorne", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES KHORNE** model only. Add 1 to the Attacks and Strength characteristics of the bearer’s melee weapons. Each time the bearer’s unit makes a Dark Pact and does not fail the resulting Leadership test, roll one D3: until the end of the phase, add the result to the Attacks and Strength characteristics of the bearer’s melee weapons instead."
       },
@@ -4030,13 +4038,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ceba9a75-e259-5238-9627-23b11e09db99",
+      "id": "ba738e16-a2d3-5990-a09c-7323a100132b",
       "name": {
         "en": "Eye of Tzeentch"
       },
       "cost": "15",
       "keywords": ["Tzeentch", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES TZEENTCH** model only. Each time the bearer’s unit makes a Dark Pact and does not fail the resulting Leadership test, if the result of that test was 8 or more, you gain 1CP."
       },
@@ -4048,13 +4057,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cfa9bb5b-5598-5ffc-9915-a7c4a5a2fcd0",
+      "id": "350c51e9-4df3-537a-857c-4ad9e32773f9",
       "name": {
         "en": "Eager for Vengeance"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). The bearer’s unit is eligible to shoot and declare a charge in a turn in which it Fell Back. Each time a model in the bearer’s unit makes an attack that targets your focus of hatred, if the bearer’s unit Fell Back this turn, add 1 to the Hit roll, and each time you select your focus of hatred as a target of that unit’s charge, add 1 to the Charge roll."
       },
@@ -4066,13 +4076,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f6621cee-7317-5863-a0bc-3dbf3d3da4b0",
+      "id": "1c53a156-4fbe-5113-8d12-6b54aa5c92d2",
       "name": {
         "en": "Eye of Abaddon"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). While the bearer is on the battlefield, each time your focus of hatred is destroyed, roll one D6: on a 4+, you gain 1CP."
       },
@@ -4084,13 +4095,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "89fa1ac3-5174-5660-a1cd-2475dd7bde3d",
+      "id": "e98d53e6-ee57-5632-82a5-d9a63764ee0b",
       "name": {
         "en": "Orbs of Unlife"
       },
       "cost": "15",
       "keywords": ["Nurgle", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES NURGLE** model only. At the end of the Fight phase, roll one D6 for every enemy unit within 3\" of the bearer, adding 1 to the result if the bearer’s unit made a Dark Pact that phase and did not fail the resulting Leadership test: on a 4+, that enemy unit suffers D3 mortal wounds."
       },
@@ -4102,13 +4114,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "72f93889-fd4a-5891-a931-23f53ef902cd",
+      "id": "32ff35a7-b195-5df3-931b-6469a385a58f",
       "name": {
         "en": "Mark of Legend"
       },
       "cost": "10",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). Once per turn, you can re-roll one Hit roll, one Wound roll or one saving throw made for the bearer."
       },
@@ -4120,13 +4133,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f45a7525-47ab-515d-bccd-03ed9f3083e2",
+      "id": "1faa1ad1-0812-5e84-82ae-5f0bef098da7",
       "name": {
         "en": "Intoxicating Elixir"
       },
       "cost": "15",
       "keywords": ["Slaanesh", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES SLAANESH** model only. The bearer has the Feel No Pain 5+ ability. Each time the bearer shoots or fights, if the bearer’s unit made a Dark Pact this phase and did not fail the resulting Leadership test, after the bearer has resolved those attacks, select one enemy unit that was hit by one or more of those attacks; that enemy unit must take a Battle-shock test."
       },
@@ -4138,13 +4152,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3548355b-933f-5b17-8371-ce9722dae6bb",
+      "id": "8732f991-197d-5688-a402-edf8eeef7f09",
       "name": {
         "en": "Falsehood"
       },
       "cost": "10",
       "keywords": ["Chaos Lord"],
       "excludes": ["Jump Pack", "Terminator"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD** model only (excluding **TERMINATOR** and **JUMP PACK** models). In the Declare Battle Formations step, you can set the bearer up in Reserves instead of setting it up on the battlefield. If you do, in one of your Movement phases, you can select one model in a friendly **LEGIONARIES** or **CHOSEN** unit that has two or more models remaining and is on the battlefield (excluding Attached units). The selected model is destroyed (ignoring any rules that are triggered when a model is destroyed) and the bearer is set up as close as possible to where that model was destroyed and only within Engagement Range of any enemy units if the destroyed model was within Engagement Range of those units. The bearer now attaches to that unit as its Leader."
       },
@@ -4156,13 +4171,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "acbb62bb-6583-5a93-894c-00ef04ddaad7",
+      "id": "d2053a9d-03f8-52ff-880f-e0f82b92f916",
       "name": {
         "en": "Cursed Fang"
       },
       "cost": "10",
       "keywords": ["Infantry", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES INFANTRY** model only. Improve the Armour Penetration characteristic of the bearer’s melee weapons by 1, and the bearer’s melee weapons have the **[PRECISION]** ability."
       },
@@ -4174,13 +4190,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "18d7520b-a23d-5a1a-b8a6-d77ec10f862b",
+      "id": "16960629-98cd-50a0-b098-1e59efb03e7c",
       "name": {
         "en": "Shroud of Obfuscation"
       },
       "cost": "15",
       "keywords": ["Infantry", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES INFANTRY** model only. The bearer has the Stealth and Lone Operative abilities."
       },
@@ -4192,13 +4209,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8a3ce298-13d2-5d8c-b653-b5d7fde00361",
+      "id": "d8a88fdd-8928-5dc8-ac37-10b7f0fd7a31",
       "name": {
         "en": "Soul Link"
       },
       "cost": "5",
       "keywords": ["Infantry", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES INFANTRY** model only. At the start of your Command phase, you can select one other **HERETIC ASTARTES INFANTRY CHARACTER** model from your army (excluding **EPIC HEROES**). Until the start of your next Command phase, the bearer gains the **PSYKER** keyword, and replace the bearer’s datasheet abilities with the datasheet abilities of the **CHARACTER** you selected."
       },
@@ -4210,13 +4228,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "568ad0b8-ad64-52c5-ba4d-c091aade203a",
+      "id": "171eb7bd-11f7-58c7-a903-86bb2c0b122c",
       "name": {
         "en": "Despot’s Claim"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. At the start of your Command phase, if the bearer is on the battlefield, roll one D6, adding 1 to the result if the bearer is wholly within 12\" of your opponent’s deployment zone: on a 5+, you gain 1CP."
       },
@@ -4228,13 +4247,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4b4c5ea0-9714-5792-a7e3-f672dca89224",
+      "id": "8afe93fb-3c4e-53fc-b7ae-6b55d9d95db6",
       "name": {
         "en": "Dread Reaver"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. Each time the bearer makes a melee attack, if the bearer is wholly within 12\" of your opponent’s deployment zone, you can re-roll the Hit roll and you can re-roll the Wound roll."
       },
@@ -4246,13 +4266,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b06ad7c1-a5e3-5166-ba3f-bfb69d762cdc",
+      "id": "96f6e541-740c-5fc1-bbf2-96a807278db4",
       "name": {
         "en": "Mark of the Hound"
       },
       "cost": "25",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. Models in the bearer’s unit have the Scouts 6\" ability."
       },
@@ -4264,13 +4285,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "71fc5666-0396-5561-b6ba-eacd30871444",
+      "id": "4ee7d739-44f6-5eba-a47e-0db2f7798598",
       "name": {
         "en": "Tyrant’s Lash"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. You can re-roll Advance rolls made for the bearer’s unit, and the bearer’s unit is eligible to shoot in a turn in which it Fell Back."
       },
@@ -4282,13 +4304,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cd4abf56-4e09-58c2-abb5-d39039398181",
+      "id": "af4e3937-a94f-59fd-b695-5bfa194e2e9b",
       "name": {
         "en": "Night’s Shroud"
       },
       "cost": "10",
       "keywords": ["Chaos Lord"],
       "excludes": ["Terminator"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD** model only (excluding **TERMINATOR** models). Models in the bearer’s unit have the Stealth ability."
       },
@@ -4300,13 +4323,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f8796740-6dce-5f4c-a0cd-c408fc3ce691",
+      "id": "9bad5511-edbe-5a3b-a669-5296f669356a",
       "name": {
         "en": "Willbreaker"
       },
       "cost": "10",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. In the Fight phase, after the bearer has made its attacks, select one enemy unit hit by one or more of those attacks. That unit must take a Battle-shock test."
       },
@@ -4318,13 +4342,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1f8525d1-72f9-5a91-ba70-6f0d03de9d97",
+      "id": "646b6e4e-def8-5751-8469-ce4ae529b9ea",
       "name": {
         "en": "Warp-Fuelled Thrusters"
       },
       "cost": "20",
       "keywords": ["Chaos Lord", "Jump Pack"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**JUMP PACK CHAOS LORD** model only. At the end of your opponent’s turn, if the bearer’s unit is not within Engagement Range of one or more enemy units, you can remove the bearer’s unit from the battlefield and place it into Strategic Reserves."
       },
@@ -4336,13 +4361,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "64cf0f4c-d713-5a22-a5b7-f77cc6233590",
+      "id": "960b6c11-f3b6-53b6-8cc3-74fbb2f60549",
       "name": {
         "en": "Eater of Dread"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. At the start of your Command phase, if the bearer is on the battlefield, roll one D6, adding 1 to the result for each Battle-shocked enemy unit that is on the battlefield: on a 5+, you gain 1CP"
       },
@@ -4354,13 +4380,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5028538b-1616-5a23-895a-55a9470932bc",
+      "id": "00e5eba4-ab57-5c20-a613-15dac305d883",
       "name": {
         "en": "Bastion Plate"
       },
       "cost": "10",
       "keywords": ["Chaos Lord"],
       "excludes": ["Jump Pack"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD** model only (excluding **JUMP PACK** models). Once per battle round, when a saving throw is failed for the bearer’s unit, you can change the Damage characteristic of that attack to 0."
       },
@@ -4372,13 +4399,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "75c9a219-6796-5e81-8122-58e239468cd2",
+      "id": "3653a798-0371-5e0f-bf8b-bfe5de266b1e",
       "name": {
         "en": "Warp Tracer"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. In your Shooting phase, after the bearer has shot, select one enemy unit hit by one or more of those attacks. Until the end of the phase, that enemy unit cannot have the Benefit of Cover."
       },
@@ -4390,13 +4418,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a39ed092-9715-531b-a6a0-6d6e168e12a8",
+      "id": "b0dfa4e6-b058-526d-bb4e-2a9bb1a6332b",
       "name": {
         "en": "Ironbound Enmity"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. Each time the bearer makes an attack while within range of an objective marker, add 1 to the Wound roll."
       },
@@ -4408,13 +4437,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9e6b5745-5287-5db6-a281-3bbd03cdb6f1",
+      "id": "900223bd-ea7e-59a7-b026-238a4877adac",
       "name": {
         "en": "Iron Artifice"
       },
       "cost": "10",
       "keywords": ["Infantry", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES INFANTRY** model only. The bearer’s weapons have the **[ANTI-VEHICLE 4+]** and **[ANTI-FORTIFICATION 4+]** abilities."
       },
@@ -4426,13 +4456,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9ba840c9-9f72-5362-b6ae-70efd0912605",
+      "id": "2d81b49f-7799-5463-a9e0-abf47dac3676",
       "name": {
         "en": "Cultist’s Brand"
       },
       "cost": "30",
       "keywords": ["Dark Apostle", "Damned"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DARK APOSTLE** or **DAMNED** model only. If every other model in the bearer’s unit (excluding Dark Disciples) is **DAMNED**, you can re-roll Advance and Charge rolls made for the bearer’s unit."
       },
@@ -4444,13 +4475,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "254c0c80-e5a7-51b9-92c5-3c87511a2e04",
+      "id": "f590db44-f22d-570a-bbc5-b787aec40562",
       "name": {
         "en": "Amulet of Tainted Vigour"
       },
       "cost": "20",
       "keywords": ["Dark Apostle"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DARK APOSTLE** model only. In your Command phase, you can return up to D3 destroyed **DAMNED** models (excluding **CHARACTER** models) to the bearer’s unit."
       },
@@ -4462,13 +4494,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2173968a-a7a8-53af-aef6-0a4326ba9797",
+      "id": "9f7bc8e8-07aa-5c67-8c18-6098d4c0f9c0",
       "name": {
         "en": "Incendiary Goad"
       },
       "cost": "25",
       "keywords": ["Dark Apostle", "Damned"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DARK APOSTLE** or **DAMNED** model only. While the bearer’s unit is below its Starting Strength, add 1 to the Strength characteristic of melee weapons equipped by **DAMNED** models in that unit, and while that unit is Below Half-strength, add 1 to the Attacks characteristic of those weapons as well."
       },
@@ -4480,13 +4513,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9f2f7124-e35c-5dee-8611-97e383bf061b",
+      "id": "28950123-24ae-530d-aa5f-ddd4a709b8a5",
       "name": {
         "en": "Warped Foresight"
       },
       "cost": "10",
       "keywords": ["Damned", "Dark Apostle"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DARK APOSTLE** or **DAMNED** model only. While the bearer is leading a unit with the Scouts 6\" ability, every model in the bearer’s unit has the Scouts 6\" ability."
       },
@@ -4498,13 +4532,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1a1edc7e-d240-5790-9334-558f9b78d3ed",
+      "id": "ab2e563d-b992-562d-895b-362665ed45e2",
       "name": {
         "en": "Invigorated Mechatendrils"
       },
       "cost": "15",
       "keywords": ["Warpsmith"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WARPSMITH** model only. Add 4\" to the bearer’s Move characteristic."
       },
@@ -4516,13 +4551,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f3052fcb-d262-53dc-b576-757cf0d4779f",
+      "id": "0892f47f-3960-5d97-b8bf-e529ec836419",
       "name": {
         "en": "Tempting Addendum"
       },
       "cost": "40",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. Each time a **HERETIC ASTARTES DAEMON VEHICLE** unit from your army invokes its contract while within 3\" of the bearer:\n\n• If it suffers one or more mortal wounds as a result of that Dark Pact, add 1 to the number of mortal wounds it suffers.\n• Until the end of the phase, each time a model in that unit makes an attack, you can re-roll the Hit roll."
       },
@@ -4534,13 +4570,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "12710e8d-e29d-5d3f-852a-31c0d31ce7e6",
+      "id": "b7da65e6-b822-5f46-9e81-f341b5fd9950",
       "name": {
         "en": "Forge’s Blessing"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. In your Command phase, select one friendly **HERETIC ASTARTES VEHICLE** unit within 12\" of the bearer. Until the start of your next Command phase, that unit has the Feel No Pain 6+ ability."
       },
@@ -4552,13 +4589,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d57d66aa-d6d9-531f-a263-a8abd83051d8",
+      "id": "8bd73345-00d9-57a3-84e5-08abb492a988",
       "name": {
         "en": "Soul Harvester"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. While the bearer is on the battlefield, each time an enemy unit within 12\" of the bearer is destroyed, roll one D6: on a 5+, you gain 1CP."
       },
@@ -4570,13 +4608,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8d34b815-b659-58ca-b83a-e0944c8fe0b3",
+      "id": "64dc6b59-1fab-5b35-ad4c-acc7bf4938d6",
       "name": {
         "en": "Surgical Precision"
       },
       "cost": "10",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model (excluding **DAMNED** models) only. The bearer’s melee weapons have the **[PRECISION]** ability."
       },
@@ -4588,13 +4627,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "68e02c87-ce0f-500c-9523-800ba865e312",
+      "id": "e1e54ad6-7652-5466-8fd2-f5e6b2e46a32",
       "name": {
         "en": "Living Carapace"
       },
       "cost": "15",
       "keywords": ["Chaos Lord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD** model only. Add 1 to the bearer’s Wounds characteristic and the bearer has the Feel No Pain 5+ ability."
       },
@@ -4606,13 +4646,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fbba0e4a-c616-5cdb-8283-bfb574e01e46",
+      "id": "ffbe0176-fcad-5e60-9158-baf694ea28f7",
       "name": {
         "en": "Helm of All-Seeing"
       },
       "cost": "25",
       "keywords": ["Infantry", "Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES INFANTRY** model (excluding **DAMNED** models) only. Enemy units that are set up on the battlefield from Reserves cannot be set up within 12\" of the bearer."
       },
@@ -4624,13 +4665,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c7451a60-5586-5b96-8c7c-bfcb544d2e27",
+      "id": "a1ed1f61-1472-5d94-838a-db074e9bb13f",
       "name": {
         "en": "Prime Test Subject"
       },
       "cost": "35",
       "keywords": ["Infantry", "Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES INFANTRY** model (excluding **DAMNED** models) only. Add 1 to the Damage characteristic of melee weapons equipped by the bearer. Each time the bearer makes a melee attack, you can re‑roll the Hit roll."
       },
@@ -4642,13 +4684,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "10d5b37f-ba72-54b7-a1bc-a3b7cf971b8c",
+      "id": "aa0e849e-5f9c-5e81-840b-ed2359b0e27b",
       "name": {
         "en": "Greyveil Hex"
       },
       "cost": "25",
       "keywords": ["Chaos Lord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD** model only. Models in the bearer’s unit have the Stealth ability.\n\nWhile the bearer’s unit is within range of one or more objective markers you control, that unit can only be selected as the target of a ranged attack if the attacking model is within 18\"."
       },
@@ -4660,13 +4703,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "97354611-22d6-5e18-b302-3227dc6142d8",
+      "id": "7eeb242e-874e-5532-85a0-2e16e12bfeb2",
       "name": {
         "en": "Warp-fuelled Thrusters"
       },
       "cost": "20",
       "keywords": ["Chaos Lord", "Jump Pack"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD JUMP PACK** model only. At the end of your opponent’s Fight phase, if the bearer’s unit is not within Engagement Range of one or more enemy units, you can remove the bearer’s unit from the battlefield and place it into Strategic Reserves."
       },
@@ -4678,13 +4722,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "78de1275-02fd-5762-96f4-90171bca5b08",
+      "id": "a1026e90-1e4e-53d3-8914-e95dc6b8a9b9",
       "name": {
         "en": "Terrorglut Parasite"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. At the start of the Fight phase, each enemy unit within Engagement Range of the bearer must take a Battle‑shock test, subtracting 1 from the result."
       },
@@ -4696,13 +4741,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6ba4ea0a-1281-5bb9-8f63-7d8f9e49b469",
+      "id": "f87e220c-1edc-53cc-a2eb-db1588862d44",
       "name": {
         "en": "Sorrowscent Vulture"
       },
       "cost": "35",
       "keywords": ["Chaos Lord", "Jump Pack"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS LORD JUMP PACK** model only. Models in the bearer’s unit have the Scouts 6\" ability.\n\nIn the Declare Battle Formations step, the bearer can be attached to a **WARP TALONS** unit."
       },
@@ -4714,13 +4760,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "49bdc536-e91c-58c5-981e-c412359b5ec2",
+      "id": "5138ba87-4a1c-5113-abe9-67aef4ea05fd",
       "name": {
         "en": "Voice of the Tyrant"
       },
       "cost": "25",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). The bearer’s unit has both abilities from the Tyrannical Motivation Detachment rule."
       },
@@ -4732,13 +4779,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7f9cfd98-5395-55ef-bb8d-f25bcbd493f0",
+      "id": "d0e982a8-5b48-55d9-b2cc-564b055dd007",
       "name": {
         "en": "Raid Leader"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). Each time the bearer’s unit is set up after disembarking from a **TRANSPORT** that has made a Normal move this turn, the bearer’s unit is still eligible to declare a charge."
       },
@@ -4750,13 +4798,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bbe486e3-52a4-5d0a-850f-1c4317d8b61b",
+      "id": "75980f5f-1900-5c3b-bfd0-97ebaeff2622",
       "name": {
         "en": "Dread Reputation"
       },
       "cost": "25",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). Each time the bearer’s unit is set up on the battlefield, each enemy unit within 6\" of the bearer’s unit (or within 12\" if the bearer’s unit was set up using the Deep Strike ability) takes a Battle‑shock test."
       },
@@ -4768,13 +4817,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d1bf6265-d037-5264-b2f9-fc5784134b96",
+      "id": "dbd3df0d-680e-5fe1-893c-3d42acece5a0",
       "name": {
         "en": "Eager for Bloodshed"
       },
       "cost": "30",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**Heretic Astartes** model only. The bearer has the Infiltrators ability."
       },
@@ -4786,13 +4836,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e3f9c080-afc8-5504-8f7c-424af34a3796",
+      "id": "17425590-a421-5173-bbf4-0a647dccba6d",
       "name": {
         "en": "Weaponised Hatred"
       },
       "cost": "35",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. Once per battle round, after your Vendetta target is destroyed, if the bearer is on the battlefield, you can select one enemy unit visible to the bearer. That enemy unit becomes your Vendetta target until you select a new one."
       },
@@ -4804,13 +4855,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b4911a44-3f69-5255-b0b2-3f3fd396ec01",
+      "id": "f65fa385-53fd-502d-b70d-da8a7705b7ad",
       "name": {
         "en": "Eyes of the Hunter"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. Ranged weapons equipped by models in the bearer’s unit have the **[IGNORES COVER]** ability."
       },
@@ -4822,13 +4874,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2b99a632-013f-5400-892c-5e55f9816e98",
+      "id": "988ec801-cb47-500e-9667-e29d763f7e34",
       "name": {
         "en": "Fratricidal Trophies"
       },
       "cost": "5",
       "keywords": ["Terminator", "Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES TERMINATOR** model only. In a turn in which the bearer’s unit chose to Default to Doctrine, until the end of the turn, each time a model in this unit makes an attack, you can re‑roll the Hit roll."
       },
@@ -4840,13 +4893,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "508847fd-9c94-50b6-a96d-8dd4a989a495",
+      "id": "036c63d2-5308-58b2-95e3-9f530d3a29dd",
       "name": {
         "en": "Empyric Symbiote"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only. Add 1 to Advance and Charge rolls made for the bearer’s unit."
       },
@@ -4858,13 +4912,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bf52308a-0ce1-5665-8304-04c99d15986d",
+      "id": "6dbfe4ba-6366-5135-9f19-9fc9cdd2c48d",
       "name": {
         "en": "Infernal Fulgurite"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). Once per battle, you can target the bearer’s unit with the Rapid Ingress Stratagem for 0CP, and can do so even if you have already targeted a different unit with that Stratagem this phase."
       },
@@ -4876,13 +4931,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1e07cd60-4649-578e-853e-81f0353a556c",
+      "id": "8fea0c4f-0292-55ed-8c1f-0a4e260604ef",
       "name": {
         "en": "Eye of the Warp"
       },
       "cost": "15",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model with the Deep Strike ability only. Each time the bearer’s unit is set up on the battlefield, until the end of the turn, you can re-roll Charge rolls made for that unit."
       },
@@ -4894,13 +4950,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "71375299-b4a1-56b1-8460-52a9bada75a6",
+      "id": "5a5a8f65-7a53-5783-b489-49b2f2f70a24",
       "name": {
         "en": "Akshur’s Binding Runes"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model with the Deep Strike ability only. The bearer’s unit can be set up using the Deep Strike ability in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules."
       },
@@ -4912,13 +4969,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "53c686cb-5b47-5b85-87bf-2e982a98f66f",
+      "id": "9b4fdf5e-eac4-5335-b2cb-471045943ac1",
       "name": {
         "en": "Tzagulla"
       },
       "cost": "25",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model with the Deep Strike ability only. Improve the Attacks, Strength and Armour Penetration characteristics of the bearer’s weapons by 1. In addition, each time the bearer’s unit is set up on the battlefield from Reserves, until the end of the turn, improve the Damage characteristic of the bearer’s weapons by 1."
       },
@@ -4930,13 +4988,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e7f421c0-db28-50c1-8aa4-529735465f46",
+      "id": "c5b7258a-2b11-5a88-8771-d649c11fc0e3",
       "name": {
         "en": "Wyredjinn"
       },
       "cost": "25",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). At the start of your Command phase, if the bearer is on the battlefield, roll one D6, adding 1 to the result if the bearer is within range of an objective marker you control: on a 4+, you gain 1CP."
       },
@@ -4948,13 +5007,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f0e4226b-4960-59a5-a765-70b29516bc05",
+      "id": "9eebefd5-1b95-59be-a795-647704545261",
       "name": {
         "en": "Cybinfernal Font"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). Models in the bearer’s unit have the **SOUL FORGE** keyword."
       },
@@ -4966,13 +5026,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c1b217d4-42d3-5ea3-bd8b-9d5ffeb27f46",
+      "id": "eb537155-200f-5aa8-9ab7-e824e39ab102",
       "name": {
         "en": "Mark of the Soul Forges"
       },
       "cost": "20",
       "keywords": ["Heretic Astartes"],
       "excludes": ["Damned"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HERETIC ASTARTES** model only (excluding **DAMNED** models). Each time the bearer makes an attack, an unmodified Hit roll of 5+ scores a Critical Hit."
       },
@@ -4984,13 +5045,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "471d2447-105c-5dfb-badf-646c5ab31f32",
+      "id": "62d5b6b8-416f-5f40-8eef-56b50d3b4430",
       "name": {
         "en": "Crown of Worms"
       },
       "cost": "15",
       "keywords": ["Warpsmith"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WARPSMITH** model only. Add 3” to the range of the bearer’s Warpsmith, Master of Mechanisms and Enrage Machine Spirits abilities"
       },
@@ -5241,7 +5303,91 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHAOS TERMINATOR SQUAD** ■ **CHOSEN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "0aebcd54-01be-5b23-8581-92df7041b89e",
@@ -6438,7 +6584,173 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHOSEN** ■ **LEGIONARIES** ■ **NEMESIS CLAW** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "ae26d5b5-ffd2-5755-9f7c-6ea3c45d4be7",
@@ -6735,7 +7047,50 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHAOS TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "1253be12-29b6-594f-9e4f-6881f15923d5",
@@ -7021,7 +7376,50 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RAPTORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "3773dc53-7315-5caf-9abd-01d88825732c",
@@ -9254,7 +9652,91 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACCURSED CULTISTS** ■ **CULTIST MOB** ■ **CULTIST MOB WITH FIREARMS** ■ **NEGAVOLT CULTISTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "9874542a-5bc4-527a-839a-e6e611c05bd8",
@@ -9890,7 +10372,255 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACCURSED CULTISTS** ■ **CHOSEN** ■ **CULTIST MOB** ■ **CULTIST MOB WITH FIREARMS** ■ **LEGIONARIES** ■ **NEGAVOLT CULTISTS** ■ **NEMESIS CLAW** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "5d2476fb-2e9f-5491-b9d2-e32a25fdc3ab",
@@ -10216,7 +10946,91 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACCURSED CULTISTS** ■ **CULTIST MOB** ■ **CULTIST MOB WITH FIREARMS** ■ **NEGAVOLT CULTISTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "fa9a5ed6-8820-5755-9090-c577692e8e2e",
@@ -10894,7 +11708,214 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACCURSED CULTISTS** ■ **CHOSEN** ■ **CULTIST MOB** ■ **CULTIST MOB WITH FIREARMS** ■ **LEGIONARIES** ■ **NEGAVOLT CULTISTS** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Accursed Cultists",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Cultist Mob",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "f4a92fc2-8727-56b7-b3cd-473f9d962f90",
@@ -11645,7 +12666,50 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RAPTORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Raptors",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "8ac4b6f6-8adb-5f06-b9f5-51e4c1e4ed0d",
@@ -13342,7 +14406,214 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHAOS TERMINATOR SQUAD** ■ **CHOSEN** ■ **LEGIONARIES** ■ **MASTERS OF THE MAELSTROM** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Masters of the Maelstrom",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Masters of the Maelstrom",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Masters of the Maelstrom",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Masters of the Maelstrom",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Masters of the Maelstrom",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Masters of the Maelstrom",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "c3574459-2662-52cd-92f5-6f71cf90aadb",
@@ -13858,7 +15129,132 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHAOS TERMINATOR SQUAD** ■ **MUTILATORS** ■ **OBLITERATORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Mutilators",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Mutilators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Mutilators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Mutilators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Mutilators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Mutilators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Obliterators",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Obliterators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Obliterators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Obliterators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Obliterators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Obliterators",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "25074d9b-39cf-598a-bd2a-c018e975b3f5",
@@ -14998,6 +16394,172 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "support",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "support",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "support",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "support",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "support",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "support",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
       ]
     },
     {
@@ -15209,7 +16771,214 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHOSEN** ■ **LEGIONARIES** ■ **NEMESIS CLAW** ■ **POSSESSED** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Possessed",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "2edfe7dc-bc4d-5743-8b3b-270e10362b20",
@@ -15608,6 +17377,131 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "support",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "support",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "support",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
         }
       ]
     },
@@ -18084,7 +19978,173 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHOSEN** ■ **LEGIONARIES** ■ **NEMESIS CLAW** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "7ae1d3cd-10ba-53c7-85bb-e6b388b02db6",
@@ -18290,7 +20350,173 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHOSEN** ■ **LEGIONARIES** ■ **NEMESIS CLAW** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "923d6baf-c292-5797-a90d-283d17fe9786",
@@ -18563,7 +20789,50 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHAOS TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chaos Terminator Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "56c7b2e3-0c94-5072-a260-5aa929ff98aa",
@@ -18784,7 +21053,50 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **TRAITOR GUARDSMEN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Traitor Guardsmen Squad",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Traitor Guardsmen Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Traitor Guardsmen Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Traitor Guardsmen Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Traitor Guardsmen Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Traitor Guardsmen Squad",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "6bff0798-d546-575d-beb2-75d752372f8f",
@@ -19949,7 +22261,214 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHOSEN** ■ **HAVOCS** ■ **LEGIONARIES** ■ **NEMESIS CLAW** ■ **RED CORSAIRS RAIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Chosen",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Havocs",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Havocs",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Havocs",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Havocs",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Havocs",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Havocs",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Nemesis Claw",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Red Corsairs Raiders",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/chaosdaemons.json
+++ b/11th/gdc/chaosdaemons.json
@@ -7,7 +7,7 @@
     "header": "#393940"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:51.334Z",
+  "updated": "2026-07-28T17:03:04.613Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2239,7 +2239,7 @@
   ],
   "enhancements": [
     {
-      "id": "40a7e882-cd23-5096-a306-5a3501e8c879",
+      "id": "f6ab4cb2-788b-52cf-ad38-e5d8bb8e617e",
       "name": {
         "en": "Apocalyptic Steeds (Upgrade)",
         "de": "Reiter der Apokalypse (Aufwertung)",
@@ -2253,6 +2253,7 @@
       "cost": "10",
       "keywords": ["Mounted", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Legiones Daemonica Mounted</k> unit only. This unit has +1\" <b>M</b>.",
         "de": "Nur für eine <k>berittene Legiones</k>-<k>Daemonica</k>-Einheit. Diese Einheit hat +1\" <b>B</b>.",
@@ -2271,7 +2272,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4f288e86-916b-535f-81b4-45666402f8fa",
+      "id": "91b877be-a595-557b-9c79-6fa395642b60",
       "name": {
         "en": "Soul-shattering Charge (Upgrade)",
         "de": "Seelenzerfetzender Angriff (Aufwertung)",
@@ -2285,6 +2286,7 @@
       "cost": "10",
       "keywords": ["Mounted", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Legiones Daemonica Mounted</k> unit only. When this unit is <b>selected to fight</b>, if this unit made a <b>charge move</b> this turn, you can use this ability. If you do, when determining which models in this unit can fight, friendly models that are within 3\" of enemy units <b>engaged</b> with this unit can target those enemy units.",
         "de": "Nur für eine <k>berittene Legiones</k>-<k>Daemonica</k>-Einheit. Wenn diese Einheit <b>zum Kämpfen gewählt wird</b> und in diesem Zug eine <b>Angriffs­bewegung</b> ausgeführt hat, kannst du diese Fähigkeit einsetzen. Wenn du dies tust, können, wenn du bestimmst, welche Modelle dieser Einheit kämpfen können, befreundete Modelle innerhalb von 3\" um feindliche Einheiten <b>im Nahkampf</b> mit dieser Einheit jene Einheiten als Ziel wählen.",
@@ -2303,7 +2305,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9fd68435-f828-5721-ac93-0917fd78ebd3",
+      "id": "d85ae8ac-25f1-5ca0-898a-ad975e860e03",
       "name": {
         "en": "Soul-hungry Slaughterers (Upgrade)",
         "de": "Seelenhungrige Schlächter (Aufwertung)",
@@ -2317,6 +2319,7 @@
       "cost": "10",
       "keywords": ["Battleline", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Legiones Daemonica Battleline</k> unit only. When you target this unit with the <b>Heroic Intervention/Fire Overwatch stratagem</b>, that use is ‑1 CP.",
         "de": "Nur für eine <k>Legiones</k>-<k>Daemonica</k>-<k>Linientruppen</k>-Einheit. Wenn du die <b>Gefechtsoption Heroische Intervention/Abwehrfeuer geben</b> mit dieser Einheit als Ziel einsetzt, kostet jener Einsatz ‑1 BP.",
@@ -2335,7 +2338,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cc6dd30a-4323-5831-802e-c74c445f74aa",
+      "id": "9c6d7d33-f2c8-59a7-959b-4f07fe19e702",
       "name": {
         "en": "Swollen with Power (Upgrade)",
         "de": "Von Macht durchdrungen (Aufwertung)",
@@ -2349,6 +2352,7 @@
       "cost": "10",
       "keywords": ["Character", "Legiones Daemonica"],
       "excludes": ["Monster"],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Legiones Daemonica Character</k> model only (excluding <k>Monster</k> units). This model has +2 <b>W</b>.",
         "de": "Nur für ein <k>Legiones</k>-<k>Daemonica</k>-<k>Charaktermodell</k> (ausgenommen <k>Monster</k>-Einheiten). Dieses Model hat +2 <b>LP</b>.",
@@ -2367,7 +2371,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "32d0c25a-1420-5c97-b2fd-8fe605fead79",
+      "id": "373ad0d1-df0c-5c95-8968-d334c1cd71dc",
       "name": {
         "en": "Bane-forged Weapons (Upgrade)",
         "de": "Fluchgeschmiedete Waffen (Aufwertung)",
@@ -2381,6 +2385,7 @@
       "cost": "15",
       "keywords": ["Battleline", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Legiones Daemonica Battleline</k> unit only. This unit’s attacks have +1 <b>S</b>.",
         "de": "Nur für eine <k>Legiones</k>-<k>Daemonica</k>-<k>Linientruppen</k>-Einheit. Attacken dieser Einheit haben +1 <b>S</b>.",
@@ -2399,13 +2404,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8750a7f6-165a-5095-bb9f-be5437634183",
+      "id": "9661a91f-85a1-5d75-9ffc-f201f4e80bae",
       "name": {
         "en": "A’rgath, The King of Blades"
       },
       "cost": "20",
       "keywords": ["Khorne", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KHORNE LEGIONES DAEMONICA** model only. Add 1 to the Attacks and Strength characteristics of the bearer’s melee weapons. While the bearer is within your army’s Shadow of Chaos, add 2 to the Attacks and Strength characteristics of the bearer’s melee weapons instead."
       },
@@ -2417,13 +2423,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bf82f617-8628-5b38-92c0-fc5e92671107",
+      "id": "0208fdcb-1bf5-5bfa-bd53-06825968f5ed",
       "name": {
         "en": "The Everstave"
       },
       "cost": "25",
       "keywords": ["Tzeentch", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TZEENTCH LEGIONES DAEMONICA** model only. Add 1 to the Strength characteristic of the bearer’s ranged weapons and increase the Range characteristic of such weapons by 3\". While the bearer is within your army’s Shadow of Chaos, add 2 to the Strength characteristic of the bearer’s ranged weapons and increase the Range characteristic of such weapons by 6\" instead."
       },
@@ -2435,13 +2442,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4375f026-81bd-5dd3-a422-d7f8f6e4fca3",
+      "id": "1285df85-0e1c-506c-8318-3a9ff9fb2a6d",
       "name": {
         "en": "The Endless Gift"
       },
       "cost": "30",
       "keywords": ["Nurgle", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NURGLE LEGIONES DAEMONICA** model only. The bearer has the Feel No Pain 5+ ability."
       },
@@ -2453,13 +2461,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6243d6a6-51ff-51d6-b74c-139ff7906fa7",
+      "id": "9daf1fda-c2be-56f7-985d-4dcd9996bd08",
       "name": {
         "en": "Soulstealer"
       },
       "cost": "15",
       "keywords": ["Slaanesh", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SLAANESH LEGIONES DAEMONICA** model only. Each time the bearer destroys an enemy model with a melee attack, roll one D6, adding 1 to the result if the bearer is within your army’s Shadow of Chaos. On a 4+, the bearer regains 1 lost wound."
       },
@@ -2471,13 +2480,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0d42e7a5-7de9-505a-baa2-fe6dcdc3e8cc",
+      "id": "3d1f5f1c-e4ce-5cf4-869d-b3da06feaecf",
       "name": {
         "en": "Slaughterthirst (Aura)"
       },
       "cost": "25",
       "keywords": ["Khorne", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA KHORNE** model only. While a friendly **LEGIONES DAEMONICA KHORNE** unit (excluding **MONSTERS**) is within 6\" of the bearer, weapons equipped by models in that unit have the **[LANCE]** ability."
       },
@@ -2489,13 +2499,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b79029ee-75da-57d4-bce0-76d3b68fa009",
+      "id": "1524139b-6146-5794-800b-a0dfc958d172",
       "name": {
         "en": "Fury’s Cage"
       },
       "cost": "20",
       "keywords": ["Monster", "Khorne", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA KHORNE MONSTER** model only. Each time the bearer is selected to fight, it can use this Enhancement. If it does, the bearer suffers D3+1 mortal wounds, and until the end of the phase, each time it makes an attack, you can re‑roll the Hit roll and you can re‑roll the Wound roll."
       },
@@ -2507,13 +2518,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1babd75c-3d82-50df-843a-5669294026ba",
+      "id": "d7197083-37be-5dbc-860f-1dfa9bc3f03f",
       "name": {
         "en": "Brazenmaw"
       },
       "cost": "15",
       "keywords": ["Khorne", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA KHORNE** model only. Add 2 to Charge rolls made for the bearer’s unit."
       },
@@ -2525,13 +2537,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8687ee16-9eff-5113-868c-21bf612fedb7",
+      "id": "5bd18797-1e1c-5e38-ae85-18e558d60fd0",
       "name": {
         "en": "Gateway Unto Damnation"
       },
       "cost": "10",
       "keywords": ["Monster", "Khorne", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA KHORNE MONSTER** model only. The bearer’s Deadly Demise ability inflicts mortal wounds on a D6 roll of 2+ instead of on a 6. In addition, if the bearer has destroyed one or more enemy units this battle, the bearer has the Deadly Demise D3+3 ability, instead of any other Deadly Demise ability on its datasheet."
       },
@@ -2543,13 +2556,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "59b88a1f-3db6-5909-b042-14b4b69797ce",
+      "id": "46166bc9-6670-5b01-8acc-52b61d151ddc",
       "name": {
         "en": "Inescapable Eye"
       },
       "cost": "15",
       "keywords": ["Tzeentch", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA TZEENTCH** model only. In your Command phase, if the bearer is on the battlefield, if your opponent has one or more Flux tokens, you gain one additional Flux token."
       },
@@ -2561,13 +2575,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "50f04fb1-b372-5b2b-851f-f5cd1102436b",
+      "id": "51e7c87d-9518-5c15-8bb6-a5810c3afe9a",
       "name": {
         "en": "Infernal Puppeteer"
       },
       "cost": "20",
       "keywords": ["Tzeentch", "Monster", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA TZEENTCH MONSTER** model only**.** In your Shooting phase, when this unit is **selected to shoot**, while an enemy unit is visible to a friendly **LEGIONES DAEMONICA TZEENTCH** unit, that enemy unit has +9\" **detection range** until this unit has shot."
       },
@@ -2579,13 +2594,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4cc1fb53-6573-501f-a1a1-0f8baa2dbe87",
+      "id": "dfb8ed4d-b198-5e52-aa05-c5c70eb2b34d",
       "name": {
         "en": "Neverblade"
       },
       "cost": "25",
       "keywords": ["Tzeentch", "Monster", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA TZEENTCH MONSTER** model only. Improve the Strength characteristic of melee weapons equipped by the bearer by 2, improve the Attacks and Armour Penetration characteristics of melee weapons equipped by the bearer by 1, and each time the bearer makes a melee attack, add 1 to the Hit roll."
       },
@@ -2597,13 +2613,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c996748b-751d-5e77-9959-f75ab5d1c676",
+      "id": "b601f73d-08a8-5384-84bc-43c605d7d927",
       "name": {
         "en": "Improbable Shield (Aura)"
       },
       "cost": "30",
       "keywords": ["Tzeentch", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA TZEENTCH** model only. While a friendly **LEGIONES DAEMONICA TZEENTCH** unit is within 6\" of the bearer, models in that unit have the Feel No Pain 4+ ability against Psychic Attacks and mortal wounds."
       },
@@ -2615,13 +2632,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6c2b4f55-8f83-5461-a5a4-7b98907ee2e0",
+      "id": "40987346-e7ef-599f-a34d-71d16c2e816f",
       "name": {
         "en": "Cankerblight (Aura)"
       },
       "cost": "15",
       "keywords": ["Nurgle", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA NURGLE** model only. Each time an enemy unit (excluding **MONSTERS** and **VEHICLES**) that is within 6\" of the bearer fails a Battle‑shock test, the bearer can use this Enhancement. If it does, one model in that unit is destroyed (chosen by its controlling player). Each time the bearer uses this Enhancement, no mortal wounds are inflicted by your army’s Daemonic Terror rule."
       },
@@ -2633,13 +2651,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3b217ef5-3ca1-50e5-ad5a-fed20ebacfe2",
+      "id": "2f0fce56-5bb6-5e15-9f05-430b1634f84b",
       "name": {
         "en": "Maggot Maws"
       },
       "cost": "15",
       "keywords": ["Nurgle", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA NURGLE** model only. In your Shooting phase, select one enemy unit within 6\" of the bearer; that enemy unit must take a Battle‑shock test. Then roll one D6: on a 3+, that enemy unit suffers D3 mortal wounds. Each time the bearer uses this Enhancement, no mortal wounds are inflicted by your army’s Daemonic Terror rule."
       },
@@ -2651,13 +2670,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e81757e4-0e57-5e9f-93ed-1832ce9da168",
+      "id": "38826210-db5e-512d-98ac-000a2eae46fb",
       "name": {
         "en": "Droning Shroud (Aura)"
       },
       "cost": "35",
       "keywords": ["Monster", "Nurgle", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA NURGLE MONSTER** model only. While a friendly **LEGIONES DAEMONICA NURGLE** unit is within 6\" of the bearer, that unit can only be targeted by a ranged attack if the attacking model is within 18\"."
       },
@@ -2669,13 +2689,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cb094152-86b4-5099-b7c5-61061352d6fe",
+      "id": "44410e01-d5b9-5d8c-9337-60bb0979f476",
       "name": {
         "en": "Font of Spores (Aura)"
       },
       "cost": "20",
       "keywords": ["Monster", "Nurgle", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA NURGLE MONSTER** model only. While a friendly **LEGIONES DAEMONICA NURGLE** unit is within 6\" of the bearer, improve the Armour Penetration characteristic of weapons equipped by models in that unit by 1."
       },
@@ -2687,13 +2708,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "07b82ffc-d495-5f2e-bc7b-84d8ca6405a5",
+      "id": "579ee5b6-5c45-5a33-9adf-b840bd8bfaba",
       "name": {
         "en": "False Majesty (Aura)"
       },
       "cost": "30",
       "keywords": ["Slaanesh", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA SLAANESH** model only. While a friendly **LEGIONES DAEMONICA SLAANESH** unit (excluding **MONSTERS**) is within 6\" of the bearer, each time a model in that unit makes a melee attack, add 1 to the Wound roll."
       },
@@ -2705,13 +2727,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "14f055be-595c-5f46-a75a-e437afa2ca0b",
+      "id": "064c75aa-9021-5a7f-b946-23622596aeb8",
       "name": {
         "en": "Dreaming Crown (Aura)"
       },
       "cost": "30",
       "keywords": ["Slaanesh", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA SLAANESH** model only. While a friendly **LEGIONES DAEMONICA SLAANESH** unit (excluding **MONSTERS**) is within 6\" of the bearer, each time a model in that unit makes a melee attack, add 1 to the Hit roll."
       },
@@ -2723,13 +2746,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "464cd93f-db53-5185-a391-519deae359b8",
+      "id": "e572c4ea-8eb6-5613-8ea9-4fa428cb3611",
       "name": {
         "en": "Avatar of Perfection"
       },
       "cost": "15",
       "keywords": ["Monster", "Slaanesh", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA SLAANESH MONSTER** model only. At the start of each phase, if there are no other friendly units within 6\" of the bearer, you can: re‑roll Advance rolls made for the bearer; re‑roll Charge rolls made for the bearer; ignore any or all modifiers to its Move characteristic and to any Advance and/or Charge rolls made for the bearer."
       },
@@ -2741,13 +2765,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "41fb10e1-6546-589c-aede-f7f950059264",
+      "id": "3068f2c3-c6f8-513d-a7ee-1350eba37775",
       "name": {
         "en": "Soul Glutton"
       },
       "cost": "10",
       "keywords": ["Monster", "Slaanesh", "Legiones Daemonica"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEGIONES DAEMONICA SLAANESH MONSTER** model only. At the end of the Fight phase, if one or more enemy models were destroyed this phase as a result of one or more of the bearer’s attacks, it can use this Enhancement. If it does, it regains up to D3 lost wounds."
       },
@@ -2759,13 +2784,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0fe07932-ffa8-5bca-934c-152e4e208165",
+      "id": "6a314cfa-e0e3-53e9-ae56-146b7a08e233",
       "name": {
         "en": "Leaping Shadows"
       },
       "cost": "25",
       "keywords": ["Shadow Legion"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHADOW LEGION** model only. Models in the bearer’s unit have the Scouts 9” ability."
       },
@@ -2777,13 +2803,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5dfd48df-52e4-5aac-ac55-28fb19924135",
+      "id": "1756745e-20d3-5aab-ade2-440d7efb1c33",
       "name": {
         "en": "Mantle of Gloom (Aura)"
       },
       "cost": "20",
       "keywords": ["Shadow Legion"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHADOW LEGION** model only. While an enemy unit is within Engagement Range of the bearer’s unit, subtract 1 from the Objective Control characteristic of models in that enemy unit."
       },
@@ -2795,13 +2822,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "39ea4cd6-99fd-5ec1-9e26-27ac3c23609a",
+      "id": "1c120b1d-c0cd-512e-9396-3580e65fd685",
       "name": {
         "en": "Fade to Darkness"
       },
       "cost": "30",
       "keywords": ["Shadow Legion"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHADOW LEGION** model only. At the end of the Fight phase, if the bearer’s unit destroyed one or more enemy units this phase and is not within Engagement Range of one or more enemy units, you can remove the bearer’s unit from the battlefield and place it into Strategic Reserves."
       },
@@ -2813,13 +2841,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c88f9b91-f124-5d12-9a82-093f78e09944",
+      "id": "1fd12147-ca71-5008-8fef-1cc6b729595b",
       "name": {
         "en": "Malice Made Manifest"
       },
       "cost": "25",
       "keywords": ["Shadow Legion"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SHADOW LEGION** model only. At the start of the Fight phase, select one enemy unit within Engagement Range of the bearer’s unit and roll one D6: on a 2‐5, that enemy unit suffers D3 mortal wounds; on a 6, that enemy unit suffers 3 mortal wounds."
       },
@@ -3832,7 +3861,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOODLETTERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Bloodletters",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "7d466720-589e-54d0-abb0-1bd094a28515",
@@ -4757,7 +4793,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLUE HORRORS** ■ **PINK HORRORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blue Horrors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Pink Horrors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d7bf34ae-8c48-5d7c-8004-ddc81179e195",
@@ -4941,7 +4989,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DAEMONETTES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Daemonettes",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b5e64307-09e2-5253-b48e-20e9898959a6",
@@ -5707,7 +5762,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUEBEARERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plaguebearers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "06ac659a-793f-5875-9b7f-7bd9d029e1e4",
@@ -5912,7 +5974,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **FLAMERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Flamers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2993a6d6-e151-5d09-96b5-2f1f8b90c5d8",
@@ -6134,7 +6203,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SCREAMERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Screamers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "8b1e01e1-3fc5-514d-bdb6-96e69847b2e2",
@@ -6978,7 +7054,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLUE HORRORS** ■ **PINK HORRORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blue Horrors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Pink Horrors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6b7fccf5-1fe5-51e5-a673-3196ce719cb2",
@@ -7666,7 +7754,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BEASTS OF NURGLE** ■ **PLAGUE TOADS** ■ **POX RIDERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Beasts of Nurgle",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "73ce7eb3-eba7-5b49-b445-2997882ce3b0",
@@ -7862,7 +7957,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DAEMONETTES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Daemonettes",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b6121698-cc24-5d82-9131-60726b8b49e7",
@@ -8273,7 +8375,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **FLESH HOUNDS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Flesh Hounds",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "c2f38971-857b-5b87-87b0-74c1a58deca0",
@@ -9953,7 +10062,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUEBEARERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plaguebearers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "68eadbdd-08e9-58de-8fc7-984d9f0a5fff",
@@ -11648,7 +11764,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOODCRUSHERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Bloodcrushers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b4d5c7ca-e189-5eb3-a9b4-f7d875684a64",
@@ -11806,7 +11929,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOODLETTERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Bloodletters",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b37ad4ff-c5b5-5030-85a9-6c37637459b5",
@@ -11962,7 +12092,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUEBEARERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plaguebearers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "03ca041c-bfbd-5b28-a804-2f69d5238dcd",
@@ -12466,7 +12603,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUEBEARERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plaguebearers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "32c1575b-797d-5e7f-bb1f-3148975512de",
@@ -12711,7 +12855,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DAEMONETTES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Daemonettes",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2883a92d-8f1a-5847-8cb5-e7bc961fc5e3",
@@ -13452,7 +13603,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **HELLFLAYERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Hellflayers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6ad89be2-0453-522d-92a7-03a3eac93456",
@@ -13616,7 +13774,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DAEMONETTES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Daemonettes",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/chaosknights.json
+++ b/11th/gdc/chaosknights.json
@@ -7,7 +7,7 @@
     "header": "#49584c"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:51.452Z",
+  "updated": "2026-07-28T17:03:04.827Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -1932,7 +1932,7 @@
   ],
   "enhancements": [
     {
-      "id": "cf2e3cb2-a51f-5127-8e93-6fd0b135d579",
+      "id": "5098cb85-b699-535b-ba07-a7a5982556da",
       "name": {
         "en": "Snarling Rivalry (Upgrade)",
         "de": "Grollende Rivalitäten (Aufwertung)",
@@ -1946,6 +1946,7 @@
       "cost": "10",
       "keywords": ["Executioner"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Executioner</k> unit only. This unit’s ranged attacks have <k>[Ignores Cover]</k>.",
         "de": "Nur für eine <k>Bluthund</k>-Einheit. Die Fernkampfattacken dieser Einheit haben <k>[Deckung ignorieren]</k>.",
@@ -1964,7 +1965,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "989757bf-39fd-5a36-bc0e-a9e298ae750e",
+      "id": "e4841287-8730-5298-a098-01c84135f17e",
       "name": {
         "en": "Soul-spoor Auspicator (Upgrade)",
         "de": "Seelenfährten-Auspex (Aufwertung)",
@@ -1978,6 +1979,7 @@
       "cost": "15",
       "keywords": ["Huntsman"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Huntsman</k> unit only. This unit’s ranged attacks have +6\" <b>R</b>.",
         "de": "Nur für eine <k>Jagdhund</k>-Einheit. Die Fernkampfattacken dieser Einheit haben +6\" <b>R</b>.",
@@ -1996,7 +1998,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5a995ba1-094f-5e4b-9b7a-b0d576f85a7e",
+      "id": "54421a01-a821-5376-ac75-57ebc2bc68c7",
       "name": {
         "en": "Pterrorshade Rookery",
         "de": "Pterrorschattenhorst",
@@ -2010,6 +2012,7 @@
       "cost": "20",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Knight Tyrant</k> model only. When this unit is <b>selected to shoot</b>, select one enemy unit within 24\" of this unit. That enemy unit has +6\" <b>detection range</b> until this unit has shot.",
         "de": "Nur für ein <k>Tyrannenritter</k>-Modell. Wenn diese Einheit <b>zum Schießen gewählt wird</b>, wähle eine feindliche Einheit innerhalb von 24\" um diese Einheit. Jene feindliche Einheit hat +6\" <b>Entdeckungsreichweite</b>, bis diese Einheit geschossen hat.",
@@ -2028,7 +2031,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1f6737e3-9bfe-50f3-a161-0b47240734cd",
+      "id": "93f3df24-9613-57d8-a22e-757b13d5fe36",
       "name": {
         "en": "Hate-filled Dominion",
         "de": "Hasserfüllte Beherrschung",
@@ -2042,6 +2045,7 @@
       "cost": "20",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Knight Tyrant</k> model only. This unit can re-roll rolls to determine the <b>A</b> of a weapon.",
         "de": "Nur für ein <k>Tyrannenritter</k>-Modell. Diese Einheit kann Würfe wiederholen, um die <b>A</b> einer Waffe zu bestimmen.",
@@ -2060,7 +2064,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9ea06b83-7857-52fb-84fa-d631be77b8f5",
+      "id": "2a46b67f-5f7d-58db-9d13-d814df93f47d",
       "name": {
         "en": "Iconoclast Idol (Aura)",
         "de": "Ikonoklasten-Idol",
@@ -2074,6 +2078,7 @@
       "cost": "20",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Chaos Knights</k> model only. While a friendly <k>Damned</k> unit is within 6\" of this model, when you target that unit with the <b>Heroic Intervention stratagem</b>, that use is ‑1 <b>CP</b>.",
         "de": "Nur für ein <k>Chaosritter</k>-Modell. Solange sich eine befreundete <k>verdammte</k> Einheit innerhalb von 6\" um dieses Modell befindet, kostet dich der Einsatz der <b>Gefechtsoption Heroische Intervention</b> mit jener Einheit als Ziel für jenen Einsatz ‑1 <b>BP</b>.",
@@ -2092,7 +2097,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f71801bd-9653-5c6a-b2ff-df12a26b5d4c",
+      "id": "30f29803-374b-5031-a51e-40ddc678d8a2",
       "name": {
         "en": "Cruel Lashmaster (Aura)",
         "de": "Grausamer Gebieter (Aura)",
@@ -2106,6 +2111,7 @@
       "cost": "25",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Chaos Knights</k> model only. While a friendly <k>Damned</k> unit is within 6\" of this model, when that unit is selected to make a <b>normal/advance/fall‑back move</b> that unit has +2\" <b>M</b> until the end of the phase.",
         "de": "Nur für ein <k>Chaosritter</k>-Modell. Solange sich eine befreundete <k>verdammte</k> Einheit innerhalb von 6\" um dieses Modell befindet, hat jene Einheit, wenn sie gewählt wird, eine <b>normale/Vorrücken-/Rückzugsbewegung</b> auszuführen, +2\" <b>B</b>.",
@@ -2124,13 +2130,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7f3862f1-b330-5813-b8b2-45b42d5319b6",
+      "id": "4bcddb0e-2706-5496-80e0-cf7e2d5964df",
       "name": {
         "en": "Nightmare’s Master"
       },
       "cost": "20",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. At the start of the Fight phase, each enemy unit within Engagement Range of the bearer must take a Battle-shock test."
       },
@@ -2142,13 +2149,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "963007d9-9889-5924-b561-d12d6eeb1b1e",
+      "id": "9d3ed713-fe6d-5a29-a3ad-db108f76a874",
       "name": {
         "en": "Tyrant’s Shadow"
       },
       "cost": "25",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. At the end of your Command phase, select one objective marker the bearer is within range of and that you control. That objective marker remains under your control until your opponent’s Level of Control over that objective marker is greater than yours at the end of a phase. In addition, until you lose control of that objective marker, it has the Deathly Terror ability as if it were a **CHAOS KNIGHTS** model from your army."
       },
@@ -2160,13 +2168,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ccb1bfc1-3f62-5514-a0dc-8551cc9adfad",
+      "id": "a885bd69-471b-588b-b99f-239dff3c6b71",
       "name": {
         "en": "Malevolent Heraldry"
       },
       "cost": "30",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. Each time you roll dice to randomly select which Dread abilities are active for your army, if the bearer is on the battlefield, you can re-roll one or both results rolled."
       },
@@ -2178,13 +2187,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c80a3a6f-e9fb-5f63-9278-15e73aa9713f",
+      "id": "bee3cd67-8201-5849-ba8b-49565825a001",
       "name": {
         "en": "Veil of Medrengard"
       },
       "cost": "35",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. The bearer has a 4+ invulnerable save against ranged attacks, and a 5+ invulnerable save against melee attacks."
       },
@@ -2196,13 +2206,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2520e06b-206d-5fe9-8564-601d745689da",
+      "id": "d639b6cb-9564-5e4c-9609-7031344dbbe8",
       "name": {
         "en": "Knight Diabolus"
       },
       "cost": "25",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. Improve the Weapon Skill characteristic of the bearer’s melee weapons by 1. While the bearer is using the Diabolic Power ability, its melee weapons have the **[LANCE]** ability"
       },
@@ -2214,13 +2225,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9e776064-6bd7-5d0b-ac59-be26ead29581",
+      "id": "e71be72a-00bd-521e-9713-a6d82ebda313",
       "name": {
         "en": "Blasphemous Engine"
       },
       "cost": "35",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. Add 2 to the bearer’s Wounds characteristic. Each time the bearer’s unit makes a Malefic Surge, you can re-roll the Leadership test taken to see if it suffers any mortal wounds."
       },
@@ -2232,13 +2244,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e36d0fac-81a7-58ad-a74b-8be484ccf185",
+      "id": "df808a93-6f0d-5ff4-95cb-0c8655a36191",
       "name": {
         "en": "Fleshmetal Fusion"
       },
       "cost": "35",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. Add 1 to the bearer’s Toughness characteristic. While the bearer is using the Unnatural Fortitude ability, each time an attack with a Damage characteristic of 1 is allocated to the bearer, add 1 to any armour saving throw made against that attack."
       },
@@ -2250,13 +2263,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3bb588c8-b868-5f9d-973e-d14a57e723d2",
+      "id": "b752c854-a928-5e7a-b41b-2b661aca3f53",
       "name": {
         "en": "Bestial Aspect"
       },
       "cost": "30",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. The bearer’s ranged weapons have the **[ASSAULT]** ability. While the bearer is using the Unholy Hunger ability, it can ignore any or all modifiers to its Move characteristic and/or to Advance rolls made for its unit."
       },
@@ -2268,13 +2282,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7d3fd832-5481-55f6-bf55-acb64084853a",
+      "id": "d5370464-4321-50f0-8f9d-2be8b4e36edc",
       "name": {
         "en": "Throne Mechanicum of Skulls"
       },
       "cost": "25",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. You can re-roll Charge rolls made for the bearer’s unit. In addition, once per battle, in your Charge phase, the bearer can use this Enhancement. If it does, until the end of the phase, the bearer’s unit is eligible to declare a charge in a turn in which it Advanced."
       },
@@ -2286,13 +2301,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c8aee852-0b8a-59d6-a9c2-30c4a12e352c",
+      "id": "59fac307-6842-53db-8be9-e267b1731a37",
       "name": {
         "en": "Blade of Celerity"
       },
       "cost": "35",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. The bearer’s ranged weapons have the **[ASSAULT]** ability. In addition, once per battle, in the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, models in the bearer’s unit have the Fights First ability."
       },
@@ -2304,13 +2320,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "33eddcde-e4ac-5922-9b58-a5ee2480d794",
+      "id": "734b4c68-2eb5-506a-a67c-bab89d2c37f8",
       "name": {
         "en": "Warp-borne Stalker"
       },
       "cost": "25",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. The bearer has the Deep Strike ability. In addition, once per battle, at the end of your opponent’s turn, if the bearer is not within Engagement Range of one or more enemy units, you can remove it from the battlefield and place it into Strategic Reserves."
       },
@@ -2322,13 +2339,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9895ff12-b92d-5158-bcbe-e9153cb6819d",
+      "id": "c0c2ff80-90d6-5f5a-9afa-f5fa79ac8a34",
       "name": {
         "en": "Putrid Carapace"
       },
       "cost": "30",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. The bearer has a Save characteristic of 2+. In addition, once per battle, at the start of either player’s Command phase, the bearer can use this Enhancement. If it does, the bearer regains up to D6 lost wounds."
       },
@@ -2340,13 +2358,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5aa79521-64a5-5c01-b842-913f0d9ebad9",
+      "id": "de237341-9be8-5813-8fba-0a302ed40f90",
       "name": {
         "en": "Mirror of Fates"
       },
       "cost": "30",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. Once per turn, when your opponent targets a unit from their army within 12” of this model with a **stratagem**, you can use this ability. If you do, increase the CP cost of that use of that **stratagem** by 1CP."
       },
@@ -2358,13 +2377,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4f00b8ce-0497-5b39-a42b-52889404d50e",
+      "id": "9e42ee3a-31ec-5125-95d6-987e42e7f21c",
       "name": {
         "en": "Blessing of the Dark Master"
       },
       "cost": "20",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. The bearer has the Stealth ability. In addition, once per battle, after you make a saving throw for the bearer, you can change the Damage characteristic of that attack to 0."
       },
@@ -2376,13 +2396,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3941ef26-7036-53a0-84cf-f549ed2061ca",
+      "id": "2134c628-e8ff-53d9-bf3b-6a61d4f0fc50",
       "name": {
         "en": "Preyslayer’s Mantle"
       },
       "cost": "15",
       "keywords": ["War Dog"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WAR DOG** model only. The bearer has the Super-heavy Walker ability."
       },
@@ -2394,13 +2415,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d4c4cafe-1a75-53fc-805e-47b2153d0ada",
+      "id": "fb736fa3-3388-576b-af0d-84e154de7ee5",
       "name": {
         "en": "Final Howl (Aura)"
       },
       "cost": "20",
       "keywords": ["War Dog"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WAR DOG** model only. While a friendly **WAR DOG** model is within 6\" of the bearer, each time that model makes an attack, re-roll a Wound roll of 1."
       },
@@ -2412,13 +2434,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3cf963b0-8a2f-54f0-877c-b24b9177388e",
+      "id": "52ed06c8-a642-59b1-b657-b79e5a3a9e4e",
       "name": {
         "en": "Loping Predator"
       },
       "cost": "10",
       "keywords": ["War Dog"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WAR DOG** model only. The bearer’s ranged weapons have the **[ASSAULT]** ability."
       },
@@ -2430,13 +2453,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "787fd0ab-066d-5592-aabc-87b447c84648",
+      "id": "5e38ce54-95ed-54ca-ad5d-08933b042ce0",
       "name": {
         "en": "Panoply of the Cursed Knights"
       },
       "cost": "15",
       "keywords": ["War Dog"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WAR DOG** model only. Each time an attack targets the bearer, worsen the Armour Penetration characteristic of that attack by 1."
       },
@@ -2448,13 +2472,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c9f61082-e6de-5c35-91f4-7dab4a20aa41",
+      "id": "d4e955db-757a-5145-ae04-718c801a3f67",
       "name": {
         "en": "Hunter’s Helm"
       },
       "cost": "15",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. You can re‑roll Advance and Charge rolls made for the bearer’s unit."
       },
@@ -2466,13 +2491,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1a2c73cb-fa31-519f-9066-ba597e3fc6b5",
+      "id": "32381b91-7926-5181-824b-d687afc62363",
       "name": {
         "en": "Octagram of Conjuration"
       },
       "cost": "40",
       "keywords": ["Knight Abominant"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KNIGHT ABOMINANT** model only. The bearer has the following ability:\n\n**Octagram of Conjuration (Aura):** While a friendly **WAR DOG** model is within 9” of this model, after that **WAR DOG** model has shot, you can select one enemy unit hit by one or more of those attacks. That enemy unit must take a Battle‑shock test."
       },
@@ -2484,13 +2510,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "34b3e2db-95a6-509f-a12b-0b0394236461",
+      "id": "8fb831e8-8eef-57e9-b911-7db0b072fd41",
       "name": {
         "en": "Aspect of the Beast"
       },
       "cost": "30",
       "keywords": ["Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CHAOS KNIGHTS** model only. At the start of your Command phase, select one Dread ability to be active for the bearer until the start of your next Command phase, in addition to the Dread abilities active for your army."
       },
@@ -2502,13 +2529,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "62ecf052-0987-5b9f-9e62-b07f111acd32",
+      "id": "1e4b05cf-db1c-5c0f-857e-78ca89c6a0c7",
       "name": {
         "en": "Throne Tyrannicus"
       },
       "cost": "25",
       "keywords": ["Titanic", "Chaos Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TITANIC CHAOS KNIGHTS** model only. In your Command phase, select one other **CHAOS KNIGHTS CHARACTER** model within 9” of the bearer. If the bearer has one or more Aura abilities that affect friendly **WAR DOG** units, until the start of your next Command phase, the selected **CHAOS KNIGHTS CHARACTER** model is affected by those Aura abilities as well."
       },

--- a/11th/gdc/combatpatrol/adeptasororitas.json
+++ b/11th/gdc/combatpatrol/adeptasororitas.json
@@ -7,7 +7,7 @@
     "header": "#570c0c"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.454Z",
+  "updated": "2026-07-28T17:03:06.779Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "d4863b7c-7ea9-5b1b-9f50-b925e0840d99",
+      "id": "9df3960e-c80c-59f9-82a4-9321453065f1",
       "name": {
         "en": "Righteous Fervour",
         "de": "Rechtschaffener Eifer",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Canoness", "Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Sanctuary Guardians Canoness</k> model only. <ul><li>This model's melee attacks have +1 <b>D</b>.</li><li>This unit's melee attacks have +1 to <b>wound rolls</b>.</li></ul>",
         "de": "Nur für ein <k>Sanktuarium-Hüterinnen-Principalis</k>-Modell. <ul><li>Die Nahkampfattacken dieses Modells haben +1 <b>SW</b>.</li><li>Die Nahkampfattacken dieser Einheit haben +1 auf <b>Verwundungswürfe</b>.</li></ul>",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "29c82f63-5d72-5257-8a58-db129f95ccef",
+      "id": "b033d8cd-2b1f-5264-82f8-5b127d3ebb18",
       "name": {
         "en": "Divine Miracle",
         "de": "Göttliches Wunder",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Adepta Sororitas"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Sanctuary Guardians Battle Sisters Squad</k> unit only. (Once per battle, per unit) At the start of any phase, you can use this ability. If you do, this unit <b>heals</b> D3+2 wounds.",
         "de": "Aufwertung: Nur für eine <k>Sanktuarium-Hüterinnen-Sororitatrupp</k>-Einheit. (Einmal pro Schlacht, pro Einheit) Du kannst diese Fähigkeit zu Beginn einer beliebigen Phase einsetzen. Wenn du dies tust, wird diese Einheit um W3+2 Lebenspunkte <b>geheilt</b>.",
@@ -637,7 +639,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SANCTUARY GUARDIANS BATTLE SISTERS SQUAD** ■ **SANCTUARY GUARDIANS CELESTIAN SACRESANTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Sanctuary Guardians Battle Sisters Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sanctuary Guardians Celestian Sacresants",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "1519449c-dcf2-5354-8329-2ec6a5f09e51",

--- a/11th/gdc/combatpatrol/adeptuscustodes.json
+++ b/11th/gdc/combatpatrol/adeptuscustodes.json
@@ -7,7 +7,7 @@
     "header": "#6d5035"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.799Z",
+  "updated": "2026-07-28T17:03:07.486Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "888e031f-65db-590c-83a0-fcb0a40e8c9d",
+      "id": "41336757-f28a-580f-9910-59462eb8eb90",
       "name": {
         "en": "Shattering Charge",
         "de": "Zerstörerischer Ansturm",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Tristraen's Gilded Blades Blade Champion</k> model only. When this unit ends a <b>charge move</b>, you can select one enemy unit <b>engaged</b> with this unit. If you do, that enemy unit makes a <b>battle-shock roll</b>, with -1 to that <b>battle-shock roll</b>.",
         "de": "Nur für ein <k>Tristraens-Goldklingen-Klingenchampion</k>-Modell. Nachdem diese Einheit eine <b>Angriffsbewegung</b> beendet hat, kannst du eine feindliche Einheit <b>im Nahkampf</b> mit dieser Einheit wählen. Wenn du dies tust, führt jene feindliche Einheit einen <b>Erschütterungswurf</b> mit -1 aus.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5d08356a-69a0-5e9f-a24b-4fe75367c40c",
+      "id": "aecaba31-f7e0-5844-b1b7-02d65f66b868",
       "name": {
         "en": "Comrades in Wrath",
         "de": "Geeint in Wut",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Adeptus Custodes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Gilded Blades Allarus Custodians</k> unit only. This unit has +1 to <b>charge rolls</b>.",
         "de": "Aufwertung: Nur für eine <k>Goldklingen-Allarus-Custodes</k>-Einheit. Diese Einheit hat +1 auf <b>Angriffswürfe</b>.",

--- a/11th/gdc/combatpatrol/adeptusmechanicus.json
+++ b/11th/gdc/combatpatrol/adeptusmechanicus.json
@@ -7,7 +7,7 @@
     "header": "#9f2628"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.644Z",
+  "updated": "2026-07-28T17:03:07.162Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "bbb7db7d-6070-5945-9c0d-ab60745e714d",
+      "id": "8ee7d7cb-a39e-5f6a-9b4b-b10f7037487e",
       "name": {
         "en": "Miniaturised Autosimulacra",
         "de": "Miniaturisierte Autosimulakra",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Purge Corps Deltic-9 Tech-Priest Manipulus</k> model only. (Once per battle, per unit) At the start of any phase, you can use this ability. If you do, select one friendly <k>Purge Corps Deltic-9</k> unit. That unit <b>heals</b> D3+2 wounds.",
         "de": "Nur für ein <k>Säuberungskorps-Delta-9-Manipulus-Techpriester</k>-Modell. (Einmal pro Schlacht, pro Einheit) Du kannst diese Fähigkeit zu Beginn einer beliebigen Phase einsetzen. Wenn du dies tust, wähle eine befreundete <k>Säuberungskorps-Delta-9</k>-Einheit. Jene Einheit wird um W3+2 Lebenspunkte <b>geheilt</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bb32bfc0-eec6-5e38-ac20-153d21432950",
+      "id": "5f0a64b1-dbf4-518d-a436-5a90586d4c53",
       "name": {
         "en": "Empowered Mechanisms",
         "de": "Verbesserte Mechanismen",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Adeptus Mechanicus"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Purge Corps Serberys Sulphurhounds</k> unit only.<ul><li>This unit's ranged attacks have <k>[Anti-Infantry 4+]</k>.</li><li>This unit can re-roll rolls to determine the <b>A</b> of a weapon.</li></ul>",
         "de": "Aufwertung: Nur für eine <k>Säuberungskorps-Serberys-Schwefelhunde</k>-Einheit.<ul><li>Die Fernkampfattacken dieser Einheit haben <k>[Anti-Infanterie 4+]</k>.</li><li>Für diese Einheit können Würfe wiederholt werden, um die <b>A</b> einer Waffe zu bestimmen.</li></ul>",
@@ -642,7 +644,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PURGE CORPS SKITARII VANGUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Purge Corps Skitarii Vanguard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "97e71b60-1639-5ac9-8f49-fb15201a8e2b",

--- a/11th/gdc/combatpatrol/aeldari.json
+++ b/11th/gdc/combatpatrol/aeldari.json
@@ -7,7 +7,7 @@
     "header": "#347379"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.258Z",
+  "updated": "2026-07-28T17:03:10.770Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -20,7 +20,7 @@
   "enhancements": [],
   "datasheets": [
     {
-      "id": "0871d986-3072-5552-8e59-148acb598ef7",
+      "id": "8d112f88-bc68-55ce-9a9c-ba69df3df3d3",
       "source": "40k-11e",
       "name": {
         "en": "Kygharil's Protectors Dire Avengers",
@@ -388,7 +388,7 @@
       ]
     },
     {
-      "id": "0871d986-3072-5552-8e59-148acb598ef7",
+      "id": "80f706a4-27c9-51c6-a7a5-19f55076987c",
       "source": "40k-11e",
       "name": {
         "en": "Kygharil's Protectors Dire Avengers",

--- a/11th/gdc/combatpatrol/agents.json
+++ b/11th/gdc/combatpatrol/agents.json
@@ -7,7 +7,7 @@
     "header": "#244b6a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.011Z",
+  "updated": "2026-07-28T17:03:07.955Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "1ac2980c-2892-5907-bf70-a5b418ffa98f",
+      "id": "f0d52e46-d4c7-54a3-90b8-00d1123f5dea",
       "name": {
         "en": "Killer Reflexes",
         "de": "Mörderische Reflexe",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Agents of the Imperium"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Inquisitor's Hand Eversor Assassin</k> model only. In the Fight phase, when this model is <b>destroyed</b>, if this unit has not been <b>selected to fight</b> this phase, roll one D6: on a 2+, do not remove this model from the battlefield. When this unit has fought, or at the end of the phase (whichever comes first), this model is removed from the battlefield.",
         "de": "Nur für ein <k>Hand-des-Inquisitors-Eversor-Assassine</k>-Modell. Wenn dieses Modell in der Nahkampfphase <b>zerstört</b> wird und diese Einheit wurde in dieser Phase noch nicht <b>zum Kämpfen gewählt</b>, wirf einen W6: Bei 2+ entferne dieses Modell nicht vom Schlachtfeld. Wenn diese Einheit gekämpft hat oder am Ende der Phase (was immer zuerst eintritt) wird dieses Modell vom Schlachtfeld entfernt.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0a692555-4fc3-52e2-83e5-bd9d544e1556",
+      "id": "5479f862-31e7-5c45-8ba0-9c6388a58b20",
       "name": {
         "en": "Sanctic Slayers",
         "de": "Geweihte Schlächter",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Ministorum Priest", "Inquisitor's Hand"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Inquisitor's Hand Ministorum Priest</k> model only. (Once per turn, per unit) When a friendly <k>Inquisitor's Hand</k> unit is <b>selected to attack</b> you can use this ability. If you do, that unit's attacks that target a unit with a <b>T</b> greater than or equal to your attack's <b>S</b> have +1 to <b>wound rolls</b>.",
         "de": "Nur für ein <k>Hand-des-Inquisitors-Priester-des-Ministorum</k>-Modell. (Einmal pro Zug, pro Einheit) Wenn eine befreundete <k>Hand-des-Inquisitors</k>-Einheit <b>zum Attackieren gewählt wird</b>, kannst du diese Fähigkeit einsetzen. Wenn du dies tust, haben Attacken dieser Einheit gegen eine Einheit, deren <b>W</b> gleich oder höher ist als die <b>S</b> deiner Attacken, +1 auf <b>Verwundungswürfe</b>.",
@@ -1209,7 +1211,7 @@
       ]
     },
     {
-      "id": "0c833b99-bcd7-54c8-a23a-1c273f3546c8",
+      "id": "984983d4-0a10-5de5-90a3-b92413f01f9d",
       "source": "40k-11e",
       "name": {
         "en": "Inquisitor's Hand Vigilant Squad",
@@ -1908,7 +1910,7 @@
       ]
     },
     {
-      "id": "0c833b99-bcd7-54c8-a23a-1c273f3546c8",
+      "id": "1236af8a-6119-5032-9741-441f6d13653e",
       "source": "40k-11e",
       "name": {
         "en": "Inquisitor's Hand Vigilant Squad",
@@ -2887,7 +2889,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **INQUISITOR'S HAND INQUISITORIAL AGENTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Inquisitor's Hand Inquisitorial Agents",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/astramilitarum.json
+++ b/11th/gdc/combatpatrol/astramilitarum.json
@@ -7,7 +7,7 @@
     "header": "#324935"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:51.919Z",
+  "updated": "2026-07-28T17:03:05.724Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "31a413fc-9e11-53c6-96d3-535c623dc008",
+      "id": "9e882c5f-f8b7-5514-99d6-5cde18109e65",
       "name": {
         "en": "Call Up the Reserves",
         "de": "Reserven ins Feld beordern",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Drayden's Lance", "Officer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Drayden's Lance Officer</k> model only. (Once per battle, per unit) At the start of any phase, you can use this ability. If you do, select one friendly <k>Drayden's Lance</k> unit. That unit <b>heals</b> D3+2 wounds.",
         "de": "Nur für ein <k>Draydens-Lanze-Offizier</k>-Modell. (Einmal pro Schlacht, pro Einheit) Du kannst diese Fähigkeit zu Beginn einer beliebigen Phase einsetzen. Wenn du dies tust, wähle eine befreundete <k>Draydens-Lanze</k>-Einheit. Jene Einheit wird um W3+2 Lebenspunkte <b>geheilt</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7a993d31-c229-5847-a790-4d3c6e641046",
+      "id": "ebc91bf4-7519-561e-950d-5b2a6e5ea59e",
       "name": {
         "en": "Drayden’s Drill",
         "de": "Draydens Drill",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Astra Militarum"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Drayden's Lance Kasrkin</k> unit only. This unit’s <b>snap shooting</b> attacks hit on unmodified <b>hit rolls</b> of 4+.",
         "de": "Aufwertung: Nur für eine <k>Draydens-Lanze-Kasrkin</k>-Einheit. <b>Eiliger-Beschuss</b>-Attacken dieser Einheit treffen bei unmodifizierten <b>Trefferwürfen</b> von 4+.",
@@ -339,7 +341,7 @@
   ],
   "datasheets": [
     {
-      "id": "0d8b8536-2bb4-5863-8ba8-e8f688f3a57a",
+      "id": "73951db7-a0c2-5cc0-987b-d6b424d83f31",
       "source": "40k-11e",
       "name": {
         "en": "Drayden's Lance Attilan Rough Riders",
@@ -911,7 +913,7 @@
       ]
     },
     {
-      "id": "0d8b8536-2bb4-5863-8ba8-e8f688f3a57a",
+      "id": "ccecd143-0808-52e5-a6dc-38a1714fb769",
       "source": "40k-11e",
       "name": {
         "en": "Drayden's Lance Attilan Rough Riders",

--- a/11th/gdc/combatpatrol/blacktemplar.json
+++ b/11th/gdc/combatpatrol/blacktemplar.json
@@ -7,7 +7,7 @@
     "header": "#142637"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.182Z",
+  "updated": "2026-07-28T17:03:02.519Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "fb8618b9-707e-5d2b-a3d7-c55aae8b8ab4",
+      "id": "04bfdcbe-7a80-5e8d-a1b3-a43d6dc6549e",
       "name": {
         "en": "Divine Endurance",
         "de": "Heilige Zähigkeit",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Vow-Sworn of Vedrenn", "Emperor's Champion"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Vow-Sworn of Vedrenn Emperor's Champion</k> model only. At the start of your Movement phase, you can select one friendly <k>Vow-Sworn of Vedrenn</k> unit <b>visible</b> to and within 12\" of this model. If you do, when that unit is selected to make an <b>advance/fall-back move</b> this turn:<ul><li>If that unit uses the <b>desperate escape</b> mode, it passes any <b>hazard rolls</b>.</li><li>That move does not prevent that unit from being <b>eligible to start an action</b>.</li></ul>",
         "de": "Nur für ein <k>Vedrenns-Eidgeschworene-Champion-des-Imperators</k>-Modell. Zu Beginn deiner Bewegungsphase kannst du eine für dieses Modell <b>sichtbare</b> befreundete <k>Vedrenns-Eidgeschworene</k>-Einheit innerhalb von 12\" wählen. Wenn du dies tust und diese Einheit gewählt wird, in diesem Zug eine <b>Vorrücken-/Rückzugsbewegung</b> auszuführen:<ul><li>besteht sie, wenn für diese Bewegung der Modus <b>verzweifelte Flucht</b> eingesetzt wird, etwaige <b>Risikowürfe</b>.</li><li>verhindert jene Bewegung nicht, dass jene Einheit <b>infrage kommt, eine Aktion zu beginnen</b>.</li></ul>",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "047ae3f8-cf1c-58da-8bbd-9873b6a3b84f",
+      "id": "5a8bbe96-9975-5842-a790-7b6341c72191",
       "name": {
         "en": "Divine Protection",
         "de": "Göttlicher Schutz",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Black Templars"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Vow-Sworn Sword Brethren</k> unit only. (Once per battle, per unit) When an enemy unit targets this unit, you can use this ability. If you do, this unit has 4+ <b>InSv</b>.",
         "de": "Aufwertung: Nur für eine <k>Eidgeschworene-Schwertbrüder</k>-Einheit. (Einmal pro Schlacht, pro Einheit) Wenn eine feindliche Einheit diese Einheit als Ziel wählt, kannst du diese Fähigkeit einsetzen. Wenn du dies tust, hat diese Einheit 4+ <b>RE</b>.",

--- a/11th/gdc/combatpatrol/bloodangels.json
+++ b/11th/gdc/combatpatrol/bloodangels.json
@@ -7,7 +7,7 @@
     "header": "#72191c"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.037Z",
+  "updated": "2026-07-28T17:03:02.281Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "39243b34-d761-5e03-b5e8-986e21d95044",
+      "id": "3cad4166-948c-5295-9e7f-7b8eeb671fd9",
       "name": {
         "en": "Masterful Fighter",
         "de": "Meisterkämpfer",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Captain", "Sanguinary Spearhead"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Sanguinary Spearhead Captain</k> model only. This model's melee attacks have:<ul><li>+2 <b>S</b>.</li><li>+1 <b>AP</b>.</li></ul>",
         "de": "Nur für ein <k>Sanguinische-Speerspitze-Captain</k>-Modell. Die Nahkampfattacken dieses Modells haben:<ul><li>+2 <b>S</b>.</li><li>+1 <b>DS</b>.</li></ul>",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d9e5784f-6d2b-5c36-832c-d6103967f5c1",
+      "id": "079daa4a-6e69-59ef-a04f-8bdbca01688d",
       "name": {
         "en": "Overwhelming Charge",
         "de": "Überwältigender Ansturm",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Blood Angels"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Sanguinary Spearhead Assault Intercessor Squad</k> unit only. When this unit is selected to make a <b>pile-in move</b>, this unit can move up to D3+3\".",
         "de": "Aufwertung: Nur für eine <k>Sanguinische-Speerspitze-Intercessor-Sturmtrupp</k>-Einheit. Wenn diese Einheit gewählt wird, eine <b>Nachrückenbewegung</b> auszuführen, kann sich diese Einheit bis zu W3+3\" weit bewegen.",
@@ -620,7 +622,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SANGUINARY SPEARHEAD ASSAULT INTERCESSOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Sanguinary Spearhead Assault Intercessor Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "352cec3a-6c71-50c0-8e58-a0d4be9fd62a",
@@ -996,7 +1005,7 @@
       ]
     },
     {
-      "id": "33e7e554-1218-5921-bc7b-3cd6cfb054bc",
+      "id": "8cd2bcfe-6b6f-58e1-a2eb-89f8be6c0448",
       "source": "40k-11e",
       "name": {
         "en": "Sanguinary Spearhead Sanguinary Guard",
@@ -1363,7 +1372,7 @@
       ]
     },
     {
-      "id": "33e7e554-1218-5921-bc7b-3cd6cfb054bc",
+      "id": "306aaff0-21f3-5fce-9d8c-4d27db66a1de",
       "source": "40k-11e",
       "name": {
         "en": "Sanguinary Spearhead Sanguinary Guard",

--- a/11th/gdc/combatpatrol/chaos_spacemarines.json
+++ b/11th/gdc/combatpatrol/chaos_spacemarines.json
@@ -7,7 +7,7 @@
     "header": "#222a2f"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:51.086Z",
+  "updated": "2026-07-28T17:03:04.230Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "9160fb0d-44ce-5a40-8608-7007f58ded6e",
+      "id": "38237c3e-1490-5962-b1c4-d70457399705",
       "name": {
         "en": "Infernal Infusion",
         "de": "Finstere Infusion",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Zarkan's Daemonkin", "Master of Possession"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Zarkan's Daemonkin Master of Possession</k> model only. This unit's attacks have +1 <b>S</b>.",
         "de": "Nur für ein <k>Zarkans-Dämonensippe-Meister-der-Besessenheit</k>-Modell. Die Attacken dieser Einheit haben +1 <b>S</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8c9dfafc-87f6-5b6a-8bee-a2a639f86f6a",
+      "id": "cdc52244-def3-5ca8-bc6d-3f76d23651b1",
       "name": {
         "en": "Prey on the Weak",
         "de": "Jagd auf die Schwachen",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Heretic Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Zarkan's Daemonkin Possessed</k> unit only. This unit has <b>Scouts 6\"</b>.",
         "de": "Aufwertung: Nur für eine <k>Zarkans-Dämonensippe-Besessene</k>-Einheit. Diese Einheit hat <b>Kundschafter 6\"</b>.",
@@ -710,7 +712,91 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ZARKAN'S DAEMONKIN LEGIONARIES** ■ **ZARKAN'S DAEMONKIN POSSESSED**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Legionaries",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Legionaries",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Possessed",
+          "targetType": "datasheet",
+          "excludesDetachment": "Pactbound Zealots"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Chaos Undivided"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Khorne"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Nurgle"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Slaanesh"
+        },
+        {
+          "type": "leader",
+          "target": "Zarkan's Daemonkin Possessed",
+          "targetType": "datasheet",
+          "requiresDetachment": "Pactbound Zealots",
+          "requiresKeyword": "Tzeentch"
+        }
+      ]
     },
     {
       "id": "085c3fb9-1459-53ef-b933-ac04ef480f66",

--- a/11th/gdc/combatpatrol/darkangels.json
+++ b/11th/gdc/combatpatrol/darkangels.json
@@ -7,7 +7,7 @@
     "header": "#013a17"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:48.865Z",
+  "updated": "2026-07-28T17:03:00.049Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "6ac0bfb3-2175-5b23-a892-d101b1a4f6aa",
+      "id": "06d3ea67-9a03-5270-9cae-946c6ad48371",
       "name": {
         "en": "Supreme Combatant",
         "de": "Überragender Kämpfer",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Vengeful Brethren", "Gravis", "Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Vengeful Brethren Gravis Captain</k> model only. When this unit is <b>selected to attack</b>, this unit's attacks have:<ul><li><k>[Lethal Hits]</k>.</li><li><u>Or:</u> <k>[Sustained Hits 1]</k>.</li></ul>",
         "de": "Nur für ein <k>Bruderschaft-der-Vergeltung-Gravis-Captain</k>-Modell. Wenn diese Einheit <b>zum Kämpfen gewählt wird</b>, haben die Attacken dieser Einheit:<ul><li><k>[Tödliche Treffer]</k>.</li><li><u>Oder:</u> <k>[Trefferhagel 1]</k>.</li></ul>",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d3c6390a-0512-5b5c-b052-96f42b0f6b72",
+      "id": "a9b0f190-3ed6-5483-b99b-eb37f0444a02",
       "name": {
         "en": "Dutiful Defenders",
         "de": "Dienstbeflissene Beschützer",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Dark Angels"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Vengeful Brethren Bladeguard Veteran Squad</k> unit only. (Once per battle round, per army) When you target this unit with the <b>Heroic Intervention stratagem</b>, that use is -1 CP.",
         "de": "Aufwertung: Nur für eine <k>Bruderschaft-der-Vergeltung-Klingengardetrupp</k>-Einheit. (Einmal pro Schlacht, pro Armee) Wenn du die <b>Gefechtsoption Heroische Intervention</b> mit dieser Einheit als Ziel einsetzt, kostet jener Einsatz -1 BP.",

--- a/11th/gdc/combatpatrol/deathguard.json
+++ b/11th/gdc/combatpatrol/deathguard.json
@@ -7,7 +7,7 @@
     "header": "#4d560e"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:49.045Z",
+  "updated": "2026-07-28T17:03:00.358Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "23bdc618-83c1-5344-8b05-880313a90325",
+      "id": "6a92c121-05f0-58c8-b7c5-c74d73c6eb27",
       "name": {
         "en": "Noisome Veil",
         "de": "Scheußlicher Dunst",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Tallyman", "Maggot Lords"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Maggot Lords Tallyman</k> model only. (Once per battle, per army) In your opponent's Shooting phase, when an enemy unit targets this unit, you can use this ability. If you do, this unit has <b>Stealth</b>.",
         "de": "Nur für ein <k>Madenfürsten-Verweser</k>-Modell. (Einmal pro Schlacht, pro Armee) Du kannst diese Fähigkeit in der Fernkampfphase deines Gegners einsetzen, wenn eine feindliche Einheit diese Einheit als Ziel wählt. Wenn du dies tust, hat diese Einheit <b>Tarnung</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "db7ac6de-32da-5153-8900-ce94b4bd336d",
+      "id": "9e601b15-6cbe-5077-88ab-7c88f5ed029b",
       "name": {
         "en": "Bountiful Regeneration",
         "de": "Überschwängliche Regeneration",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Lord of Virulence", "Maggot Lords"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Maggot Lords Lord of Virulence</k> model only. In your Command phase, this model <b>heals</b> 1 wound.",
         "de": "Nur für ein <k>Madenfürsten-Fürst-der-Virulenz</k>-Modell. In deiner Befehlsphase wird dieses Modell um 1 Lebenspunkt <b>geheilt</b>.",
@@ -1584,7 +1586,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **MAGGOT LORDS DEATHSHROUD TERMINATORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Maggot Lords Deathshroud Terminators",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/drukhari.json
+++ b/11th/gdc/combatpatrol/drukhari.json
@@ -7,7 +7,7 @@
     "header": "#0f454e"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.432Z",
+  "updated": "2026-07-28T17:03:11.087Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "ef301f02-7c93-53fa-bef3-ae9b5874991d",
+      "id": "2424e767-6c96-5fd1-9d58-ad390bdb8d68",
       "name": {
         "en": "Toxin-laced Blades",
         "de": "Giftbestrichene Klingen",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Haemonculus", "Coven of Agonies"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Coven of Agonies Haemonculus</k> model only. This unit's melee attacks have +1 <b>AP</b>.",
         "de": "Nur für ein <k>Zirkel-der-Qualen-Haemonculus</k>-Modell. Die Nahkampfattacken dieses Modells haben +1 <b>DS</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e68e5938-a2a0-50f9-8d97-b4f021465690",
+      "id": "82cb615f-b645-5df3-a3ff-046a01e96fd5",
       "name": {
         "en": "Superior Soulcraft",
         "de": "Überragendes Seelenhandwerk",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Coven of Agonies Cronos</k> unit only. This unit can re-roll rolls to determine the <b>A</b> of a weapon.",
         "de": "Aufwertung: Nur für eine <k>Zirkel-der-Qualen-Cronos</k>-Einheit. Für diese Einheit können Würfe wiederholt werden, um die <b>A</b> einer Waffe zu bestimmen.",
@@ -1005,7 +1007,7 @@
       ]
     },
     {
-      "id": "6e2a5ad4-74b9-5565-829a-1bb489ece145",
+      "id": "04f7c277-721b-54c0-9951-31de5cf1876d",
       "source": "40k-11e",
       "name": {
         "en": "Coven of Agonies Wracks",
@@ -1458,7 +1460,7 @@
       ]
     },
     {
-      "id": "6e2a5ad4-74b9-5565-829a-1bb489ece145",
+      "id": "d5400e4e-9e20-5c04-9e2a-0eab52c6bbe5",
       "source": "40k-11e",
       "name": {
         "en": "Coven of Agonies Wracks",
@@ -2238,7 +2240,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **COVEN OF AGONIES WRACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Coven of Agonies Wracks",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/emperors_children.json
+++ b/11th/gdc/combatpatrol/emperors_children.json
@@ -7,7 +7,7 @@
     "header": "#1A3037"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.686Z",
+  "updated": "2026-07-28T17:03:11.576Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "3086b07c-d46b-5ed4-b164-8ef5ef83df71",
+      "id": "3e2cfa44-2930-567b-a179-ad2985bc9293",
       "name": {
         "en": "Invigorating Agonies",
         "de": "Erquickliche Qualen",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Lord Exultant", "Callous Blades"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Callous Blades Lord Exultant</k> model only. (Once per battle, per army) In your opponent's Shooting phase, when an enemy unit has shot, if this unit was hit by those attacks, you can use this ability. If you do, this unit can make a <b>surge move</b> of up to D3+1\".",
         "de": "Nur für ein <k>Herzlose-Klingen-Fürst-des-Überschwangs</k>-Modell. (Einmal pro Schlacht, pro Armee) In der Fernkampfphase deines Gegners kannst du diese Fähigkeit einsetzen, wenn eine feindliche Einheit geschossen hat und diese Einheit von mindestens einer jener Attacken getroffen wurde. Wenn du dies tust, kann diese Einheit eine <b>Ansturmbewegung</b> von bis zu W3+1\" ausführen.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "87a93d52-f74c-5ef7-aee6-6654c0a5a0b8",
+      "id": "b4ee836d-9b06-51eb-9ef8-1bf77eb49ea3",
       "name": {
         "en": "Martial Perfection",
         "de": "Perfektionierte Kampfkunst",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Callous Blades Infractors</k> unit only. (Once per battle, per army) In the Fight phase, when an enemy unit targets this unit, you can use this ability. If you do, attacks that target your unit have -1 to <b>hit rolls</b>.",
         "de": "Aufwertung: Nur für eine <k>Herzlose-Klingen-Infractoren</k>-Einheit. (Einmal pro Schlacht, pro Armee) In der Nahkampfphase kannst du diese Fähigkeit einsetzen, wenn eine feindliche Einheit diese Einheit als Ziel wählt. Wenn du dies tust, haben Attacken gegen deine Einheit  -1 auf <b>Trefferwürfe</b>.",
@@ -339,7 +341,7 @@
   ],
   "datasheets": [
     {
-      "id": "7dce0221-aeb4-53ad-bb67-2e1f0ee44b1e",
+      "id": "f050a344-9a2f-5843-bfca-c444357f098e",
       "source": "40k-11e",
       "name": {
         "en": "Callous Blades Flawless Blades",
@@ -611,7 +613,7 @@
       ]
     },
     {
-      "id": "7dce0221-aeb4-53ad-bb67-2e1f0ee44b1e",
+      "id": "dae41fe9-72a7-5d4a-8242-043a21e9c7ec",
       "source": "40k-11e",
       "name": {
         "en": "Callous Blades Flawless Blades",
@@ -1564,7 +1566,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **LORD KAPHRAEL OF THE CALLOUS BLADES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Callous Blades Infractors",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/greyknights.json
+++ b/11th/gdc/combatpatrol/greyknights.json
@@ -7,7 +7,7 @@
     "header": "#4a5e67"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.247Z",
+  "updated": "2026-07-28T17:03:06.373Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "e4191b41-a0e3-5d68-8f25-5961cd1d41d6",
+      "id": "6764df5d-1ee3-594a-b2a0-3de553e5b468",
       "name": {
         "en": "Purifying Force",
         "de": "Kräfte der Läuterung",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Brotherhood Terminator Squad", "Crowe's Sanctifiers"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Crowe's Sanctifiers Brotherhood Terminator Squad</k> unit only. (Once per battle, per army) When this unit is <b>selected to fight</b>, if it made a <b>charge move</b> this turn, you can use this ability. If you do, this unit's melee attacks have <k>[Lethal Hits]</k>.",
         "de": "Aufwertung: Nur für eine <k>Crowes-Läuterer-Bruderschaft-Terminatortrupp</k>-Einheit. (Einmal pro Schlacht, pro Armee) Wenn diese Einheit <b>zum Kämpfen gewählt wird</b> und in diesem Zug eine <b>Angriffsbewegung</b> ausgeführt hat, kannst du diese Fähigkeit einsetzen. Wenn du dies tust, haben die Nahkampfattacken dieser Einheit <k>[Tödliche Treffer]</k>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0b456bc8-6a49-5657-900e-df7f4a26b267",
+      "id": "b0c2abfb-aee3-5074-91b3-0a593d0134bb",
       "name": {
         "en": "Sanctified Auspexes",
         "de": "Geweihtes Auspex",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Venerable Dreadnought", "Crowe's Sanctifiers"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Crowe's Sanctifiers Venerable Dreadnought</k> unit only. This unit's ranged attacks can re-roll <u>one</u> <b>hit roll</b>.",
         "de": "Aufwertung: Nur für eine <k>Crowes-Läuterer-Ehrwürdiger-Dreadnought</k>-Einheit. Für Fernkampfattacken dieser Einheit kann <u>ein</u> <b>Trefferwurf</b> wiederholt werden.",

--- a/11th/gdc/combatpatrol/gsc.json
+++ b/11th/gdc/combatpatrol/gsc.json
@@ -7,7 +7,7 @@
     "header": "#391625"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.567Z",
+  "updated": "2026-07-28T17:03:11.337Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "0d1edfa4-32ef-56a1-aed5-289300ef3bce",
+      "id": "b735f821-f6eb-53d6-8c32-c80861d20b09",
       "name": {
         "en": "Practiced Eye",
         "de": "Geübter Blick",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Jackal Alphus", "Claw of Ascension"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Claw of Ascension Jackal Alphus</k> model only. At the start of your Shooting phase, you can select one enemy unit. Friendly <k>Claw of Ascension</k> units' attacks that target that enemy unit have +1 to <b>hit rolls</b>.",
         "de": "Nur für ein <k>Klaue-der-Erlösung-Schakal-Alphus</k>-Modell. Zu Beginn deiner Fernkampfphase kannst du eine feindliche Einheit wählen. Attacken befreundeter <k>Klaue-der-Erlösung</k>-Einheiten gegen jene feindliche Einheit haben +1 auf <b>Trefferwürfe</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "70b17473-39b1-578b-a285-40853271d289",
+      "id": "592257b7-824e-5433-8b53-e8c044031b56",
       "name": {
         "en": "Heavy Munitions",
         "de": "Panzerbrechende Munition",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Claw of Ascension Achilles Ridgerunners</k> unit only. This unit's Achilles missile launcher weapon has +1 <b>A</b>, <b>S</b> and <b>AP</b>.",
         "de": "Aufwertung: Nur für eine <k>Klaue-der-Erlösung-Achilles-Gratpirscher</k>-Einheit. Die Achilles-Raketenwerfer-Waffe dieser Einheit hat +1 <b>A</b>, <b>S</b> und <b>DS</b>.",
@@ -1067,7 +1069,7 @@
       ]
     },
     {
-      "id": "b1e1ef45-335c-5fa2-9efd-e0dd1a03a01e",
+      "id": "57bb3185-044b-5ef3-adae-decb86065d8a",
       "source": "40k-11e",
       "name": {
         "en": "Claw of Ascension Hybrid Metamorphs",
@@ -1492,7 +1494,7 @@
       ]
     },
     {
-      "id": "b1e1ef45-335c-5fa2-9efd-e0dd1a03a01e",
+      "id": "62564d79-c5fb-5918-8913-c64b0b4d4abc",
       "source": "40k-11e",
       "name": {
         "en": "Claw of Ascension Hybrid Metamorphs",
@@ -2243,7 +2245,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CLAW OF ASCENSION ATALAN JACKALS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Claw of Ascension Atalan Jackals",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/necrons.json
+++ b/11th/gdc/combatpatrol/necrons.json
@@ -7,7 +7,7 @@
     "header": "#04532a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.913Z",
+  "updated": "2026-07-28T17:03:10.076Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "cc8d7052-bbd2-55e9-a0b3-e7957ed33847",
+      "id": "4938da90-1681-5d5c-a7f6-c62685415680",
       "name": {
         "en": "Metalline Might",
         "de": "Macht des Metalls",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Amonhotekh's Guard Overlord</k> model only. This model's melee attacks have +2 <b>S</b>.",
         "de": "Nur für ein <k>Amonhotekhs-Wächter-Hochlord</k>-Modell. Die Nahkampfattacken dieses Modells haben +2 <b>S</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "67cd4c74-2944-5f29-b0ec-000cff354827",
+      "id": "515d978d-c94f-5680-9446-05de78099b34",
       "name": {
         "en": "Unblemished Legions",
         "de": "Makellose Legionen",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Amonhotekh's Guard Necron Warriors</k> unit only.<ul><li>This unit has +1 <b>M</b>.</li><li>This unit's ranged attacks have <k>[Assault]</k></li></ul>",
         "de": "Aufwertung: Nur für eine <k>Amonhotekhs-Wächter-Necronkrieger</k>-Einheit.<ul><li>Diese Einheit hat +1 <b>B</b>.</li><li>Die Fernkampfattacken dieser Einheit haben <k>[Sturm]</k></li></ul>",

--- a/11th/gdc/combatpatrol/orks.json
+++ b/11th/gdc/combatpatrol/orks.json
@@ -7,7 +7,7 @@
     "header": "#465b18"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.296Z",
+  "updated": "2026-07-28T17:03:08.612Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "5ad7ba25-9936-5cb7-923e-44a0ea737e5a",
+      "id": "7cf714a8-dbd2-5675-a74f-f72bd19439d9",
       "name": {
         "en": "Rallying War Cry",
         "de": "Stärkender Schlachtruf",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>'Ardmob Warboss</k> model only. (Once per battle, per unit) In your Command phase, you can use this ability. If you do, return up to D3+2 <b>destroyed bodyguard</b> models to this unit.",
         "de": "Nur für ein <k>Obamob-Waaaghboss</k>-Modell. (Einmal pro Schlacht, pro Einheit) In deiner Befehlsphase kannst du diese Fähigkeit einsetzen. Wenn du dies tust, kannst du bis zu W3+2 <b>zerstörte Leibwächter</b>-Modelle in diese Einheit zurückbringen.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d527a2cb-8d13-59e7-b79b-8d7039dbe04d",
+      "id": "e7bd931c-6126-5ffd-bdce-65c3c1d797f4",
       "name": {
         "en": "Extra Platin’",
         "de": "Extrarüstung",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>'Ardmob Wartrakk</k> unit only. This unit has:<ul><li>3+ <b>Sv</b>.</li><li>4+ <b>InSv</b>.</li></ul>",
         "de": "Aufwertung: Nur für eine <k>Obamob-Ketta</k>-Einheit. Diese Einheit hat:<ul><li>3+ <b>RW</b>.</li><li>4+ <b>RE</b>.</li></ul>",
@@ -339,7 +341,7 @@
   ],
   "datasheets": [
     {
-      "id": "87fa4970-217c-557a-b4a2-9b401fdb0b28",
+      "id": "11f4177d-3a9a-5266-84a0-309bb2e06a5e",
       "source": "40k-11e",
       "name": {
         "en": "’Ardmob Boyz",
@@ -745,7 +747,7 @@
       ]
     },
     {
-      "id": "87fa4970-217c-557a-b4a2-9b401fdb0b28",
+      "id": "78b8a97c-f845-5013-a912-2f6b11461560",
       "source": "40k-11e",
       "name": {
         "en": "’Ardmob Boyz",
@@ -1712,7 +1714,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **'ARDMOB BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "’Ardmob Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2f1fe6fe-3953-5363-824d-025960323ba3",
@@ -2278,7 +2287,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **'ARDMOB BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "’Ardmob Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/space_marines.json
+++ b/11th/gdc/combatpatrol/space_marines.json
@@ -7,7 +7,7 @@
     "header": "#4b6262"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:49.872Z",
+  "updated": "2026-07-28T17:03:01.981Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "baff7487-1907-53af-aa65-208c01e3c0e6",
+      "id": "533369fc-705b-5618-aa33-ede88c23fc1a",
       "name": {
         "en": "Blade Masters",
         "de": "Klingenmeister",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Assault Force Vanguard Veteran Squad with Jump Packs</k> unit only. When an enemy unit ends a <b>charge move</b>, if that enemy unit is <b>engaged</b> with this unit, that unit's melee attacks have -1 to <b>wound rolls</b> until the end of the turn.",
         "de": "Aufwertung: Nur für eine <k>Angriffsstreitmacht-Expugnatorgarde-mit-Sprungmodulen</k>-Einheit. Wenn eine feindliche Einheit eine <b>Angriffsbewegung</b> beendet und sich jene feindliche Einheit <b>im Nahkampf</b> mit dieser Einheit befindet, haben die Attacken jener feindlichen Einheit bis zum Ende des Zugs -1 auf <b>Verwundungswürfe</b>.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b1a9e438-42aa-5066-a83d-ba482aee29b8",
+      "id": "b3201522-f3b6-51d8-b1b9-25ffa1bcfff8",
       "name": {
         "en": "Battle-line Veterans",
         "de": "Linientruppen-Veteranen",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Assault Force Intercessor Squad</k> unit only. This unit's bolt rifle weapons have <k>[Rapid Fire 1]</k>.",
         "de": "Aufwertung: Nur für eine <k>Angriffsstreitmacht-Intercessortrupp</k>-Einheit. Die Boltgewehr-Waffen dieser Einheit haben <k>[Schnellfeuer 1]</k>.",
@@ -1752,7 +1754,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT FORCE INTERCESSOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Force Intercessor Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "8ff49b77-5dbb-5bd6-8236-97cf74b401f7",

--- a/11th/gdc/combatpatrol/spacewolves.json
+++ b/11th/gdc/combatpatrol/spacewolves.json
@@ -7,7 +7,7 @@
     "header": "#435d63"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.331Z",
+  "updated": "2026-07-28T17:03:02.734Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "853104b5-1068-5e5a-8c25-278fce5395ac",
+      "id": "7fd9b226-1a12-5d69-80fc-5194a4f18afd",
       "name": {
         "en": "Lone Hunter",
         "de": "Einsamer Jäger",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Battle Leader", "Askar's Wolfpack"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Askar's Wolfpack Battle Leader</k> model only. This model has:<ul><li><b>Lone Operative 9\"</b>.</li><li><b>Stealth</b>.</li><li>+1 <b>T</b>.</li></ul>",
         "de": "Nur für ein <k>Askars-Wolfsrudel-Wolfsgarde-Held</k>-Modell. Dieses Modell hat:<ul><li><b>Einsamer Wolf 9\"</b>.</li><li><b>Tarnung</b>.</li><li>+1 <b>W</b>.</li></ul>",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8088d5dc-8ca9-5ddc-9748-5d6996a7bf21",
+      "id": "ce7328a7-371d-5bc0-9693-e8b9446d18ae",
       "name": {
         "en": "Aggressive Response",
         "de": "Aggressives Echo",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Terminator", "Wolf Guard", "Askar's Wolfpack"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Askar's Wolfpack Wolf Guard Terminators</k> unit only. (Once per turn, per unit) In your opponent's Shooting phase, when an enemy unit has shot, if this unit was hit by those attacks, this unit can make a <b>surge move</b> of up to D3+1\".",
         "de": "Aufwertung: Nur für eine <k>Askars-Wolfsrudel-Wolfsgarde-Terminatoren</k>-Einheit. (Einmal pro Zug, pro Einheit) In der Fernkampfphase deines Gegners kann diese Einheit, nachdem eine feindliche Einheit geschossen hat und diese Einheit von mindestens einer jener Attacken getroffen wurde, eine <b>Ansturmbewegung</b> von bis zu W3+1\" ausführen.",
@@ -1849,7 +1851,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASKAR'S WOLFPACK BLOOD CLAWS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Askar's Wolfpack Blood Claws",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/tau.json
+++ b/11th/gdc/combatpatrol/tau.json
@@ -7,7 +7,7 @@
     "header": "#2e5a6a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.690Z",
+  "updated": "2026-07-28T17:03:09.542Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "8193dc29-eace-57aa-a3dc-ec15f2cd50ab",
+      "id": "752f09c2-7a6d-53f0-b48f-7356048e33e9",
       "name": {
         "en": "Earth Caste Modifications",
         "de": "Erdkaste-Modifikationen",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Sudden Dawn Cadre Commander in Enforcer Battlesuit</k> model only.<ul><li>When this unit has shot, you can select one enemy unit hit by those attacks. That enemy unit is <b>suppressed</b> until the start of your next turn:<ul><li>While a unit is <b>suppressed</b>, that unit’s attacks have -1 to <b>hit rolls</b>.</li></ul><li>When this unit makes an <b>ingress move</b>, it can be set up more than 6\" horizontally from all enemy units (instead of more than 8\"). If this unit does, is <u>not</u> <b>eligible to declare a charge</b> until the end of the turn.</li></ul>",
         "de": "Nur für ein <k>Dämmerungsschlagkader-Commander-in-Vollstrecker-Kampfanzug</k>-Modell.<ul><li>Wenn diese Einheit geschossen hat, kannst du eine feindliche Einheit wählen, die von mindestens einer jener Attacken getroffen wurde. Wenn du dies tust, ist jene feindliche Einheit bis zu Beginn deines nächsten Zugs <b>niedergehalten</b>:<ul><li>Solange eine Einheit <b>niedergehalten</b> ist, haben die Attacken jener Einheit -1 auf <b>Trefferwürfe</b>.</li></ul><li>Wenn diese Einheit eine <b>Einsatzbewegung</b> ausführt, kann sie horizontal weiter als 6\" entfernt von allen feindlichen Einheiten platziert werden (statt weiter als 8\"). Wenn sie dies tut, kommt sie bis zum Ende des Zugs <u>nicht</u> <b>zum Ansagen eines Angriffs infrage</b>.</li></ul>",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0ff3f747-065f-521c-bd81-fc0522ffc2e8",
+      "id": "82e8efbb-cbe4-5790-8e82-13eda9ce57f1",
       "name": {
         "en": "Proximity Scanners",
         "de": "Umgebungsscanner",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Sudden Dawn Cadre Devilfish</k> unit only. When a friendly unit embarked within this unit disembarks, that friendly unit's pulse blaster and pulse carbine weapons have +1 <b>A</b>.",
         "de": "Aufwertung: Nur für eine <k>Dämmerungskader-Teufelsrochen</k>-Einheit. Wenn eine befreundete Einheit an Bord dieser Einheit aussteigt, haben die Pulsblaster- und Pulskarabiner-Waffen jener befreundeten Einheit +1 <b>A</b>.",

--- a/11th/gdc/combatpatrol/thousandsons.json
+++ b/11th/gdc/combatpatrol/thousandsons.json
@@ -7,7 +7,7 @@
     "header": "#185862"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.591Z",
+  "updated": "2026-07-28T17:03:03.248Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "d5208a17-072c-5c5b-be2e-ec70aafddabf",
+      "id": "bee4ba84-d718-59b4-ae6a-f0b627b5a070",
       "name": {
         "en": "Foresight of the Changer",
         "de": "Hellsicht des Wandlers",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Tzaangor Shaman", "Prism of Zadophon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Prism of Zadophon Tzaangor Shaman</k> model only. (Once per turn, per unit) In your opponent's Movement phase, when an enemy unit ends a move within 8\" of this unit, if this unit is <b>unengaged</b>, this unit can make a <b>normal move</b> of up to D3+1\".",
         "de": "Nur für ein <k>Zadophons-Prisma-Tzaangor-Schamane</k>-Modell. (Einmal pro Zug, pro Einheit) Wenn eine feindliche Einheit in der Bewegungsphase deines Gegners eine Bewegung innerhalb von 8\" um diese Einheit beendet und diese Einheit <b>nicht im Nahkampf</b> ist, kann diese Einheit eine <b>normale Bewegung</b> von bis zu W3+1\" ausführen.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "06eb7d7a-c18f-5192-93ca-88e0a930e101",
+      "id": "ba51d059-011b-5983-bf8a-d6db8927b261",
       "name": {
         "en": "Warp-tainted Shells",
         "de": "Warpverseuchte Geschosse",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Daemon Prince", "Prism of Zadophon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Prism of Zadophon Daemon Prince</k> model only. This model's infernal cannon weapon has <k>[Psychic]</k>.",
         "de": "Nur für ein <k>Zadophons-Prisma-Dämonenprinz</k>-Modell. Die Infernale-Kanone-Waffe dieses Modells hat <k>[Psionisch]</k>.",
@@ -684,7 +686,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PRISM OF ZADOPHON TZAANGOR ENLIGHTENED**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Prism of Zadophon Tzaangor Enlightened",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "77d43249-4137-551a-8609-86d7753a10f7",

--- a/11th/gdc/combatpatrol/tyranids.json
+++ b/11th/gdc/combatpatrol/tyranids.json
@@ -7,7 +7,7 @@
     "header": "#381a3a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:49.304Z",
+  "updated": "2026-07-28T17:03:00.814Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "c04c5a6d-4f5f-52c3-8fa3-3faab7350679",
+      "id": "f07af4d1-6bfb-54c8-bd93-85bfa5f7248c",
       "name": {
         "en": "Adapted Organism",
         "de": "Angepasster Organismus",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Vardenghast Swarm", "Winged Tyranid Prime"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Vardenghast Swarm Winged Tyranid Prime</k> model only.<ul><li>This model has 4+ <b>InSv</b>.</li><li>This model's melee attacks have +2 <b>AP</b>.</li></ul>",
         "de": "Nur für ein <k>Vardenghast-Schwarm-Geflügelter-Alphakrieger</k>-Modell.<ul><li>Dieses Modell hat 4+ <b>RE</b>.</li><li>Die Nahkampfattacken dieses Modells haben +2 <b>DS</b>.</li></ul>",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fe54df10-8e50-5a12-9efa-f8e90738cd82",
+      "id": "b847635a-4859-5c73-90f0-010557f9bfa9",
       "name": {
         "en": "Psychoclastic Overload",
         "de": "Psychoklastische Überladung",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Vardenghast Swarm Psychophage</k> unit only. This unit can re-roll rolls to determine the <b>A</b> of a weapon.",
         "de": "Aufwertung: Nur für eine <k>Vardenghast-Schwarm-Psychophage</k>-Einheit. Für diese Einheit können Würfe zum Bestimmen der <b>A</b> einer Waffe wiederholt werden.",
@@ -1136,7 +1138,7 @@
       ]
     },
     {
-      "id": "f3445b98-3f15-55ee-bf25-79b9733bedb6",
+      "id": "d4457653-f93d-567e-8058-6c622a2580bb",
       "source": "40k-11e",
       "name": {
         "en": "Vardenghast Swarm Termagants",
@@ -1396,7 +1398,7 @@
       ]
     },
     {
-      "id": "f3445b98-3f15-55ee-bf25-79b9733bedb6",
+      "id": "1a85f2b9-eb09-5a0c-ac36-59af83e3779e",
       "source": "40k-11e",
       "name": {
         "en": "Vardenghast Swarm Termagants",

--- a/11th/gdc/combatpatrol/votann.json
+++ b/11th/gdc/combatpatrol/votann.json
@@ -7,7 +7,7 @@
     "header": "#3c4b3f"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.457Z",
+  "updated": "2026-07-28T17:03:08.956Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "64240a7f-8db4-577d-907e-1a88aa09bc9b",
+      "id": "07948337-9941-54e3-8f38-3fb5ef4942ca",
       "name": {
         "en": "Indomitable Exemplar",
         "de": "Gipfel der Unzerstörbarkeit",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Einhyr Champion", "Bane-Slayer's Bulwark"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Bane-slayer's Bulwark Einhyr Champion</k> model only. In the Fight phase, when this model is <b>destroyed</b>, if this unit has not been <b>selected to fight</b> this phase, roll one D6: on a 2+, do not remove this model from the battlefield. When this unit has fought, or at the end of the phase (whichever comes first), this model is removed from the battlefield.",
         "de": "Nur für ein <k>Fluchschlächters-Bollwerk-Einhyr-Champion</k>-Modell. Wenn dieses Modell in der Nahkampfphase <b>zerstört</b> wird und diese Einheit in dieser Phase noch nicht <b>zum Kämpfen gewählt wurde</b>, wirf einen W6: Bei 2+ entferne dieses Modell nicht vom Schlachtfeld; wenn diese Einheit gekämpft hat oder am Ende der Phase (was immer zuerst eintritt), wird dieses Modell vom Schlachtfeld entfernt.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "46e2b2e5-6f8f-5eb6-bb0e-a42fcfb67e50",
+      "id": "ca9a53ab-ce4e-5198-81fc-2678c7b7c47b",
       "name": {
         "en": "Brôkhyr Barrage",
         "de": "Brôkhyr-Geschosshagel",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Upgrade: <k>Bane-slayer's Bulwark Brôkhyr Thunderkyn</k> unit only. <ul><li>This unit's ranged attacks have <k>[Ignores Cover]</k>.</li><li>In your Shooting phase, when this unit has shot, you can select one enemy unit hit by those ranged attacks. If you do, that enemy unit makes a <b>battle-shock roll</b>.</li></ul>",
         "de": "Aufwertung: Nur für eine <k>Fluchschlächters-Bollwerk-Brôkhyr-Grollkyn</k>-Einheit. <ul><li>Die Fernkampfattacken dieser Einheit haben <k>[Deckung ignorieren]</k>.</li><li>In deiner Fernkampfphase kannst du, wenn diese Einheit geschossen hat, eine feindliche Einheit wählen, die von mindestens einer jener Attacken getroffen wurde. Wenn du dies tust, führt jene feindliche Einheit einen <b>Erschütterungswurf</b> aus.</li></ul>",
@@ -2001,7 +2003,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BANE-SLAYER'S BULWARK EINHYR HEARTHGUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Bane-Slayer's Bulwark Einhyr Hearthguard",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/combatpatrol/worldeaters.json
+++ b/11th/gdc/combatpatrol/worldeaters.json
@@ -7,7 +7,7 @@
     "header": "#4d161a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.757Z",
+  "updated": "2026-07-28T17:03:03.580Z",
   "parent_id": null,
   "parent_name": null,
   "isCombatPatrol": true,
@@ -273,7 +273,7 @@
   ],
   "enhancements": [
     {
-      "id": "b4b62252-f2d1-5797-b50c-bd3cb9c17995",
+      "id": "f5935772-33a9-5210-8189-4f93d66b3d36",
       "name": {
         "en": "Fearsome Presence",
         "de": "Furchterregende Präsenz",
@@ -287,6 +287,7 @@
       "cost": "null",
       "keywords": ["Daemon Prince", "Frenzied Reavers"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Frenzied Reavers Daemon Prince</k> model only. This model has <b>OC</b> 5.",
         "de": "Nur für ein <k>Rasende-Zerstörer-Dämonenprinz</k>-Modell. Dieses Modell hat <b>MK</b> 5.",
@@ -305,7 +306,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cc8668d0-14a3-59c1-97d9-e0554b754690",
+      "id": "0fefff04-bf8f-50d9-9332-f6cf050d2020",
       "name": {
         "en": "Bane of the Craven",
         "de": "Verderbnis der Feiglinge",
@@ -319,6 +320,7 @@
       "cost": "null",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Frenzied Reavers Master of Executions</k> model only. When an enemy unit <b>engaged</b> with this unit is selected to make a <b>fall-back move</b>:<ul><li>That enemy unit must select the <b>desperate\nescape mode</b>.</li><li>If that enemy unit is <b>battle-shocked</b>, that enemy unit has -1 to the <b>hazard rolls</b> made for that <b>desperate escape</b>.</li></ul>",
         "de": "Nur für ein <k>Rasende-Zerstörer-Meister-der-Exekutionen</k>-Modell. Wenn eine feindliche Einheit <b>im Nahkampf</b> mit dieser Einheit gewählt wird, eine <b>Rückzugsbewegung</b> auszuführen:<ul><li>muss jene feindliche Einheit den Modus <b>Verzweifelte\nFlucht</b> wählen.</li><li>Wenn jene feindliche Einheit <b>erschüttert</b> ist, hat sie -1 auf die <b>Risikowürfe</b> für jene <b>Verzweifelte Flucht</b>.</li></ul>",
@@ -1639,7 +1641,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **FRENZIED REAVERS KHORNE BERZERKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Frenzied Reavers Khorne Berzerkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "c2e9c3d9-dd8b-5f0f-b904-63798ec2f498",

--- a/11th/gdc/core.json
+++ b/11th/gdc/core.json
@@ -1,0 +1,674 @@
+{
+  "source": "40k-11e",
+  "compatibleDataVersion": 913,
+  "updated": "2026-07-28T17:34:25.814Z",
+  "stratagems": [
+    {
+      "id": "db2db16d-cd39-5e21-a9d0-e8d1f4f1493c",
+      "name": {
+        "en": "Command Re-roll",
+        "de": "Befehlswiederholungswurf",
+        "es": "Repetición de mando",
+        "fr": "Relance de Commandement",
+        "it": "Ripetizione Comando",
+        "ja": "リロール命令",
+        "ko": "지휘 재굴림",
+        "zh": "指挥重掷"
+      },
+      "cost": 1,
+      "turn": "either",
+      "type": "Core Stratagem",
+      "phase": ["any"],
+      "target": {
+        "en": "That unit or model.",
+        "de": "Jene Einheit oder jenes Modell",
+        "es": "Esa unidad o miniatura.",
+        "fr": "Cette unité ou figurine.",
+        "it": "Quell’unità o modello.",
+        "ja": "そのユニットまたは兵。",
+        "ko": "그 아군 유닛 혹은 모델.",
+        "zh": "那个单位或者模型"
+      },
+      "when": {
+        "en": "Any phase, just after you make one of the following rolls for a friendly unit or model: <ul><li><b>Advance roll</b></li><li><b>Charge roll</b></li><li><b>Damage roll</b></li><li><b>Hazard roll</b></li><li><b>Hit roll</b></li><li><b>Save roll</b></li><li><b>Wound roll</b></li><li>A roll to determine the number of attacks generated with a weapon.</li></ul>",
+        "de": "Beliebige Phase, unmittelbar nachdem du einen der folgenden Würfe für eine befreundete Einheit oder ein befreundetes Modell ausgeführt hast: <ul><li><b>Vorrückenwurf</b></li><li><b>Angriffswurf</b></li><li><b>Schadenswurf</b></li><li><b>Risikowurf</b></li><li><b>Trefferwurf</b></li><li><b>Schutzwurf</b></li><li><b>Verwundungswurf</b></li><li>Ein Wurf, um die Anzahl der Attacken einer Waffe zu ermitteln</li></ul>",
+        "es": "En cualquier fase, justo después de que hagas una de las siguientes tiradas para una unidad o miniatura amigas: <ul><li><b>De avanzar</b></li><li><b>De carga</b></li><li><b>De daño</b></li><li><b>De riesgo</b></li><li><b>Para impactar</b></li><li><b>Para herir</b></li><li><b>De salvación</b></li><li>Una tirada para determinar la cantidad de ataques que hace un arma.</li></ul>",
+        "fr": "À n’importe quelle phase, juste après que vous avez fait un des jets suivants pour une unité ou une figurine amie : <ul><li><b>Jet d’avance</b></li><li><b>Jet de charge</b></li><li><b>Jet de dégâts</b></li><li><b>Jet de risque</b></li><li><b>Jet de touche</b></li><li><b>Jet de sauvegarde</b></li><li><b>Jet de blessure</b></li><li>Un jet pour déterminer le nombre d’attaques générées par une arme.</li></ul>",
+        "it": "In qualsiasi fase, subito dopo che hai effettuato uno dei seguenti tiri per un’unità amica o un modello amico: <ul><li><b>Tiro per avanzare</b></li><li><b>Tiro per caricare</b></li><li><b>Tiro per i danni</b></li><li><b>Tiro pericolo</b></li><li><b>Tiro per colpire</b></li><li><b>Tiro salvezza</b></li><li><b>Tiro per ferire</b></li><li>Un tiro per determinare il numero di attacchi generati con un’arma.</li></ul>",
+        "ja": "任意のフェイズ中、自軍側ユニットや兵が、以下のロールのいずれか1つを行った直後：<ul><li><b>全力移動ロール</b></li><li><b>突撃ロール</b></li><li><b>ダメージ量判定ロール</b></li><li><b>危機ロール</b></li><li><b>ヒットロール</b></li><li><b>セーヴィング</b></li><li><b>ウーンズロール</b></li><li>いずれかの武器で行う攻撃回数を決めるためのロール。</li></ul>",
+        "ko": "어느 페이즈든, 아군 유닛 또는 모델에 다음 주사위 굴림 중 하나를 수행한 직후. <ul><li><b>급속 이동 굴림</b></li><li><b> 돌격 굴림</b></li><li><b>피해 굴림</b></li><li><b>위험 굴림</b></li><li><b>명중 굴림</b></li><li><b>방호 굴림</b></li><li><b>타격 굴림</b></li><li>무기의 공격 횟수를 정하는 주사위 굴림</li></ul>",
+        "zh": "任意阶段中，在您为一个己方单位或者模型进行了以下一次掷骰后：<ul><li><b>突进掷骰</b><b>冲锋掷骰</b></li><li><b>伤害掷骰</b></li><li><b>危险掷骰</b></li><li><b>命中掷骰</b></li><li><b>豁免掷骰</b></li><li><b>致伤掷骰</b></li><li>为一件武器决定攻击次数的掷骰。</li></ul>"
+      },
+      "effect": {
+        "en": "You re-roll that roll. If you are rolling more than one dice together, select one of those dice to re-roll (excluding <b>charge rolls</b>, which you must re-roll in full).",
+        "de": "Du wiederholst jenen Wurf. Wenn du mehr als einen Würfel auf einmal wirfst, wähle einen jener Würfel, den du wiederholst (ausgenommen <b>Angriffswürfe</b>, die du vollständig wiederholen musst).",
+        "es": "Repite esa tirada. Si esa tirada incluía varios dados a la vez, elige solo uno de ellos y repítelo (salvo <b>tiradas de carga</b>, que se repiten en su totalidad).",
+        "fr": "Vous relancez ce jet. Si vous jetez plus d’un dé en même temps, choisissez l’un de ces dés pour le relancer (sauf pour les <b>jets de charge</b>, que vous devez relancer entièrement).",
+        "it": "Ripeti quel tiro. Se tiri più dadi insieme, scegli uno di quei dadi e ripetine il tiro (tranne i <b>tiri per caricare</b>, che devi ripetere per intero).",
+        "ja": "そのロールをリロールする。2個以上のダイスを同時にロールしている場合、それらのダイスのうち1個を選んでリロールする（ただし<b>突撃ロール</b>の場合は、すべてのダイスをリロールすること）。",
+        "ko": "그 주사위 굴림을 재굴림합니다. 한 번에 여러 주사위를 굴렸다면, 그중 하나만 재굴림합니다(예외적으로 <b>돌격 굴림</b>은 주사위 두 개를 모두 다시 굴림).",
+        "zh": "效果：重掷那次掷骰。如果你进行的掷骰使用了超过一枚骰子，那么选择其中一枚骰子进行重掷（<b>冲锋掷骰</b>为例外，您必须重掷这次掷骰的所有骰子）。"
+      },
+      "fluff": {
+        "en": "A great commander can bend even the vagaries of fate and fortune to their will, the better to ensure victory.",
+        "de": "Ein großer Befehlshaber kann selbst die Gezeiten von Glück und Schicksal mit seiner schieren Willenskraft in die Knie zwingen, um den Sieg zu sichern.",
+        "es": "Un gran comandante puede someter a su voluntad incluso los caprichos del destino y la fortuna para asegurarse la victoria.",
+        "fr": "Un grand commandant peut même plier les caprices du destin à sa volonté, afin d’assurer la victoire.",
+        "it": "Un grande comandante può piegare al suo volere persino i capricci del fato, spianando la strada per la vittoria.",
+        "ja": "偉大な指揮官は、運命や思わぬ出来事さえも意のままに操り、勝利を確実なものにする。",
+        "ko": "위대한 지휘관은 변덕스러운 운명마저 길들여 승리의 발판으로 삼는다.",
+        "zh": "为了确保胜利，一名优秀的指挥官甚至能够扭转变幻莫测的命运。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "0eaedaa5-9575-5247-8b1c-d8fdf94e3335",
+      "name": {
+        "en": "Fire Overwatch",
+        "de": "Abwehrfeuer geben",
+        "es": "Disparos preventivos",
+        "fr": "Tir en État d'Alerte",
+        "it": "Tirare di Reazione",
+        "ja": "警戒射撃",
+        "ko": "경계 사격",
+        "zh": "警戒射击"
+      },
+      "cost": 1,
+      "turn": "opponents",
+      "type": "Core Stratagem",
+      "phase": ["movement"],
+      "target": {
+        "en": "One friendly <b>unengaged</b> unit (excluding <k>TITANIC</k> units).",
+        "de": "Eine befreundete Einheit (ausgenommen <k>TITANISCHE</k> Einheiten), die <b>nicht im Nahkampf</b> ist",
+        "es": "1 unidad amiga que <b>no esté trabada</b> (salvo unidades <k>TITÁNICA</k>).",
+        "fr": "1 unité <b>non engagée</b> amie (sauf les unités <k>TITANESQUES</k>).",
+        "it": "Un’unità <b>non ingaggiata</b> amica (escluse le unità <k>TITANICHE</k>).",
+        "ja": "味方の<b>非接敵状態</b>のユニット（<k>巨大兵器</k>・ユニットを除く）を1個選択する。",
+        "ko": "<b>교전 상태가 아닌</b> 아군 유닛 하나(<k>거대</k> 유닛 제외).",
+        "zh": "一个<b>不处于交战状态</b>的己方单位（<k>巨型</k>单位除外）。"
+      },
+      "when": {
+        "en": "End of your opponent’s Movement phase.",
+        "de": "Ende der Bewegungsphase deines Gegners",
+        "es": "Al final de la fase de movimiento del oponente.",
+        "fr": "À la fin de la phase de Mouvement adverse.",
+        "it": "Alla fine della fase di Movimento dell’avversario.",
+        "ja": "敵軍側移動フェイズ終了時。",
+        "ko": "상대의 이동 페이즈 종료 시.",
+        "zh": "在您对手的移动阶段结束时。"
+      },
+      "effect": {
+        "en": "Your unit shoots using <b>snap shooting</b> (15.09).",
+        "de": "Deine Einheit schießt mittels <b>eiligem Beschuss</b> (15.09)",
+        "es": "Tu unidad dispara haciendo <b>disparos repentinos</b> (15.09).",
+        "fr": "Votre unité tire en utilisant le type <b>tir au jugé</b> (15.09).",
+        "it": "La tua unità spara usando <b>tiro improvviso</b> (15.09).",
+        "ja": "その自軍ユニットは<b>即応射撃</b>（15.09）で射撃を行う。",
+        "ko": "이 유닛이 <b>스냅 샷</b>(15.09) 사격을 수행합니다.",
+        "zh": "目标单位使用<b>快速射击</b>进行射击（15.09)。"
+      },
+      "fluff": {
+        "en": "A hail of fire can drive back advancing foes.",
+        "de": "Ein wilder Feuerhagel treibt vorrückende Feinde zurück.",
+        "es": "Una lluvia de disparos puede frenar el avance enemigo.",
+        "fr": "Une grêle de tirs peut repousser l’ennemi qui approche.",
+        "it": "Una salva di proiettili può respingere l’avanzata nemica.",
+        "ja": "迫り来る敵を撃退すべく、猛射を行う。",
+        "ko": "화력을 쏟아부어 적의 전진을 저지한다.",
+        "zh": "狂乱的弹幕能够击退来袭的敌人。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "c1cbaa1c-8a89-54aa-8d09-97c06bbefdbc",
+      "name": {
+        "en": "Crushing Impact",
+        "de": "Zerschmetternder Aufprall",
+        "es": "Impacto aplastante",
+        "fr": "Impact Écrasant",
+        "it": "Impatto Devastante",
+        "ja": "圧倒的衝撃",
+        "ko": "충각",
+        "zh": "粉碎冲击"
+      },
+      "cost": 1,
+      "turn": "your",
+      "type": "Core Stratagem",
+      "phase": ["charge"],
+      "target": {
+        "en": "That <k>MONSTER/VEHICLE</k> unit",
+        "de": "Jene <k>MONSTER/FAHRZEUG</k>-Einheit",
+        "es": "Esa unidad <k>MONSTRUO/VEHÍCULO</k>.",
+        "fr": "Cette unité de <k>MONSTRE/VÉHICULE</k>",
+        "it": "Quell’unità <k>MOSTRO/VEICOLO</k>",
+        "ja": "その<k>モンスター/ビークル</k>・ユニット",
+        "ko": "그 <k>괴수/기체</k> 유닛.",
+        "zh": "那个<k>凶兽/载具</k>单位。"
+      },
+      "when": {
+        "en": "Your Charge phase, just after a friendly <k>MONSTER/VEHICLE</k> unit ends a <b>charge move</b>.",
+        "de": "Deine Angriffsphase, unmittelbar nachdem eine befreundete <k>MONSTER-/FAHRZEUG</k>-Einheit eine Angriffsbewegung beendet",
+        "es": "En tu fase de carga, justo después de que una unidad <k>MONSTRUO/VEHÍCULO</k> amiga termine un <b>movimiento de carga</b>.",
+        "fr": "À votre phase de Charge, juste après qu’une unité de <k>MONSTRE/VÉHICULE</k> amie a fini un <b>mouvement de charge</b>.",
+        "it": "Nella tua fase di Carica, subito dopo che un’unità <k>MOSTRO/VEICOLO</k> amica ha terminato un <b>movimento di carica</b>.",
+        "ja": "自軍の突撃フェイズ中、味方<k>モンスター/ビークル</k>・ユニットが<b>突撃移動</b>を終了した直後。",
+        "ko": "플레이어의 돌격 페이즈, 아군 <k>괴수/기체</k> 유닛이 <b>돌격 이동</b>을 종료한 직후.",
+        "zh": "己方冲锋阶段中，在一个己方<k>凶兽/载具</k>单位结束一次<b>冲锋移动</b>后。"
+      },
+      "effect": {
+        "en": "Resolve the following sequence:\n\n<b>1.</b> Select one enemy unit <b>engaged</b> with your unit.\n\n<b>2.</b> Select one model in your unit <b>engaged</b> with that enemy unit.\n\n<b>3.</b> Roll a number of D6 equal to the T characteristic of that model: for each 1, your unit suffers 1 <b>mortal wound</b>; for each 5+, that enemy unit suffers 1 <b>mortal wound</b> (to a maximum of 6 <b>mortal wounds</b> per unit)",
+        "de": "Handle die folgende Abfolge ab:\n\n<b>1.</b> Wähle eine feindliche Einheit <b>im Nahkampf</b> mit deiner Einheit.\n\n<b>2.</b> Wähle ein Modell deiner Einheit <b>im Nahkampf</b> mit jener feindlichen Einheit.\n\n<b>3.</b> Wirf eine Anzahl W6 gleich dem <b>W</b>-Wert jenes Modells: Für jede 1 erleidet deine Einheit 1 <b>tödliche Verwundung</b>; für jede 5+ erleidet jene feindliche Einheit 1 <b>tödliche Verwundung</b> (bis zu einem Maximum von 6 <b>tödlichen Verwundungen</b> pro Einheit).",
+        "es": "Sigue esta secuencia:\n\n<b>1.</b> Elige 1 unidad enemiga <b>trabada</b> con tu unidad.\n\n<b>2.</b> Elige 1 miniatura de tu unidad <b>trabada</b> con esa unidad enemiga.\n\n<b>3.</b> Tira tantos D6 como el atributo R de esa miniatura: tu unidad sufre 1 <b>herida mortal</b> por cada 1, y esa unidad enemiga sufre 1 <b>herida mortal</b> por cada 5+ (hasta un máximo de 6 <b>heridas mortales</b> por unidad).",
+        "fr": "Résolvez la séquence suivante :\n\n<b>1.</b> _x0007_Choisissez 1 unité ennemie <b>engagée</b> avec votre unité.\n\n<b>2.</b> Choisissez 1 figurine de votre unité <b>engagée</b> avec cette unité ennemie.\n\n<b>3.</b> Jetez autant de D6 que la caractéristique d’E de cette figurine : pour chaque 1, votre unité subit 1 <b>blessure mortelle</b> ; pour chaque 5+, l’unité ennemie subit 1 <b>blessure mortelle</b> (jusqu’à un maximum de 6 <b>blessures mortelles</b> par unité)",
+        "it": "Risolvi la sequenza in basso:\n\n<b>1.</b> Scegli un’unità nemica <b>ingaggiata</b> con la tua unità.\n\n<b>2.</b> Scegli un modello della tua unità <b>ingaggiato</b> con quella unità nemica.\n\n<b>3.</b> Tira un numero di D6 pari alla caratteristica R di quel modello: per ogni 1 la tua unità subisce 1 <b>ferita mortale</b>; per ogni 5+ quell’unità nemica subisce 1 <b>ferita mortale</b> (fino a un massimo di 6 <b>ferite mortali</b> per unità).",
+        "ja": "以下の手順を解決する：\n\n<b>1.</b> その自軍ユニットと<b>接敵状態</b>である敵ユニットを1個選択する。\n\n<b>2.</b> 選択した敵ユニットと<b>接敵状態</b>である自軍ユニット内の兵を1体選択する。\n\n<b>3.</b>その兵の【耐】と同じ数のD6をロールする：それぞれのダイスについて、ロール結果が1の場合はその自軍側ユニットが1ポイントの、ロール結果が5+の場合は選択した敵ユニットが1ポイントの<b>致命的ダメージ</b>を受ける（この効果で、同じユニットが受ける<b>致命的ダメージ</b>は最大6ポイントまで）。",
+        "ko": "다음 절차를 처리합니다.\n\n<b>1.</b> 이 유닛과 <b>교전 상태</b>인 적 유닛 하나를 지정합니다.\n\n<b>2.</b> 지정한 적 유닛과 <b>교전 상태</b>인 이 유닛의 모델 하나를 선택합니다.\n\n<b>3.</b> 그 모델의 내구 수치와 같은 개수의 D6를 굴립니다. 값이 1인 주사위 하나당 이 유닛이 1 <b>치명상</b>을 입습니다. 값이 5+인 주사위 하나당 그 적 유닛이 1 <b>치명상</b>을 입습니다(유닛 당 입는 <b>치명상</b>의 최대치는 6).",
+        "zh": "结算以下流程：\n\n<b>1.</b> 选择一个与目标单位处于<b>交战状态</b>的敌方单位。\n\n<b>2.</b> 选择目标单位中一个与那个敌方单位处于<b>交战状态</b>的模型。\n\n<b>3.</b> 掷相当于那个模型 T 属性数量的 D6：每有一个结果为 1，目标单位便受到 1 处<b>致命伤</b>；每有一个结果为 5+，那个敌方单位受到 1 处<b>致命伤</b>（每个单位以此方式能够受到最多 6 处<b>致命伤</b>）。"
+      },
+      "fluff": {
+        "en": "In extremis, armoured vehicles and rampaging monsters can use their sheer size as a weapon, ramming and crushing enemies beneath their colossal bulk, though doing so risks sustaining damage in return.",
+        "de": "Wenn es sein muss, können gepanzerte Fahrzeuge und tobende Monster ihre schiere Größe als Waffe einsetzen, in Feinde brechen und sie unter ihrer kolossalen Masse zermalmen, auch wenn es das Risiko birgt, selbst Schaden zu nehmen.",
+        "es": "In extremis, vehículos blindados y monstruos desbocados usan su enorme tamaño como arma, embistiendo y aplastando enemigos bajo su colosal volumen, aunque al hacerlo puedan sufrir daños a cambio.",
+        "fr": "En cas extrême, les blindés et les monstres peuvent utiliser leur carrure comme arme, éperonnant et broyant les ennemis sous leur masse colossale, mais ce n’est pas sans risque pour eux.",
+        "it": "Se necessario, i veicoli corazzati e i mostri inferociti possono sfruttare la mole come un’arma, speronando gli avversari e schiacciandoli sotto un peso colossale, anche se così rischiano di subire danni.",
+        "ja": "差し迫った状況下では、装甲車両や荒れ狂う怪物が、己の巨体を武器として用い、敵に激突して押しつぶしてしまうこともある。無論、そのような行動は自らを傷つける危険を伴う。",
+        "ko": "유사시 장갑차량이나 돌진하는 괴수는 엄청난 덩치를 무기 삼아 적들을 깔아뭉개 분쇄할 수 있다. 물론 그 대가로 피해를 감수해야 한다.",
+        "zh": "在极端情况下，装甲载具和狂暴的怪物能够将自己的体型作为武器，冲撞并碾压敌人，不过这么做也伴随着受到损伤的风险。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "b325f578-8416-542a-b4aa-d109c54e4951",
+      "name": {
+        "en": "Epic Challenge",
+        "de": "Epische Herausforderung",
+        "es": "Desafío épico",
+        "fr": "Défi Épique",
+        "it": "Sfida Epica",
+        "ja": "壮大なる決闘",
+        "ko": "장엄한 대결",
+        "zh": "史诗挑战"
+      },
+      "cost": 1,
+      "turn": "either",
+      "type": "Core Stratagem",
+      "phase": ["fight"],
+      "target": {
+        "en": "That <b>CHARACTER</b> unit.",
+        "de": "Jene <b>CHARAKTERMODELL</b>-Einheit",
+        "es": "Esa unidad <b>PERSONAJE</b>.",
+        "fr": "Cette unité de <b>PERSONNAGE</b>.",
+        "it": "Quell’unità <b>PERSONAGGIO</b>",
+        "ja": "その<b>キャラクター</b>・ユニット。",
+        "ko": "그 <b>캐릭터</b> 유닛.",
+        "zh": "那个<b>角色</b>单位。"
+      },
+      "when": {
+        "en": "Fight phase, just after a friendly <k>CHARACTER</k> unit is <b>selected to fight</b>.",
+        "de": "Nahkampfphase, unmittelbar nachdem eine befreundete <k>CHARAKTERMODELL</k>-Einheit <b>zum Kämpfen gewählt</b> wird",
+        "es": "En la fase de combate, justo después de que <b>se elija para combatir</b> una unidad <k>PERSONAJE</k> amiga.",
+        "fr": "À la phase de Combat, juste après qu'une unité de <k>PERSONNAGE</k> amie a été <b>choisie pour combattre</b>.",
+        "it": "Nella fase di Combattimento, subito dopo che un’unità <k>PERSONAGGIO</k> amica è stata <b>scelta per combattere</b>.",
+        "ja": "タイミング：白兵フェイズ中、味方<k>キャラクター</k>・ユニットが<b>白兵を宣言した</b>直後。",
+        "ko": "백병전 페이즈, 아군 <k>캐릭터</k> 유닛이 <b>백병전 수행을 위해 지정</b>된 직후.",
+        "zh": "近战阶段中，在一个己方<k>角色</k>单位<b>被选择进行近战</b>后。"
+      },
+      "effect": {
+        "en": "Select one <k>CHARACTER</k> model in your unit. Until the end of the phase, that model’s melee weapons have the <b>[PRECISION]</b> ability.",
+        "de": "Wähle ein <k>CHARAKTERMODELL</k> deiner Einheit. Bis zum Ende der Phase haben die Nahkampfwaffen jenes Modells die Fähigkeit <b>[PRÄZISION]</b>.",
+        "es": "Elige 1 miniatura <k>PERSONAJE</k> de tu unidad. Hasta el final de la fase, las armas de combate equipadas a esa miniatura tienen la habilidad <b>[PRECISIÓN]</b>.",
+        "fr": "Choisissez 1 figurine de <k>PERSONNAGE</k> de votre unité. Jusqu’à la fin de la phase, les armes de mêlée de cette figurine ont l’aptitude <b>[PRÉCISION]</b>.",
+        "it": "Scegli un modello di <k>PERSONAGGIO</k> della tua unità. Fino alla fine della fase, le armi da mischia di quel modello hanno l’abilità <b>[PRECISIONE]</b>.",
+        "ja": "その自軍ユニット内の<k>キャラクター</k>の兵1体を選択する。そのフェイズの終了時まで、その兵が装備している白兵武器は<b>［精密攻撃］</b>アビリティを持つ。",
+        "ko": "이 유닛의 <k>캐릭터</k> 모델 하나를 지정합니다. 페이즈가 종료될 때까지, 그 모델의 백병전 무기에 <b>[정밀]</b> 능력을 부여합니다.",
+        "zh": "效果：选择一个目标单位中的<k>角色</k>模型。直到阶段结束前，那个模型的近战武器拥有<b>[精准]</b>技能。"
+      },
+      "fluff": {
+        "en": "The legends of the 41st millennium are replete with deadly duels between mighty champions.",
+        "de": "Die Legenden des 41. Jahrtausends sind voller tödlicher Duelle zwischen mächtigen Streitern.",
+        "es": "Las leyendas del 41.ᵉʳ milenio están repletas de duelos mortales entre poderosos campeones.",
+        "fr": "Les légendes du 41ᵉ Millénaire abondent de duels mortels entre d’illustres champions.",
+        "it": "Le leggende del XLI millennio sono piene di duelli letali tra possenti campioni.",
+        "ja": "41千年紀の伝説には、強大な勇士たちによる決闘が数多く語られている。",
+        "ko": "41번째 천년기의 전설은 강대한 영웅들의 피 튀기는 대결로 점철되어 있다.",
+        "zh": "第 41 千年的传奇中充满了强大勇士之间的殊死对决。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "56a28416-baae-5f00-a540-62c244ee9c7b",
+      "name": {
+        "en": "Rapid Ingress",
+        "de": "Schneller Einsatz",
+        "es": "Inserción rápida",
+        "fr": "Arrivée Précipitée",
+        "it": "Inserzione Rapida",
+        "ja": "即応投入",
+        "ko": "신속 진입",
+        "zh": "迅速入场"
+      },
+      "cost": 1,
+      "turn": "opponents",
+      "type": "Core Stratagem",
+      "phase": ["movement"],
+      "target": {
+        "en": "One friendly unit that is in <b>strategic reserves</b> (excluding <k>AIRCRAFT</k>).",
+        "de": "Eine befreundete Einheit in <b>strategischer Reserve</b> (ausgenommen <k>FLUGZEUGE</k>)",
+        "es": "1 unidad amiga que esté en <b>reservas estratégicas</b> (salvo <k>AERONAVES</k>).",
+        "fr": "1 unité amie qui est en <b>réserve stratégique</b> (sauf les <k>AÉRODYNES</k>).",
+        "it": "Un’unità amica nelle <b>riserve strategiche</b> (esclusi gli <k>AEROMOBILI</k>).",
+        "ja": "<b>戦略的予備兵力</b>に配置されている味方ユニット1個（<k>航空機</k>を除く）。",
+        "ko": "<b>전략 예비대</b>(<k>항공기</k> 제외)에 속한 아군 유닛 하나.",
+        "zh": "目标：一个位于<b>战略预备队</b>中的己方单位（<k>飞行器</k>除外）。"
+      },
+      "when": {
+        "en": "End of your opponent’s Movement phase.",
+        "de": "Ende der Bewegungsphase deines Gegners",
+        "es": "Al final de la fase de movimiento del oponente.",
+        "fr": "À la fin de la phase de Mouvement adverse.",
+        "it": "Alla fine della fase di Movimento dell’avversario.",
+        "ja": "敵軍側移動フェイズ終了時。",
+        "ko": "상대의 이동 페이즈 종료 시.",
+        "zh": "在您对手的移动阶段结束时。"
+      },
+      "effect": {
+        "en": "Your unit makes an <b>ingress move</b> (20.04).",
+        "de": "Deine Einheit führt eine <b>Einsatzbewegung</b> aus (20.04).",
+        "es": "Tu unidad hace un <b>movimiento de inserción</b> (20.04).",
+        "fr": "Votre unité effectue un <b>mouvement d'insertion</b> (20.04).",
+        "it": "La tua unità effettua un <b>movimento di inserzione</b> (20.04).",
+        "ja": "その自軍ユニットは<b>突入移動</b>（20.04）を行う。",
+        "ko": "이 유닛이 <b>진입 이동</b>(20.04)을 수행합니다.",
+        "zh": "目标单位进行一次<b>入场移动</b>（20.04）。"
+      },
+      "restrictions": {
+        "en": "You cannot use this <b>stratagem</b> during the first battle round.",
+        "de": "Du kannst diese <b>Gefechtsoption</b> nicht in der ersten Schlachtrunde einsetzen.",
+        "es": "No puedes usar esta <b>estratagema</b> durante la primera ronda de batalla.",
+        "fr": "Vous ne pouvez pas utiliser ce <b>stratagème</b> pendant le premier round de bataille.",
+        "it": "Non puoi usare questo <b>stratagemma</b> durante il primo round di battaglia.",
+        "ja": "第1バトルラウンド中は、この<b>策略</b>を使用できない。",
+        "ko": "이 <b>스트라타젬</b>은 첫 번째 전투 라운드에 사용할 수 없습니다.",
+        "zh": "您不能在第一战斗轮次中使用本<b>计谋</b>。"
+      },
+      "fluff": {
+        "en": "Be it cunning strategy, potent technology or supernatural ritual, there are many means by which a commander may hasten their warriors’ onset.",
+        "de": "Ob durchdachte Strategie, machtvolle Technik oder widernatürliche Rituale, es gibt viele mögliche Methoden, wie ein Befehlshaber den Vormarsch seiner Truppen beschleunigen kann.",
+        "es": "Ya sea mediante una astuta estrategia, potente tecnología o un ritual sobrenatural, hay muchos medios por los que un comandante puede acelerar la llegada de sus guerreros.",
+        "fr": "Qu’il s’agisse de stratégie, de technologie ou de rituel surnaturel, nombreux sont les moyens par lesquels un commandant peut hâter l’arrivée de ses troupes.",
+        "it": "Astute strategie, potenti tecnologie o rituali sovrannaturali: sono molti gli strumenti con cui un comandante può rendere più rapido l’arrivo dei suoi guerrieri.",
+        "ja": "狡猾な戦略、強力な技術、あるいは霊的な儀式など、司令官は予備の戦力を臨機応変に投入するための様々な手段を有している。",
+        "ko": "교활한 책략이나 가공할 기술력, 초자연적 의식에 이르기까지, 전사들의 발걸음에 날개를 달아줄 수단은 다양하다.",
+        "zh": "无论是战略诡计、强大科技或是超凡仪式，一名指挥官拥有许多让手下战士们快速抵达战场的方法。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "e1005013-5751-54dd-a97c-fa38b5aea8cd",
+      "name": {
+        "en": "Heroic Intervention",
+        "de": "Heroische Intervention",
+        "es": "Intervención heroica",
+        "fr": "Intervention Héroïque",
+        "it": "Intervento Eroico",
+        "ja": "英雄的介入",
+        "ko": "영웅적 개입",
+        "zh": "英勇介入"
+      },
+      "cost": 1,
+      "turn": "opponents",
+      "type": "Core Stratagem",
+      "phase": ["charge"],
+      "target": {
+        "en": "One friendly <b>unengaged</b> unit within 12\" of one or more enemy units. You can only select a <k>VEHICLE</k> unit if it is a <k>CHARACTER/WALKER</k> unit.",
+        "de": "Eine befreundete Einheit, die <b>nicht im Nahkampf</b> und innerhalb von 12\" um mindestens eine feindliche Einheit ist. Du kannst eine <k>FAHRZEUG</k>-Einheit nur dann wählen, wenn sie eine <k>CHARAKTERMODELL-/LÄUFER</k>-Einheit ist.",
+        "es": "1 unidad amiga que <b>no esté trabada</b> y que esté a 12\" o menos de alguna unidad enemiga. Solo puedes elegir una unidad <k>VEHÍCULO</k> si además es <k>PERSONAJE/BÍPODE</k>.",
+        "fr": "1 unité <b>non engagée</b> amie à 12\" ou moins d’une ou plusieurs unités ennemies. Vous pouvez choisir une unité de <k>VÉHICULE</k> seulement si c’est une unité de <k>PERSONNAGE/MARCHEUR</k>.",
+        "it": "Un’unità <b>non ingaggiata</b> amica entro 12\" da una o più unità nemiche. Puoi scegliere un’unità <k>VEICOLO</k> solo se è un’unità <k>PERSONAGGIO/CAMMINATORE</k>.",
+        "ja": "1個以上の敵ユニットの12mv以内に一部でも入っている、味方<b>非接敵状態</b>のユニット1個。<k>ビークル</k>・ユニットを選択する場合は、そのユニットが<k>キャラクター/ウォーカー</k>・ユニットの場合のみ選択可能。",
+        "ko": "<b>교전 상태가 아니며</b> 적 유닛 하나 이상의 12\" 내에 있는 아군 유닛 하나. 단, <k>기체</k> 유닛을 지정하려면 그 유닛의 키워드에 <k>캐릭터/보행체</k>가 있어야 합니다.",
+        "zh": "一个位于一个或多个敌方单位 12\" 内，并且<b>不处于交战状态</b>的己方单位。您可以选择一个<k>载具</k>单位，前提是那个单位是一个<k>角色/机甲</k>单位。"
+      },
+      "when": {
+        "en": "End of your opponent’s Charge phase.",
+        "de": "Am Ende der Angriffsphase deines Gegners",
+        "es": "Al final de la fase de carga del oponente.",
+        "fr": "À la fin de la phase de Charge adverse.",
+        "it": "Alla fine della fase di Carica dell’avversario.",
+        "ja": "敵軍側突撃フェイズ開始時。",
+        "ko": "상대의 돌격 페이즈 종료 시.",
+        "zh": "在您对手的冲锋阶段结束时。"
+      },
+      "effect": {
+        "en": "<b>Resolve a charge</b> with your unit (11.02). While doing so, before making the <b>charge roll</b>, you must select <u>one</u> of the following modes:<ul><li><appref><b>Leap to Defend</b></li>: When selecting <b>charge targets</b>, you can only select enemy units that made a <b>charge move</b> this phase and are within the <b>maximum distance</b>.</li></ul>",
+        "de": "<b>Handle einen Angriff</b> mit deiner Einheit ab (11.02). Dabei musst du vor dem <b>Angriffswurf</b> <u>einen</u> der folgenden Modi wählen:<ul><li><appref><b>Zu Hilfe eilen</b></li>: Wenn du <b>Angriffsziele</b> wählst, kannst du nur feindliche Einheiten wählen, die in dieser Phase eine <b>Angriffsbewegung</b> ausgeführt haben und sich innerhalb der <b>maximalen Entfernung</b> befinden.</li></ul>",
+        "es": "<b>Resuelve una carga</b> con tu unidad (11.02). Al hacerlo, antes de hacer la <b>tirada de carga</b>, debes elegir <u>uno</u> de los siguientes modos:<ul><li><appref><b>A defender</b></li>: Al elegir los <b>blancos de la carga</b>, solo puedes elegir unidades enemigas que hayan hecho un <b>movimiento de carga</b> en esta fase y estén a la <b>distancia máxima</b> o menos.</li></ul>",
+        "fr": "<b>Résolvez une charge</b> avec votre unité (11.02). Ce faisant, avant de faire le <b>jet de charge</b>, vous devez choisir <u>1</u> des modes suivants :<ul><li><appref><b>Bondir pour Défendre</b></li> Quand vous choisissez des <b>cibles de charge</b>, vous pouvez seulement choisir des unités ennemies qui ont effectué un <b>mouvement de charge</b> à cette phase et qui sont dans la <b>distance maximale</b>.</li></ul>",
+        "it": "<b>Risolvi una carica</b> con la tua unità (11.02). Mentre lo fai, prima di effettuare il <b>tiro per caricare</b> devi scegliere <u>una</u> delle seguenti modalità:<ul><li><appref><b>Balzare per Difendere</b></li>: quando scegli i <b>bersagli della carica</b>, puoi selezionare solo unità nemiche che hanno effettuato un <b>movimento di carica</b> in questa fase e si trovano entro la <b>distanza massima</b>.</li></ul>",
+        "ja": "その自軍ユニットは<b>突撃を解決する</b>（11.02）。その突撃の間、<b>突撃ロール</b>を行う前に、以下のモードから<u>1つ</u>を選択しなければならない：<ul><li><appref><b>前進防衛</b></li>：<b>突撃対象</b>を選択する際、このフェイズ中に<b>突撃移動</b>を行っており、さらに<b>最大距離</b>の範囲内にいる敵ユニットのみを選択できる。</li></ul>",
+        "ko": "이 유닛으로 <b>돌격을 처리</b>합니다(11.02). 돌격을 처리할 때, <b>돌격 굴림</b>을 수행하기 전에 다음 하부 유형 중 <u>하나</u>를 선택해야 합니다.<ul><li><appref><b>방어의 도약</b></li>: <b>돌격 대상</b>을 지정할 때, 이번 페이즈에 <b>돌격 이동</b>을 수행했으며 <b>최대 거리</b> 내에 있는 적 유닛만 지정할 수 있습니다.</li></ul>",
+        "zh": "为目标单位<b>结算一次冲锋</b>（11.02)。在这么做时，在进行<b>冲锋掷骰</b>前，您必须选择以下<u>一个</u>模式：<ul><li><appref><b>前去防卫</b></li>：在选择<b>冲锋目标</b>时，您只能选择在本阶段中进行了<b>冲锋移动</b>并且位于<b>最大距离</b>内的敌方单位。</li></ul>"
+      },
+      "fluff": {
+        "en": "Voices raised in furious war cries, your warriors surge forth to meet the enemy’s onslaught head‑on.",
+        "de": "Wilde Kriegsschreie brüllend stürmen deine Krieger vor, um dem Angriff des Feindes zu begegnen.",
+        "es": "Tus guerreros alzan sus voces en furiosos gritos de guerra e interceptan la acometida del enemigo.",
+        "fr": "Des cris de guerre montent et vos guerriers se ruent tête baissée face à l’offensive adverse.",
+        "it": "Con le voci levate in furiose urla di guerra, i guerrieri avanzano a testa bassa verso i nemici all’assalto.",
+        "ja": "熾烈な咆哮をあげながら、戦士たちは敵の猛攻撃に真っ向からの対決を挑む。",
+        "ko": "전사들이 전투의 함성을 내지르며 적의 맹공에 정면으로 맞서 돌격한다.",
+        "zh": "随着愤怒的战吼，战士们向前冲去，主动迎击敌人的攻势。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "55e8e302-c2a2-57fb-852d-a88fbb95f6c2",
+      "name": {
+        "en": "Insane Bravery",
+        "de": "Wahnsinniger Mut",
+        "es": "Valor insensato",
+        "fr": "Courage Insensé",
+        "it": "Folle Coraggio",
+        "ja": "狂気の奮戦",
+        "ko": "광적인 용맹",
+        "zh": "疯狂之勇"
+      },
+      "cost": 1,
+      "turn": "your",
+      "type": "Core Stratagem",
+      "phase": ["charge"],
+      "target": {
+        "en": "That unit.",
+        "de": "Jene Einheit",
+        "es": "Esa unidad.",
+        "fr": "Cette unité.",
+        "it": "Quell’unità.",
+        "ja": "そのユニット。",
+        "ko": "그 유닛.",
+        "zh": "那个单位"
+      },
+      "when": {
+        "en": "Battle‑shock step of your Command phase, just before you make a <b>battle-shock roll</b> for a friendly unit.",
+        "de": "Im Schritt „Erschütterung“ deiner Befehlsphase, unmittelbar bevor du einen <b>Erschütterungswurf</b> für eine befreundete Einheit ausführst",
+        "es": "En el paso de acobardamiento de tu fase de mando, justo antes de hacer una <b>tirada de acobardamiento</b> para una unidad amiga.",
+        "fr": "À l’étape d’Ébranlement de votre phase de Commandement, juste avant que vous fassiez un <b>jet d'ébranlement</b> pour une unité amie.",
+        "it": "Nel passo Traumi della tua fase di Comando, subito prima di effettuare un <b>tiro per i traumi</b> per un’unità amica.",
+        "ja": "タイミング：自軍の指揮フェイズの戦闘ショックステップ中、味方ユニットが<b>戦闘ショックロール</b>を行う直前。",
+        "ko": "지휘 페이즈의 전투충격 단계, 아군 유닛의 <b>전투충격 굴림</b>을 수행하기 직전.",
+        "zh": "时机：己方指挥阶段的<b>战斗震慑</b>步骤中，在您为一个己方单位进行<b>战斗震慑掷骰</b>前。"
+      },
+      "effect": {
+        "en": "That <b>battle-shock roll</b>, is automatically successful",
+        "de": "Jener <b>Erschütterungswurf</b> gelingt automatisch.",
+        "es": "Esa <b>tirada de acobardamiento</b> tiene éxito automáticamente.",
+        "fr": "Ce <b>jet d'ébranlement</b>, est automatiquement réussi",
+        "it": "Quel <b>tiro per i traumi</b> ha automaticamente successo.",
+        "ja": "その<b>戦闘ショックロール</b>は自動的に成功する。",
+        "ko": "그 <b>전투충격 굴림</b>을 자동으로 성공합니다.",
+        "zh": "那次<b>战斗震慑掷骰</b>自动成功。"
+      },
+      "restrictions": {
+        "en": "You cannot use this <b>stratagem</b> more than once per battle.",
+        "de": "Du kannst diese <b>Gefechtsoption</b> nicht mehr als einmal pro Schlacht einsetzen.",
+        "es": "No puedes usar esta <b>estratagema</b> más de una vez por batalla.",
+        "fr": "Vous ne pouvez pas utiliser ce <b>stratagème</b> plus d'une fois par bataille.",
+        "it": "Non puoi usare questo <b>stratagemma</b> più di una volta per battaglia.",
+        "ja": "自軍はこの<b>策略</b>をバトル中1回限り使用できる。",
+        "ko": "이 <b>스트라타젬</b>은 전투 중 한 번만 사용할 수 있습니다.",
+        "zh": "您在每场战斗中使用本<b>计谋</b>的次数不能超过一次。"
+      },
+      "fluff": {
+        "en": "Indifferent to their own survival, these warriors hold their ground against seemingly impossible odds.",
+        "de": "Gleichgültig gegenüber dem eigenen Überleben halten diese Krieger scheinbar unmöglicher Übermacht stand.",
+        "es": "A estos guerreros no les importa su propia supervivencia, y mantienen el terreno contra todo pronóstico.",
+        "fr": "Indifférents à leur propre survie, ces guerriers tiennent leurs positions envers et contre tout.",
+        "it": "Incuranti della propria sopravvivenza, questi guerrieri mantengono la posizione contro avversità che sembrano insormontabili.",
+        "ja": "戦士たちは自身の命をも顧みず、不可能と思われる困難に立ち向かってゆく。",
+        "ko": "자신의 안위는 개의치 않은 채, 전사들은 불가능에 맞서며 물러서지 않는다.",
+        "zh": "这些战士根本没有考虑自身的安危，就算在敌众我寡的情况下也能坚持战斗。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "d20903b0-10e0-554d-916c-650fc6127821",
+      "name": {
+        "en": "Smokescreen",
+        "de": "Rauchvorhang",
+        "es": "Pantalla de humo",
+        "fr": "Écran de Fumée",
+        "it": "Coltre di Fumo",
+        "ja": "煙幕",
+        "ko": "연막",
+        "zh": "烟幕"
+      },
+      "cost": 1,
+      "turn": "opponents",
+      "type": "Core Stratagem",
+      "phase": ["shooting"],
+      "target": {
+        "en": "One friendly <k>SMOKE</k> unit.",
+        "de": "Eine befreundete <k>RAUCH</k>-Einheit",
+        "es": "Una unidad <k>HUMO</k> amiga.",
+        "fr": "1 unité à <k>FUMÉE</k> amie.",
+        "it": "Un’unità con <k>FUMO</k> amica.",
+        "ja": "味方の<k>煙幕</k>・ユニット1個。",
+        "ko": "아군의 <k>연막탄</k> 유닛 하나.",
+        "zh": "一个己方<k>烟幕</k>单位"
+      },
+      "when": {
+        "en": "Start of your opponent’s Shooting phase.",
+        "de": "Zu Beginn der Fernkampfphase deines Gegners",
+        "es": "Al inicio de la fase de disparo del oponente.",
+        "fr": "Au début de la phase de Tir adverse.",
+        "it": "All’inizio della fase di Tiro dell’avversario.",
+        "ja": "敵軍側射撃フェイズ開始時。",
+        "ko": "상대의 사격 페이즈 시작 시.",
+        "zh": "在您对手的射击阶段开始时。"
+      },
+      "effect": {
+        "en": "Until the end of the phase, each time an attack targets either your <k>SMOKE</k> unit, or a unit that is <u>not</u> <b>fully visible</b> to the attacking model because of one or more models in your <k>SMOKE</k> unit, the target has the <b>benefit of cover</b> against that attack (13.08).",
+        "de": "Bis zum Ende der Phase profitiert bei jeder Attacke, deren Ziel deine <k>RAUCH</k>-Einheit ist oder eine Einheit, die durch mindestens ein Modell deiner <k>RAUCH</k>-Einheit für das attackierende Modell <u>nicht</u> <b>vollständig sichtbar</b> ist, das Ziel <b>von Deckung</b> (13.08).",
+        "es": "Hasta el final de la fase, siempre que un ataque tome como blanco tu unidad <k>HUMO</k> o una unidad que <u>no</u> sea <b>completamente visible</b> para la miniatura atacante debido a alguna miniatura de tu unidad <k>HUMO</k>, el blanco <b>se beneficia de cobertura</b> contra ese ataque (13.08).",
+        "fr": "Jusqu'à la fin de la phase, à chaque attaque qui cible soit votre unité à <k>FUMÉE</k>, soit une unité qui <u>n’est pas</u> <b>entièrement visible</b> de la figurine attaquante à cause d’une ou plusieurs figurines de votre unité à <k>FUMÉE</k>, la cible a le <b>bénéfice du couvert</b> contre l’attaque (13.08).",
+        "it": "Fino alla fine della fase, ogni volta che un attacco ha come bersaglio la tua unità con <k>FUMO</k>, o un’unità che <u>non</u> è <b>completamente visibile</b> al modello attaccante a causa di uno o più modelli della tua unità con <k>FUMO</k>, il bersaglio ha il <b>beneficio della copertura</b> contro quell’attacco (13.08).",
+        "ja": "そのフェイズ終了時まで、その自軍の<k>煙幕</k>・ユニットか、その<k>煙幕</k>ユニット内の兵1体以上によって攻撃側の兵が<b>完全視認</b>を<u>妨げられている</u>状態のユニットを対象にした攻撃が行われた場合、攻撃対象はその攻撃に対して<b>遮蔽物ボーナス</b>（13.08）を得る。",
+        "ko": "페이즈가 종료될 때까지, 아군 <k>연막탄</k> 유닛이 공격의 대상으로 지정될 때, 또는 아군 <k>연막탄</k> 유닛의 모델 하나 이상으로 인해 공격하는 모델이 <b>완전한 시야를 확보</b>하지 <u>못한</u> 다른 유닛이 그 공격의 대상으로 지정될 때, 대상은 그 공격에만 적용되는 <b>엄폐 효과</b>를 받습니다(13.08).",
+        "zh": "直到阶段结束前，每当目标<k>烟幕</k>单位受到攻击，或者一个因为目标<k>烟幕</k>单位中的一个或多个模型而导致自身对攻击模型<u>不</u><b>完全可见</b>的单位受到攻击时，攻击目标针对那次攻击拥有<b>掩体增益</b>（13.08）。"
+      },
+      "fluff": {
+        "en": "Even the most skilled marksmen struggle to hit targets veiled by billowing screens of smoke.",
+        "de": "Selbst fähigste Schützen haben Probleme damit, durch dichte Rauchwolken verborgene Ziele zu treffen.",
+        "es": "Incluso los tiradores más hábiles tienen dificultades para acertar a los blancos ocultos por el humo.",
+        "fr": "Le plus habile aura du mal à toucher une cible voilée par un nuage de fumée.",
+        "it": "Persino i tiratori più abili faticano a colpire i bersagli celati dietro una fitta coltre di fumo.",
+        "ja": "いかに熟練した射手であれ、煙幕に隠れた標的を撃つのは至難の業だ。",
+        "ko": "자욱한 연막에 숨은 표적은 최고의 저격수조차 쉬이 명중하기 어렵다.",
+        "zh": "在烟幕中，再出色的神枪手也难以命中目标。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "d1148b3e-b26a-5483-83f4-a07492a9e982",
+      "name": {
+        "en": "Explosives",
+        "de": "Sprengsätze",
+        "es": "Explosivos",
+        "fr": "Explosifs",
+        "it": "Esplosivi",
+        "ja": "爆発物",
+        "ko": "폭발물",
+        "zh": "炸药"
+      },
+      "cost": 1,
+      "turn": "your",
+      "type": "Core Stratagem",
+      "phase": ["shooting"],
+      "target": {
+        "en": "One friendly <b>unengaged</b> <k>EXPLOSIVES/GRENADES</k> unit that is <b>eligible to shoot</b> and did not make an <b>advance move</b> this turn.",
+        "de": "Eine befreundete <k>SPRENGSÄTZE-/GRANATEN</k>-Einheit, die <b>nicht im Nahkampf</b> ist, <b>zum Schießen infrage</b> kommt und in diesem Zug keine <b>Vorrückenbewegung</b> ausgeführt hat",
+        "es": "1 unidad <k>EXPLOSIVOS/GRANADAS</k> amiga que <b>no esté trabada</b>, que sea <b>apta para disparar</b>, y que no haya hecho un <b>movimiento de avanzar</b> en este turno.",
+        "fr": "1 unité à <k>EXPLOSIFS/GRENADES</k> <b>non engagée</b> amie qui est <b>éligible pour tirer</b> et n'a pas fait de <b>mouvement d'avance</b> à ce tour.",
+        "it": "Un’unità <b>non ingaggiata</b> con <k>ESPLOSIVI/GRANATE</k> amica <b>idonea a tirare</b> e che non ha effettuato un <b>movimento di avanzata</b> in questo turno.",
+        "ja": "対象：このターン中に<b>全力移動</b>を行っておらず<b>射撃を宣言可能</b>な、<b>非接敵状態</b>の味方<k>爆発物/グレネード</k>・ユニット1個。",
+        "ko": "<b>교전 상태가 아니고</b>, 이번 턴에 <b>급속 이동</b>을 수행하지 않았으며, <b>사격 수행이 가능</b>한 아군 <k>폭발물/수류탄</k> 유닛 하나.",
+        "zh": "在回合中没有进行过<b>突进移动</b>，<b>可以进行射击</b>，并且<b>不处于交战状态</b>的一个己方<k>炸药/手雷</k>单位。"
+      },
+      "when": {
+        "en": "Your Shooting phase.",
+        "de": "Deine Fernkampfphase",
+        "es": "En tu fase de disparo.",
+        "fr": "À votre phase de Tir.",
+        "it": "Nella tua fase di Tiro.",
+        "ja": "自軍側射撃フェイズ中。",
+        "ko": "플레이어의 사격 페이즈.",
+        "zh": "在您的射击阶段中。"
+      },
+      "effect": {
+        "en": "Resolve the following sequence:\n<b>1.</b> Select one EXPLOSIVES/GRENADES model in your unit.\n<b>2.</b> Select one <b>unengaged</b> enemy unit within 8\" of and <b>visible</b> to that model.\n<b>3.</b> Roll six D6: for each 4+, that enemy unit suffers 1 <b>mortal wound</b> (06.02).",
+        "de": "Handle die folgende Abfolge ab:\n<b>1.</b> Wähle ein <k>SPRENGSÄTZE-/GRANATEN</k>-Modell deiner Einheit.\n<b>2.</b> Wähle eine feindliche Einheit, die <b>nicht im Nahkampf</b> ist, sich innerhalb von 8\" um jenes Modell befindet und für es <b>sichtbar</b> ist.\n<b>3.</b> Wirf sechs W6: Für jede 4+ erleidet jene feindliche Einheit 1 <b>tödliche Verwundung</b> (06.02).",
+        "es": "Sigue esta secuencia:\n<b>1.</b> Elige 1 miniatura <k>EXPLOSIVOS/GRANADAS</k> de tu unidad.\n<b>2.</b> Elige 1 unidad enemiga que <b>no esté trabada</b>, que esté a 8\" o menos de esa miniatura, y que sea visible para ella.\n<b>3.</b> Tira seis D6: esa unidad enemiga sufre 1 <b>herida mortal</b> (06.02) por cada 4+.",
+        "fr": "Résolvez la séquence suivante :\n<b>1.</b> Choisissez 1 figurine à EXPLOSIFS/GRENADES de votre unité.\n<b>2.</b> Choisissez 1 unité ennemie <b>non engagée</b> à 8\" ou moins et <b>visible</b> de cette figurine.\n<b>3.</b> Jetez six D6 : pour chaque 4+, cette unité ennemie subit 1 <b>blessure mortelle</b> (06.02).",
+        "it": "Risolvi la sequenza in basso:\n<b>1.</b> Scegli un modello con ESPLOSIVI/GRANATE della tua unità.\n<b>2</b>. Scegli un’unità nemica <b>non ingaggiata</b> entro 8\" da quel modello e <b>visibile</b> a esso.\n<b>3.</b> Tira sei D6: per ogni 4+ quell’unità nemica subisce 1 <b>ferita mortale</b> (06.02).",
+        "ja": "以下の手順を解決する：\n<b>1.</b> その自軍ユニット内の爆発物/グレネードの兵を1体選択する。\n<b>2.</b> 選択した兵の8mv以内に一部でも入っており、<b>視認可能</b>で、<b>非接敵状態</b>の敵ユニットを1個選択する。\n<b>3.</b> その後、D6を6個ロールする。ロール結果で4+が出るたび、選択された敵ユニットは1ポイントの<b>致命的ダメージ</b>を受ける (06.02)。",
+        "ko": "다음 절차를 처리합니다.\n<b>1.</b> 이 유닛의 폭발물/수류탄 모델 하나를 지정합니다.\n<b>2.</b> 그 모델의 8\" 내에 있고 <b>시야에 들어가며</b> <b>교전 상태가 아닌</b> 적 유닛 하나를 지정합니다.\n<b>3.</b> D6를 여섯 개 굴립니다. 값이 4+인 주사위 하나당 그 적 유닛이 1 <b>치명상</b>(06.02)을 입습니다.",
+        "zh": "结算以下流程：\n<b>1.</b> 选择目标单位中的一个<b>炸药/手雷</b>模型。\n<b>2.</b> 选择一个位于那个模型 8\" 内，对其<b>可见</b>，并且<b>不处于交战状态</b>的敌方单位。\n<b>3.</b> 掷六枚 D6：每有一个结果为 4+，那个敌方单位便受到 1 处<b>致命伤</b>（06.02）。"
+      },
+      "fluff": {
+        "en": "Priming grenades or other explosives, these warriors draw back and hurl death into the enemy’s midst.",
+        "de": "Diese Krieger machen Granaten oder andere Sprengsätze bereit, holen aus und schleudern sie mitten zwischen ihre Feinde.",
+        "es": "Tras preparar granadas u otros explosivos, estos guerreros cogen impulso y arrojan muerte en medio del enemigo.",
+        "fr": "Armant leurs grenades et autres explosifs, ces guerriers reculent et envoient la mort au beau milieu de l’ennemi.",
+        "it": "Dopo aver innescato le granate o altri esplosivi, questi guerrieri arretrano e fanno piovere morte tra i nemici.",
+        "ja": "この戦士たちはグレネードや爆発物を作動させ、後退した後に敵の中心に向かって投射し、死をもたらす。",
+        "ko": "한 걸음 뒤에서 전사들이 수류탄과 같은 폭발물을 점화하여 적 대열의 한복판에 죽음을 투척한다.",
+        "zh": "战士们激活手雷和其他爆破物，向敌群投掷过去。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "37babc95-e394-52ab-8fcf-9b5f95dd9325",
+      "name": {
+        "en": "Counteroffensive",
+        "de": "Gegenoffensive",
+        "es": "Contraofensiva",
+        "fr": "Contre-offensive",
+        "it": "Controffensiva",
+        "ja": "反攻戦術",
+        "ko": "역공",
+        "zh": "反攻"
+      },
+      "cost": 2,
+      "turn": "opponents",
+      "type": "Core Stratagem",
+      "phase": ["fight"],
+      "target": {
+        "en": "One friendly unit that is <b>eligible to fight</b>.",
+        "de": "Eine befreundete Einheit, die <b>zum Kämpfen infrage</b> kommt",
+        "es": "1 unidad amiga <b>apta para combatir</b>.",
+        "fr": "1 unité amie qui est <b>éligible pour combattre</b>.",
+        "it": "Un’unità amica <b>idonea a combattere</b>.",
+        "ja": "<b>白兵を宣言可能</b>な味方ユニット1個。",
+        "ko": "<b>백병전 수행이 가능</b>한 아군 유닛 하나.",
+        "zh": "一个<b>可以进行近战</b>的己方单位。"
+      },
+      "when": {
+        "en": "Fight step of your opponent’s Fight phase, just after an enemy unit has resolved its attacks.",
+        "de": "Im Schritt „Kämpfen“ der gegnerischen Nahkampfphase, unmittelbar nachdem eine feindliche Einheit ihre Attacken abgehandelt hat",
+        "es": "En el paso Combatir de la fase de combate del oponente, justo después de que una unidad enemiga haya resuelto sus ataques.",
+        "fr": "À l’étape Combattre de la phase de Combat adverse, juste après qu’une unité ennemie a résolu ses attaques.",
+        "it": "Nel passo Combattere della fase di Combattimento dell’avversario, subito dopo che un’unità nemica ha risolto i propri attacchi.",
+        "ja": "敵軍側白兵フェイズの白兵ステップ中、いずれかの敵ユニットが攻撃を解決した直後。",
+        "ko": "상대 백병전 페이즈의 백병전 단계, 적 유닛 하나가 공격 처리를 종료한 직후.",
+        "zh": "对手近战阶段的近战步骤中，在一个敌方单位的攻击结算完成后。"
+      },
+      "effect": {
+        "en": "Until the end of the phase, your unit has the <b>Fights First</b> ability and it must be the next unit you <b>select to fight</b> (12.04).",
+        "de": "Bis zum Ende der Phase hat deine Einheit die Fähigkeit <b>Erstschlag</b> und sie muss die nächste Einheit sein, die du <b>zum Kämpfen wählst</b> (12.04).",
+        "es": "Hasta el final de la fase, tu unidad tiene la habilidad <b>Combatir primero</b> y debe ser la siguiente unidad que <b>eliges para combatir</b> (12.04).",
+        "fr": "Jusqu'à la fin de la phase, votre unité a l'aptitude <b>Combat en Premier</b> et elle doit être la prochaine unité que vous <b>choisissez pour combattre</b> (12.04).",
+        "it": "Fino alla fine della fase la tua unità ha l’abilità <b>Combatte per Prima</b> e deve essere la prossima unità che <b>scegli per combattere</b> (12.04).",
+        "ja": "そのフェイズ終了時まで、その自軍ユニットは<b>『先手』</b>アビリティを持つ。自軍は、次にそのユニットで<b>白兵を宣言</b>（12.04）しなければならない。",
+        "ko": "페이즈가 종료될 때까지, 이 유닛에 <b>선제공격</b> 능력을 부여하며, 다음으로 <b>백병전 수행을 위해 지정</b>하는 유닛은 반드시 이 유닛이어야 합니다.",
+        "zh": "直到阶段结束前，目标单位拥有<b>先攻</b>技能，并且必须是下一个被您<b>选择进行近战</b>的单位（12.04）。"
+      },
+      "fluff": {
+        "en": "In close‑quarters combat, the slightest hesitation can leave an opening for a swift foe to exploit.",
+        "de": "Im Nahkampf kann schon das kleinste Zögern eine Gelegenheit eröffnen, die ein schneller Feind geschickt ausnutzen wird.",
+        "es": "En combate cuerpo a cuerpo, la más mínima duda puede dejar una abertura aprovechable para un enemigo avispado.",
+        "fr": "En combat rapproché, la moindre hésitation peut laisser entrevoir une faille à exploiter.",
+        "it": "Nel combattimento ravvicinato persino la minima esitazione lascia un punto scoperto che un nemico rapido può sfruttare.",
+        "ja": "白兵においては、わずかな躊躇いが命取りになる。",
+        "ko": "근접전에서는 약간의 망설임조차 민첩한 적에게 틈새를 보이게 할 수 있다.",
+        "zh": "在近距离战斗中，最为短暂的犹豫也会让迅速的敌人趁机进攻。"
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    },
+    {
+      "id": "0f9b69bd-a7e0-5e3d-b3fc-d0440c30269c",
+      "name": {
+        "en": "New Orders"
+      },
+      "cost": 1,
+      "turn": "your",
+      "type": "Strategic Ploy",
+      "phase": ["command"],
+      "target": {
+        "en": "One of your active Secondary Mission cards."
+      },
+      "when": {
+        "en": "End of your Command phase."
+      },
+      "effect": {
+        "en": "Discard it and draw one new Secondary Mission card."
+      },
+      "fluff": {
+        "en": "High command has received new intelligence."
+      },
+      "faction_id": null,
+      "detachment": "",
+      "detachment_id": null,
+      "detachment_faction": "",
+      "source": "40k-11e"
+    }
+  ]
+}

--- a/11th/gdc/core/chapter_approved.json
+++ b/11th/gdc/core/chapter_approved.json
@@ -13,7 +13,7 @@
   "source": "40k-11e",
   "cardType": "coreRules",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:07.169Z",
+  "updated": "2026-07-28T17:03:27.637Z",
   "isCombatPatrol": false,
   "sections": [
     {

--- a/11th/gdc/core/combat_patrol.json
+++ b/11th/gdc/core/combat_patrol.json
@@ -13,7 +13,7 @@
   "source": "40k-11e",
   "cardType": "coreRules",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:07.136Z",
+  "updated": "2026-07-28T17:03:27.602Z",
   "isCombatPatrol": false,
   "sections": [
     {

--- a/11th/gdc/core/core_rules.json
+++ b/11th/gdc/core/core_rules.json
@@ -13,7 +13,7 @@
   "source": "40k-11e",
   "cardType": "coreRules",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:07.112Z",
+  "updated": "2026-07-28T17:03:27.566Z",
   "isCombatPatrol": false,
   "sections": [
     {

--- a/11th/gdc/core/event_companion.json
+++ b/11th/gdc/core/event_companion.json
@@ -13,7 +13,7 @@
   "source": "40k-11e",
   "cardType": "coreRules",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:07.158Z",
+  "updated": "2026-07-28T17:03:27.624Z",
   "isCombatPatrol": false,
   "sections": [
     {

--- a/11th/gdc/darkangels.json
+++ b/11th/gdc/darkangels.json
@@ -7,7 +7,7 @@
     "header": "#013a17"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:48.851Z",
+  "updated": "2026-07-28T17:03:00.035Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "rules": {
@@ -1900,7 +1900,7 @@
   ],
   "enhancements": [
     {
-      "id": "99395e02-e91d-5390-ad8e-d6472839ad61",
+      "id": "793ae3ec-6d6d-59b0-9dfc-e564420d8cfb",
       "name": {
         "en": "Limitless Zeal",
         "de": "Grenzenlos fanatisch",
@@ -1914,6 +1914,7 @@
       "cost": "10",
       "keywords": ["Chaplain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Chaplain</k> model only. This unit has +1 to <b>charge rolls</b>.",
         "de": "Nur für ein <k>Ordenspriester</k>-Modell. Diese Einheit hat +1 auf <b>Angriffswürfe</b>.",
@@ -1932,7 +1933,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "09932d7d-2d4d-5ec0-9dfd-91dfc049051e",
+      "id": "a0ed4377-f487-59d0-b4f5-34f81986f310",
       "name": {
         "en": "Thundercowl Turbines (Upgrade)",
         "de": "Donnerschleierturbinen (Aufwertung)",
@@ -1946,6 +1947,7 @@
       "cost": "15",
       "keywords": ["Fly", "Ravenwing"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Ravenwing Fly</k> unit only. In your first Movement phase, this unit can make an <b>ingress move</b>.",
         "de": "Nur für eine <k>fliegende Ravenwing</k>-Einheit. In deiner ersten Bewegungsphase kann diese Einheit eine <b>Einsatzbewegung</b> ausführen.",
@@ -1964,7 +1966,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b0bd82e0-9ae9-52a6-b952-6d35e44b64e1",
+      "id": "c3fd9eab-b3e7-5174-ac62-dcc52ee25eb5",
       "name": {
         "en": "Nightforged Battery (Upgrade)",
         "de": "Nachtgeschmiedete Batterie (Aufwertung)",
@@ -1978,6 +1980,7 @@
       "cost": "15",
       "keywords": ["Dark Angels"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Land Speeder Vengeance</k> unit only. This unit can re‑roll:\r<ul><li>Rolls to determine the <b>A</b> of a weapon.</li>\r<li><b>Hazard rolls</b>.</li></ul>",
         "de": "Nur für eine <k>Land-Speeder-Vengeance</k>-Einheit. Für diese Einheit können folgende Würfe wiederholt werden:\n<ul><li>Würfe zum Bestimmen der <b>A</b> einer Waffe.</li>\n<li><b>Risikowürfe</b>.</li></ul>",
@@ -1996,7 +1999,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fb5c0d84-8d90-57b7-b5b3-6e457fa8705a",
+      "id": "330b292c-c6be-564c-ba84-0824758e1bcb",
       "name": {
         "en": "Petition of Stability (Upgrade)",
         "de": "Stabilitätsgesuch (Aufwertung)",
@@ -2010,6 +2013,7 @@
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Adeptus Astartes</k> unit only. This unit’s <b>plasma</b> attacks have +6\" <b>R</b>.",
         "de": "Nur für eine <k>Adeptus-Astartes</k>-Einheit. Die <b>Plasma</b>-Attacken dieser Einheit haben +6\" <b>Reichw.</b>",
@@ -2028,7 +2032,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9bd38b95-b8be-58f6-8b3f-5adc44b3ce6d",
+      "id": "cf733a68-2453-5724-9d19-32b5ec07aedc",
       "name": {
         "en": "Entreaty of Perpetual Ardour (Upgrade)",
         "de": "Erflehen unauslöschlichen Eifers (Aufwertung)",
@@ -2042,6 +2046,7 @@
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Hellblaster Squad</k> only. This unit’s <b>snap shooting</b> attacks hit on unmodified <b>hit rolls</b> of 5+.",
         "de": "Nur für eine <k>Plasma-Interfectortrupp</k>-Einheit. <b>Eiliger-Beschuss</b>-Attacken dieser Einheit treffen bei unmodifizierten <b>Trefferwürfen</b> von 5+.",
@@ -2060,7 +2065,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8c060a41-6c3d-500c-989d-599be6ba0ef1",
+      "id": "e28263f6-2296-5223-99b6-9cf5a6e17861",
       "name": {
         "en": "Inescapable Interrogation",
         "de": "Unausweichliche Befragung",
@@ -2074,6 +2079,7 @@
       "cost": "20",
       "keywords": ["Chaplain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Chaplain</k> model only. This unit’s ranged attacks have <k>[Ignores Cover]</k>.",
         "de": "Nur für ein <k>Ordenspriester</k>-Modell. Die Fernkampfattacken dieser Einheit haben <k>[Deckung ignorieren]</k>.",
@@ -2092,13 +2098,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9c4014e7-59c4-5d25-a638-c1beae9d4419",
+      "id": "b8e5f60e-910d-5852-9a4b-2fa5f15e97a8",
       "name": {
         "en": "Shroud of Heroes"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. (Once per battle, per army) When this model is **destroyed**, at the end of the phase, roll one D6:\n▪ On a 2+, set up this model on the battlefield, **unengaged** and as close as possible to where it was **destroyed**. This model is not part of an **attached** unit and its unit has a **starting strength** of 1. This model has 3 wounds remaining, or its full wounds remaining if this model was **battle-shocked** when it was **destroyed**."
       },
@@ -2110,13 +2117,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e2a964f7-bd8b-5b38-8fae-9fd8d0ff2bbd",
+      "id": "14f870ba-8d76-5b39-8a21-1a8826fbd76a",
       "name": {
         "en": "Stubborn Tenacity"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, each time a model in that unit makes an attack, add 1 to the Hit roll if that unit is below its Starting Strength, and add 1 to the Wound roll as well if that unit is Battle-shocked and below its Starting Strength."
       },
@@ -2128,13 +2136,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dd8fc691-2a2d-51d8-a637-68210c4f82cb",
+      "id": "64bc284a-3168-50fa-b6b4-6f707fc9ece4",
       "name": {
         "en": "Weapons of the First Legion"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks, Strength and Damage characteristics of the bearer’s melee weapons. While the bearer is Battle-shocked, add 2 to the Attacks, Strength and Damage characteristics of the bearer’s melee weapons instead."
       },
@@ -2146,13 +2155,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "28e163fe-ea72-51bc-bf84-7e690ce5b210",
+      "id": "e51576d7-2dfb-5b1c-803b-e78810a201c0",
       "name": {
         "en": "Pennant of Remembrance"
       },
       "cost": "10",
       "keywords": ["Ancient", "Bladeguard Ancient"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ANCIENT** model only. While the bearer is leading a unit, models in that unit have the Feel No Pain 6+ ability. While that unit is Battle-shocked, models in that unit have the Feel No Pain 4+ ability instead."
       },
@@ -2164,13 +2174,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "889709b9-f03c-5e1f-aeb0-243195903649",
+      "id": "2694b15a-fd6d-54ef-88c3-2adc17193af6",
       "name": {
         "en": "Champion of the Deathwing"
       },
       "cost": "15",
       "keywords": ["Deathwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATHWING** model only. Melee weapons equipped by the bearer have the **[LETHAL HITS]** ability, and each time the bearer makes a melee attack, if it is within range of your Vowed objective marker, a Critical Hit is scored on an unmodified Hit roll of 5+."
       },
@@ -2182,13 +2193,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bda3688d-5543-5b3d-a8d9-ac2d0440d95e",
+      "id": "73051580-cffe-55fb-b517-7a031d684671",
       "name": {
         "en": "Eye of the Unseen"
       },
       "cost": "10",
       "keywords": ["Deathwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATHWING** model only. Each time you target the bearer’s unit with a Stratagem, roll one D6, adding 1 if the bearer is within range of your Vowed objective marker: on a 5+, you gain 1CP."
       },
@@ -2200,13 +2212,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "92b7c3dc-87b8-579e-8461-5235d0516b7e",
+      "id": "f598cc52-f48c-52ef-9a83-647b4ecf69e0",
       "name": {
         "en": "Singular Will"
       },
       "cost": "20",
       "keywords": ["Deathwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATHWING** model only. Each time the bearer’s unit Piles In or Consolidates, models in that unit can move an additional 3\"."
       },
@@ -2218,13 +2231,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c778992-81c4-558f-8504-39ad4ca59aec",
+      "id": "a4e6c46f-24e8-545c-906e-6a5ddfa489bc",
       "name": {
         "en": "Deathwing Assault"
       },
       "cost": "30",
       "keywords": ["Deathwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATHWING** model with the Deep Strike ability only. The bearer’s unit can be set up using the Deep Strike ability in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules."
       },
@@ -2236,13 +2250,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "367a8014-6f48-5135-8813-4009826172e5",
+      "id": "729697e1-ab1c-57fa-b8fc-306944cef46a",
       "name": {
         "en": "Master-crafted Weapon"
       },
       "cost": "10",
       "keywords": ["Ravenwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**RAVENWING** model only. Melee weapons equipped by the bearer have the **[PRECISION]** ability."
       },
@@ -2254,13 +2269,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "df42b551-8621-5ae9-9dd1-63f9550d9849",
+      "id": "b06d3c5a-f692-5427-bc16-583d493040f1",
       "name": {
         "en": "Mounted Strategist"
       },
       "cost": "30",
       "keywords": ["Ravenwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**RAVENWING** model only. You can re-roll Advance and Charge rolls made for the bearer’s unit."
       },
@@ -2272,13 +2288,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ac8cc6cd-09be-5c22-8b7f-a256e4a022a5",
+      "id": "31f46dce-1bad-59a8-83d4-e5e0775ad882",
       "name": {
         "en": "Master of Manoeuvre"
       },
       "cost": "15",
       "keywords": ["Ravenwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**Ravenwing** model only. If the bearer’s unit starts the battle in Strategic Reserves, its points value does not count towards the combined points limit for units from your army that are in Strategic Reserve, and for the purposes of setting up that unit on the battlefield, treat the current battle round number as being one higher than it actually is."
       },
@@ -2290,13 +2307,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9b73eac9-4f80-50bf-b268-0196ff571d61",
+      "id": "15247bb5-72dd-50b3-80ea-b93d7534a175",
       "name": {
         "en": "Recon Hunter"
       },
       "cost": "20",
       "keywords": ["Ravenwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**RAVENWING** model only. Models in the bearer’s unit have the Scouts 9\" ability."
       },
@@ -2308,13 +2326,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ff29ccdb-291f-5d03-9562-8c4e32decb99",
+      "id": "b5d37345-de0b-5559-930a-f107e5dee9cf",
       "name": {
         "en": "Calibanite Armaments"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Damage characteristic of the bearer’s melee weapons."
       },
@@ -2326,13 +2345,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "13ef326e-8145-57b6-8e90-44d7662d3c2d",
+      "id": "08cd6939-399e-5351-9a94-2749f24fc2ce",
       "name": {
         "en": "Lord of the Hunt"
       },
       "cost": "15",
       "keywords": ["Ravenwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**RAVENWING** model only. The bearer’s unit is eligible to shoot and declare a charge in a turn in which it Fell Back and you can re‑roll Desperate Escape tests taken for models in the bearer’s unit."
       },
@@ -2344,13 +2364,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d2ce8304-6b98-5ef4-95be-55b026b57a33",
+      "id": "36f98806-41c1-5ceb-844f-416d6fc48c89",
       "name": {
         "en": "Stalwart Champion"
       },
       "cost": "15",
       "keywords": ["Captain", "Lieutenant", "Chaplain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CAPTAIN**, **CHAPLAIN** or **LIEUTENANT** model only. While the bearer’s unit is not Battle‑shocked, add 1 to the Objective Control characteristic of models in the bearer’s unit."
       },
@@ -2362,13 +2383,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "64d1c02a-a7e4-578b-aef6-86cfba1a0af7",
+      "id": "472ce887-c7e0-5060-a1d9-e29fcc85ae53",
       "name": {
         "en": "Fulgus Magna"
       },
       "cost": "20",
       "keywords": ["Deathwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATHWING** model only. Once per battle, at the end of your opponent’s turn, if the bearer’s unit is not within Engagement Range of one or more enemy units, the bearer can use this Enhancement. If it does, remove the bearer’s unit from the battlefield and place it into Strategic Reserves."
       },
@@ -2380,13 +2402,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b209832f-0a51-58d9-9664-dd2f59a9abea",
+      "id": "2db303c9-bf24-554d-a834-a8b67f55fca3",
       "name": {
         "en": "Tempered in Battle (Aura)"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While a friendly **ADEPTUS ASTARTES** unit is within 6\" of this model, you can re-roll Battle-shock and Leadership tests taken for that unit."
       },
@@ -2398,13 +2421,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "df176021-16b9-5d39-bed0-830aa98ac551",
+      "id": "65f84628-2383-5b5f-bd67-ea4467187c0e",
       "name": {
         "en": "Ancient Weapons"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Improve the Strength characteristic of melee weapons equipped by the bearer by 2, and improve the Armour Penetration and Damage characteristics of those weapons by 1."
       },
@@ -2416,13 +2440,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c778992-81c4-558f-8504-39ad4ca59aec",
+      "id": "761a1eab-21c7-5267-8091-d01ddbbae8e3",
       "name": {
         "en": "Deathwing Assault"
       },
       "cost": "15",
       "keywords": ["Deathwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATHWING** model with the Deep Strike ability only. The bearer’s unit can be set up using the Deep Strike ability in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules."
       },
@@ -2434,13 +2459,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ffa403d0-7c36-5d0b-a86a-6e9ea9961cc7",
+      "id": "6cd4526b-d626-54aa-8cd5-b6032774a4a4",
       "name": {
         "en": "Lord of the Ravenwing"
       },
       "cost": "10",
       "keywords": ["Ravenwing"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**RAVENWING** model only. You can re-roll Advance and Charge rolls made for the bearer’s unit."
       },
@@ -2645,7 +2671,49 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **HELLBLASTER SQUAD** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "dba448cc-ea5e-5fd9-bd91-c795467fd1d2",
@@ -2847,7 +2915,49 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **HELLBLASTER SQUAD** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b0e28fbd-1d1d-5c84-acc7-ee729e62fe99",
@@ -3031,7 +3141,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATHWING COMMAND SQUAD** ■ **DEATHWING KNIGHTS** ■ **DEATHWING TERMINATOR SQUAD** ■ **TERMINATOR ASSAULT SQUAD** ■ **TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Deathwing Knights",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwing Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0a59cf75-fb0a-540f-9206-4ff05900b6a4",
@@ -3939,7 +4071,49 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **HELLBLASTER SQUAD** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a673671f-02bc-550b-b51b-bb4c0237e6b4",
@@ -4525,7 +4699,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0749c654-22ff-5ed6-be5e-9acdf8583933",
@@ -5659,7 +5870,19 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **OUTRIDER SQUAD** ■ **RAVENWING BLACK KNIGHTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Outrider Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ravenwing Black Knights",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "eab64694-a982-55df-80a6-73d5036f7d8f",
@@ -6259,7 +6482,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **OUTRIDER SQUAD** ■ **RAVENWING BLACK KNIGHTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Outrider Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ravenwing Black Knights",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/deathguard.json
+++ b/11th/gdc/deathguard.json
@@ -7,7 +7,7 @@
     "header": "#4d560e"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:49.037Z",
+  "updated": "2026-07-28T17:03:00.346Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2143,7 +2143,7 @@
   ],
   "enhancements": [
     {
-      "id": "bed8fe83-7581-5248-b2e3-8d535a93bd16",
+      "id": "f1d68c88-bcd6-56bf-b287-db69cccdb212",
       "name": {
         "en": "Parasitic Woe‑reaper (Upgrade)",
         "de": "Parasitärer Leidensschlinger (Aufwertung)",
@@ -2157,6 +2157,7 @@
       "cost": "15",
       "keywords": ["Contagion Engines"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Contagion Engine</k> unit only. When this unit has fought, one model in this unit <b>heals</b> D3 wounds.",
         "de": "Nur für eine <k>Maschinerie</k>-<k>der</k>-<k>Fäulnis</k>-Einheit. Nachdem diese Einheit gekämpft hat, wird ein Modell dieser Einheit um W3 Lebenspunkte <b>geheilt</b>.",
@@ -2175,7 +2176,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "eb3ba309-0552-5bdd-9766-1378440b8851",
+      "id": "0f52b203-5e89-5f1b-820b-96187bcddf0e",
       "name": {
         "en": "Lancet of the Worldsore (Upgrade)",
         "de": "Lanzette der Weltengeschwulst (Aufwertung)",
@@ -2189,6 +2190,7 @@
       "cost": "15",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "Friendly <k>Helbrute/Myphitic Blight‑Hauler</k> unit only. This unit has <k>Mobile</k>.",
         "de": "Nur für eine befreundete <k>Höllenschlächter</k>-<k>/Myphitische</k>-<k>Seuchenschlepper</k>-Einheit. Diese Einheit hat <k>Mobil</k>.",
@@ -2207,7 +2209,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "076a9bec-84fd-53f8-88ed-e39881afc474",
+      "id": "539a4ab9-718b-5af9-87d1-04f790af481b",
       "name": {
         "en": "Insectile Murmuration (Upgrade)",
         "de": "Stimme der Insekten (Aufwertung)",
@@ -2221,6 +2223,7 @@
       "cost": "15",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Plague Marines</k> unit only. When this unit’s attacks target a unit within <b>Contagion Range</b> of a friendly unit, those attacks can re‑roll <b>wound rolls</b> of 1.",
         "de": "Nur für eine <k>Seuchenmarine</k>-Einheit. Wenn diese Einheit Attacken gegen eine feindliche Einheit in <b>Infektionsreichweite</b> einer befreundeten Einheit ausführt, können <b>Verwundungswürfe</b> von 1 wiederholt werden.",
@@ -2239,7 +2242,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e572f126-393c-5829-9733-0859bebe8018",
+      "id": "9611a303-9e77-5ed5-81f5-dcd29ba50b86",
       "name": {
         "en": "Plagueveil (Upgrade)",
         "de": "Fäulnisschleier (Aufwertung)",
@@ -2253,6 +2256,7 @@
       "cost": "15",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Plague Marines</k> unit only. This unit has -3\" <b>detection range</b>.",
         "de": "Nur für eine <k>Seuchenmarine</k>-Einheit. Diese Einheit hat -3\" <b>Entdeckungsreichweite</b>.",
@@ -2271,7 +2275,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6431226c-3279-5d01-8cd7-02bf65646efe",
+      "id": "6abab6c9-3670-5578-965c-07bd20c36659",
       "name": {
         "en": "Rejuvenating Swarm",
         "de": "Schorfschwarm",
@@ -2285,6 +2289,7 @@
       "cost": "20",
       "keywords": ["Infantry", "Death Guard"],
       "excludes": ["Terminator"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Death Guard Infantry</k> model only (excluding <k>Terminator</k> models). Attacks that target this unit with a <b>S</b> greater than this unit’s <b>T</b> have -1 to <b>wound rolls</b>.",
         "de": "Nur für ein <k>Death</k>-<k>Guard</k>-<k>Infanterie</k>-Modell (ausgenommen <k>Terminator</k>-Modelle). Attacken gegen diese Einheit, deren <b>S</b> höher ist als der <b>W</b> dieser Einheit, haben -1 auf <b>Verwundungswürfe</b>.",
@@ -2303,7 +2308,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4e9963ff-5f24-500f-b48a-d7ced62f8be2",
+      "id": "17b153b8-ddf4-5646-8179-5b009f3a1029",
       "name": {
         "en": "Host of the Hybridised Pox",
         "de": "Wirtskörper der Hybridpocken",
@@ -2317,6 +2322,7 @@
       "cost": "40",
       "keywords": ["Infantry", "Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Death Guard Infantry</k> model only. (Once per battle, per army) In your Command phase, you can use this ability. If you do, select one of the <b>Plagues</b> listed in <b>Nurgle’s Gift</b> (see <i>Codex: Death Guard</i>). Enemy units within <b>Contagion Range</b> of this unit also have the effect of that <b>Plague</b> <u>in addition</u> to your army’s chosen <b>Plague</b> until the end of the battle.",
         "de": "Nur für ein <k>Death</k>-<k>Guard</k>-<k>Infanterie</k>-Modell. (Einmal pro Schlacht, pro Armee) In deiner Befehlsphase kannst du diese Fähigkeit einsetzen. Wenn du dies tust, wähle eine der <b>Seuchen</b>, die unter <b>Nurgles ­Geschenke</b> (siehe Codex: Death Guard) aufgeführt sind. Feindliche Einheiten in <b>Infektionsreichweite</b> dieser Einheit unterliegen <u>zusätzlich</u> zur gewählten <b>Seuche</b> deiner Armee bis zum Ende der Schlacht dem Effekt jener <b>Seuche</b>.",
@@ -2335,13 +2341,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5672306e-9410-5b58-b7b0-dcb98b75f252",
+      "id": "44910d9f-e717-5236-b213-bced9ccb066b",
       "name": {
         "en": "Daemon Weapon of Nurgle"
       },
       "cost": "10",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. Each time the bearer makes a melee attack, an unmodified Hit roll of 5+ scores a Critical Hit."
       },
@@ -2353,13 +2360,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1850daac-4364-5c67-b857-49e2f9bff098",
+      "id": "e6ee4380-0efb-562d-b5f1-8cc42337c8fa",
       "name": {
         "en": "Furnace of Plagues"
       },
       "cost": "25",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. Add 1 to the Strength and Attacks characteristics of the bearer’s melee weapons, and the bearer’s melee weapons have the **[DEVASTATING WOUNDS]** ability."
       },
@@ -2371,13 +2379,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "aeab3eaf-4053-588e-8118-3d94429410eb",
+      "id": "6f4103c8-8ca1-52ca-b557-26e4c4cad74d",
       "name": {
         "en": "Arch Contaminator"
       },
       "cost": "25",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. While the bearer’s unit is within range of an objective marker you control, each time a model in the bearer’s unit makes an attack, you can re-roll the Wound roll."
       },
@@ -2389,13 +2398,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d114afb9-b898-5611-a486-90b633a18eca",
+      "id": "af239e40-696f-5d1c-bd12-ecb2496e650f",
       "name": {
         "en": "Revolting Regeneration"
       },
       "cost": "30",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. The bearer has the Feel No Pain 5+ ability."
       },
@@ -2407,13 +2417,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "39fc74e7-ceb6-53db-ab83-2eaddd9879ac",
+      "id": "68dc97a3-763c-5704-9f42-c6226bbcfe5c",
       "name": {
         "en": "Eye of Affliction"
       },
       "cost": "20",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. Ranged weapons equipped by models in the bearer’s unit have the **[IGNORES COVER]** ability while targeting an Afflicted enemy unit."
       },
@@ -2425,13 +2436,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2ba490c4-926d-5b86-8f22-b48d11eb2863",
+      "id": "a0633048-a026-5dee-a661-21580f0e8260",
       "name": {
         "en": "Bilemaw Blight"
       },
       "cost": "10",
       "keywords": ["Malignant Plaguecaster"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MALIGNANT PLAGUECASTER** only. At the start of your Shooting phase, until the end of the phase, add 12\" to the Range characteristics of the bearer’s Plague Wind weapon."
       },
@@ -2443,13 +2455,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b840d298-168e-5f92-9d7e-d65f8efea64d",
+      "id": "95f0723a-a5c2-54a4-9304-864c6d5d0dc7",
       "name": {
         "en": "Shriekworm Familiar"
       },
       "cost": "15",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. Once per battle round, you can target the bearer’s unit with the Fire Overwatch Stratagem for 0CP."
       },
@@ -2461,13 +2474,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0087ac44-7f9c-5f2b-85a8-a690ecdb1b05",
+      "id": "8e62bc64-9be0-52f4-a8f6-282a8ee9c420",
       "name": {
         "en": "Tendrilous Emissions"
       },
       "cost": "30",
       "keywords": ["Lord of Virulence"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LORD OF VIRULENCE** only. While the bearer is within 3\" of one or more friendly **DEATH GUARD VEHICLE** units, the bearer has the Lone Operative ability, and each time one of those **VEHICLE** units makes a ranged attack that targets an enemy unit visible to the bearer, re-roll a Wound roll of 1."
       },
@@ -2479,13 +2493,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9788834e-00d4-5dd7-a155-782a01aa0cbf",
+      "id": "1ceec444-8399-5254-b1bc-eac8ad88d891",
       "name": {
         "en": "Final Ingredient"
       },
       "cost": "20",
       "keywords": ["Biologus Putrifier"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BIOLOGUS PUTRIFIER** only. Once per battle, after the bearer’s unit has fought, if one or more **CHARACTER** models were destroyed as a result of those attacks, select one Plague. Until the end of the battle, while an enemy unit is Afflicted, that unit has the effect of the selected Plague in addition to any other."
       },
@@ -2497,13 +2512,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4ba7227d-a1fa-50f3-ba76-34f19b658bb7",
+      "id": "f142f851-890b-5fa1-9f13-95b576d1a45f",
       "name": {
         "en": "Visions of Virulence"
       },
       "cost": "15",
       "keywords": ["Malignant Plaguecaster"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MALIGNANT PLAGUECASTER** only. While an enemy unit is enfeebled by the bearer’s Pestilent Fallout ability, that unit is also Afflicted."
       },
@@ -2515,13 +2531,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "211d0237-3efb-5261-ba10-898fb16ef512",
+      "id": "5fd0618c-a284-5e20-9964-7b0b6e24ec55",
       "name": {
         "en": "Needle of Nurgle"
       },
       "cost": "25",
       "keywords": ["Plague Surgeon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**PLAGUE SURGEON** only. Each time the bearer uses its Tainted Narthecium ability, you can return up to D3 destroyed models to the bearer’s unit (instead of 1)."
       },
@@ -2533,13 +2550,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f226e20a-399f-5eaf-bd8d-12d8091381d5",
+      "id": "39ebcd86-07a8-5925-b206-1f94e435d946",
       "name": {
         "en": "Cornucophagus"
       },
       "cost": "35",
       "keywords": ["Lord of Poxes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LORD OF POXES** only. In the Declare Battle Formations step select one Plague. Until the end of the battle, while an enemy unit is within Contagion Range of the bearer, that enemy unit has the effect of that Plague in addition to any other."
       },
@@ -2551,13 +2569,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b4fe2e71-e5c4-55a4-9371-babf8bd2e1f4",
+      "id": "ece0e342-1635-524b-84b1-facd1d42dab6",
       "name": {
         "en": "Beckoning Blight"
       },
       "cost": "20",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. Each time a **PLAGUE LEGIONS** unit from your army is set up on the battlefield using the Deep Strike ability, if it is set up wholly within 12\" of the bearer, it can be set up anywhere that is more than 6\" horizontally away from all enemy models, instead of more than 8\"."
       },
@@ -2569,13 +2588,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b7e10a39-8f7d-53cf-ae30-67f146732349",
+      "id": "dd561346-866a-51d7-bcbd-b2b322412420",
       "name": {
         "en": "Fell Harvester"
       },
       "cost": "10",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. Add 2 to the Attacks characteristic of the bearer’s melee weapons."
       },
@@ -2587,13 +2607,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ca9f05e6-d9c5-5c6e-90f2-ce50c90d2c1b",
+      "id": "951f42ae-7c66-50d8-ad41-786808363ec2",
       "name": {
         "en": "Entropic Knell"
       },
       "cost": "15",
       "keywords": ["Great Unclean One"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREAT UNCLEAN ONE** only. In the Battle-shock step of your opponent’s Command phase, each enemy unit within 6\" of the bearer that is below its Starting Strength must take a Battle-shock test, subtracting 1 from that test."
       },
@@ -2605,13 +2626,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "69c4cbb2-afd4-5399-8a88-bfe31e6200d1",
+      "id": "1de48589-75e5-5edb-b04f-c2129cde3e8e",
       "name": {
         "en": "Tome of Bounteous Blessings"
       },
       "cost": "20",
       "keywords": ["Malignant Plaguecaster"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MALIGNANT PLAGUECASTER** only. Each time a **PLAGUE LEGIONS** unit within 12\" of the bearer takes a Battle-shock test, add 1 to that test and, if that test is passed, one model in that unit regains up to D3 lost wounds (if that unit is a **BATTLELINE** unit and that test is passed, up to D3 destroyed models can be returned to that unit instead)."
       },
@@ -2623,13 +2645,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4438bb68-56cb-50ff-b034-f2cf03c38470",
+      "id": "2a8bd434-f136-5299-bae8-82bd0987c6c9",
       "name": {
         "en": "Witherbone Pipes"
       },
       "cost": "25",
       "keywords": ["Noxious Blightbringer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NOXIOUS BLIGHTBRINGER** only. While the bearer is leading a **POXWALKERS** unit, add 1 to the Objective Control characteristic of models in that unit, and each time that unit takes a Battle-shock or Leadership test, add 1 to that test."
       },
@@ -2641,13 +2664,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8ff2f45d-da60-5500-8dd5-e57c53ee706b",
+      "id": "c49c7ab4-aa47-5fa3-9535-895a68bc6db9",
       "name": {
         "en": "Lord of the Walking Pox"
       },
       "cost": "15",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. If the bearer is leading a **POXWALKER** unit, and is in Strategic Reserves, for the purposes of setting up that unit on the battlefield, treat the current battle round as the third battle round."
       },
@@ -2659,13 +2683,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7f5dcbc5-421e-5e49-9063-6bbfb9932b58",
+      "id": "6a1ce929-8639-5346-8dfc-4742a9e19407",
       "name": {
         "en": "Sorrowsyphon"
       },
       "cost": "10",
       "keywords": ["Malignant Plaguecaster"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MALIGNANT PLAGUECASTER** only. While the bearer is leading a **POXWALKERS** unit, add 1 to the Damage characteristic of the bearer’s Plague Wind weapon. Each time the bearer makes one or more attacks with a Plague Wind weapon, after the bearer’s unit has resolved its attacks, D3 Bodyguard models from the bearer’s unit are destroyed."
       },
@@ -2677,13 +2702,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4a7fa8ce-5d68-5b8d-ae76-b2e5d6920fb5",
+      "id": "b8707865-9fbd-5210-868b-15d56b126bc7",
       "name": {
         "en": "Talisman of Burgeoning"
       },
       "cost": "25",
       "keywords": ["Death Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEATH GUARD** model only. While the bearer is leading a unit, add 1 to the Toughness characteristic of **POXWALKERS** models in that unit."
       },
@@ -2695,13 +2721,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0a84238c-f9fd-5938-bcbf-07d4d1245356",
+      "id": "b4828be2-6bd1-5336-ba5a-7da43644fcb6",
       "name": {
         "en": "Face of Death"
       },
       "cost": "10",
       "keywords": ["Terminator"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TERMINATOR** model only. At the start of the Fight phase, each enemy unit within Engagement Range of the bearer’s unit must take a Battle-shock test."
       },
@@ -2713,13 +2740,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "03c2363f-1d30-5af6-853a-54b536019592",
+      "id": "2700881b-0466-5383-8f14-c193a16d1a49",
       "name": {
         "en": "Vile Vigour"
       },
       "cost": "15",
       "keywords": ["Terminator"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TERMINATOR** model only. While the bearer is leading a unit, add 1\" to the Movement characteristic of models in that unit and you can re-roll Advance rolls made for that unit."
       },
@@ -2731,13 +2759,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4dbb55db-0008-593d-b443-4ee0846a2d9b",
+      "id": "6c0eb9c9-7a04-508a-a760-e9d0b387193a",
       "name": {
         "en": "Warprot Talisman"
       },
       "cost": "30",
       "keywords": ["Terminator"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TERMINATOR** model only. Once per battle, at the end of your opponent’s turn, if the bearer’s unit is not within Engagement Range of one or more enemy units, you can remove it from the battlefield and place it into Strategic Reserves."
       },
@@ -2749,13 +2778,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4ab749f6-aafb-5658-95f9-792c09a28126",
+      "id": "01ee4ccf-2552-5d8a-9d27-dcb7aa667733",
       "name": {
         "en": "Helm of The Fly King"
       },
       "cost": "20",
       "keywords": ["Terminator"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TERMINATOR** model only. While the bearer is leading a unit, models in that unit cannot be targeted by ranged attacks unless the attacking model is within 18\"."
       },
@@ -2963,7 +2993,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES**  *You can attach this model to a* **PLAGUE MARINES** *unit, even if one other Leader unit has already been attached to it (you cannot attach more than one of the same Leader to the same unit). If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.*"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "03151889-d649-524b-a300-a012a530cb1e",
@@ -6210,7 +6247,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES**  *You can attach this model to a* **PLAGUE MARINES** *unit, even if one other Leader unit has already been attached to it (you cannot attach more than one of the same Leader to the same unit). If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.*"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0b020c25-102b-5feb-93f5-5eda796bd1d5",
@@ -6812,7 +6856,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES**  *You can attach this model to a* **PLAGUE MARINES** *unit, even if one other Leader unit has already been attached to it (you cannot attach more than one of the same Leader to the same unit). If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.*"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "698c4ab7-52ba-5652-a76f-1a8b7aeef5ac",
@@ -6982,7 +7033,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLIGHTLORD TERMINATORS** ■ **DEATHSHROUD TERMINATORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blightlord Terminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathshroud Terminators",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9fa7d463-6690-5d76-912b-0dd99eef99c2",
@@ -7167,7 +7230,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "7e1487a4-3432-5db1-b36e-7a1877263a57",
@@ -7350,7 +7420,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLIGHTLORD TERMINATORS** ■ **DEATHSHROUD TERMINATORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blightlord Terminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathshroud Terminators",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "bcf0fc13-638a-51d7-b0b6-630b22f34cba",
@@ -7556,7 +7638,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES** ■ **POXWALKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Poxwalkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f8f8d778-fea0-5af6-be79-9d3c09870662",
@@ -8381,7 +8475,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES** ■ **POXWALKERS**  *You con attach this model to a* **PLAGUE MARINES** *or* **POXWALKERS** *unit, even if one other Leader unit has already been attached to it (you cannot attach more than one of the same Leader to the same unit). If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.*"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Poxwalkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "27c961bb-dde0-57b3-abca-1e9823dfa9c9",
@@ -9084,7 +9190,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES**  *You can attach this model to a* **PLAGUE MARINES** *unit, even if one other Leader unit has already been attached to it (you cannot attach more than one of the same Leader to the same unit). If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.*"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "191a9eb3-9820-5145-b378-2fc699702fce",
@@ -9670,7 +9783,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PLAGUE MARINES**  *You can attach this model to a* **PLAGUE MARINES** *unit, even if one other Leader unit has already been attached to it (you cannot attach more than one of the same Leader to the same unit). If you do, and that Bodyguard unit is destroyed, the Leader units attached to it become separate units, with their original Starting Strengths.*"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Plague Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0108df02-9869-5b94-9596-80f0fe42b689",
@@ -9844,7 +9964,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLIGHTLORD TERMINATORS** ■ **DEATHSHROUD TERMINATORS** ■ **POXWALKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blightlord Terminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathshroud Terminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Poxwalkers",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/deathwatch.json
+++ b/11th/gdc/deathwatch.json
@@ -7,7 +7,7 @@
     "header": "#3d3e41"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.434Z",
+  "updated": "2026-07-28T17:03:02.918Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "rules": {
@@ -327,13 +327,14 @@
   ],
   "enhancements": [
     {
-      "id": "8727598c-ebe1-549d-8275-c8caeab0a5c2",
+      "id": "83f17f3b-5163-5d06-bf60-9d944db15a04",
       "name": {
         "en": "Thief of Secrets"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Improve the Strength, Damage and Armour Penetration characteristics of the bearer’s melee weapons by 1. At the end of the Fight phase, if one or more enemy models were destroyed as a result of a melee attack made by the bearer this phase, until the end of the battle, improve the Strength, Damage and Armour Penetration characteristics of the bearer’s melee weapons by 2 instead."
       },
@@ -345,13 +346,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6204707b-96c1-598b-8007-b7b64f51f7ca",
+      "id": "7575fc80-4f5b-5fb3-a5ee-f3b31c296ce3",
       "name": {
         "en": "Osseus Key"
       },
       "cost": "15",
       "keywords": ["Watch Master", "Adeptus Astartes", "Techmarine"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WATCH MASTER** or **TECHMARINE** model only. At the start of your opponent’s Shooting phase, select one enemy **VEHICLE** unit (excluding **TITANIC** units) within 12\" of and visible to the bearer. That unit must take a Leadership test. If that test is passed, until the end of the phase, each time a model in that unit makes an attack, subtract 1 from the Hit roll; if that test is failed, that unit is not eligible to shoot this phase."
       },
@@ -363,13 +365,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2c66d7b1-c513-567b-91e3-cf1be40a31c5",
+      "id": "5bcfe787-4f32-57ad-99c1-b38533849aeb",
       "name": {
         "en": "Beacon Angelis"
       },
       "cost": "25",
       "keywords": ["Deathwatch"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Models in the bearer’s unit have the Deep Strike ability. In addition, you can target the bearer’s unit with the Rapid Ingress Stratagem for 0CP."
       },
@@ -381,13 +384,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "755fc770-c8f2-5692-a2ae-a7a1c4c10390",
+      "id": "a931954c-ac36-59e4-92bc-e31759b4d553",
       "name": {
         "en": "The Tome of Ectoclades"
       },
       "cost": "30",
       "keywords": ["Watch Master", "Adeptus Astartes", "Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WATCH MASTER** or **CAPTAIN** model only. Once per battle, after you have selected your Oath of Moment target, the bearer can use this Enhancement. If it does, select a second enemy unit to be an Oath of Moment target.\n\n**Designer’s Note:** *This means that each time a model with the Oath of Moment ability makes an attack that targets either of your Oath of Moment targets, you can re-roll the Hit roll.*"
       },
@@ -4847,7 +4851,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATHWATCH VETERANS** ■ **DECIMUS KILL TEAM** ■ **FORTIS KILL TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "10af0717-f94a-5ae6-90f3-427da01cbe73",
@@ -5019,7 +5040,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATHWATCH VETERANS** ■ **DECIMUS KILL TEAM** ■ **FORTIS KILL TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/drukhari.json
+++ b/11th/gdc/drukhari.json
@@ -7,7 +7,7 @@
     "header": "#0f454e"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.426Z",
+  "updated": "2026-07-28T17:03:11.079Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2235,7 +2235,7 @@
   ],
   "enhancements": [
     {
-      "id": "2ade1e65-19e7-53c4-9e61-89ad1f35de5a",
+      "id": "11f5aa0f-ac7e-55b5-8e77-d0094a920102",
       "name": {
         "en": "Towering Arrogance",
         "de": "Maßlose Arroganz",
@@ -2249,6 +2249,7 @@
       "cost": "15",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Archon</k> model only. This unit has:\r<ul><li>+1 <b>Ld</b> and <b>OC</b>.</li></ul>",
         "de": "Nur für ein <k>Archon</k>-Modell. Diese Einheit hat:\n<ul><li>+1 <b>MW</b> und <b>MK</b>.</li></ul>",
@@ -2267,7 +2268,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "42133176-46fe-536c-8cf9-50ae6ad9c0fb",
+      "id": "4c1bd012-bccf-524e-bf0b-47a51d6f5330",
       "name": {
         "en": "Elixir of the Corpse Courts (Upgrade)",
         "de": "Elixier der Kadaverzünfte (Aufwertung)",
@@ -2281,6 +2282,7 @@
       "cost": "15",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>CRONOS/TALOS</k> unit only. This unit has 5+ <b>InSv</b>.",
         "de": "Nur für eine <k>Schmerzmaschine</k>-Einheit. Diese Einheit hat 5+ <b>RE</b>.",
@@ -2299,7 +2301,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "06b5232f-c178-5006-b043-491810db176d",
+      "id": "ca31d43e-a9e0-52b4-8004-5ddc2a0ef00b",
       "name": {
         "en": "Contempt for Rivals",
         "de": "Verachtung für Rivalen",
@@ -2313,6 +2315,7 @@
       "cost": "20",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Archon</k> model only. This unit’s attacks have <k>[Precision]</k>.",
         "de": "Nur für ein <k>Archon</k>-Modell. Die Attacken dieser Einheit haben <k>[Präzision]</k>.",
@@ -2331,7 +2334,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "86b76035-6722-5444-95ea-740a5745b116",
+      "id": "7530314d-9f4b-5d49-9588-f319b6b5ac93",
       "name": {
         "en": "Gnarlskin Experimentor",
         "de": "Verschorfter Experimentator",
@@ -2345,6 +2348,7 @@
       "cost": "20",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Haemonculus</k> model only. Attacks that target this unit with a <b>S</b> greater than your unit’s <b>T</b> have -1 to <b>wound rolls</b>.",
         "de": "Nur für ein <k>Haemonculus</k>-Modell. Attacken gegen diese Einheit mit einer <b>S</b>, die höher ist als der <b>W</b> dieser Einheit, haben -1 auf <b>Verwundungswürfe</b>.",
@@ -2363,7 +2367,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3c35ae68-b563-5d04-9312-86ec29c6de42",
+      "id": "671a8f38-5e61-550d-a321-dad89ec70b9c",
       "name": {
         "en": "Periapt of Torments",
         "de": "Amulett der Qualen",
@@ -2377,6 +2381,7 @@
       "cost": "20",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Succubus</k> model only. Enemy units cannot target this unit with <b>snap shooting</b> attacks.",
         "de": "Nur für ein <k>Succubus</k>-Modell. Feindliche Einheiten können gegen diese Einheit keine <b>Eiliger-Beschuss</b>-Attacken ausführen.",
@@ -2395,7 +2400,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d7e45f5b-b069-5e33-baaf-8c26147361c7",
+      "id": "342b82b9-8ed7-583e-8004-3fd6c9c89e87",
       "name": {
         "en": "Hyperstimm Trafficker",
         "de": "Kampfdrogenhändlerin",
@@ -2409,6 +2414,7 @@
       "cost": "20",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Succubus</k> model only. This unit has +1 <b>T</b>.",
         "de": "Nur für ein <k>Succubus</k>-Modell. Diese Einheit hat +1 <b>W</b>.",
@@ -2427,13 +2433,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f6ccfd36-f950-5152-bc5a-fd936b530646",
+      "id": "2a1fe1d6-aa31-52e5-b3d7-faa424a5d764",
       "name": {
         "en": "Phantasmal Smoke"
       },
       "cost": "15",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DRUKHARI** model only. While the bearer’s unit is wholly within 6\" of a friendly **DRUKHARI TRANSPORT**:\n\n■ Models in the bearer’s unit have the Stealth ability.\n■ Each time a ranged attack targets the bearer’s unit, models in that unit have the Benefit of Cover against that attack."
       },
@@ -2445,13 +2452,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "69c6e265-a359-5f72-b4ad-70b00c4782a3",
+      "id": "158ec325-db3f-5ab6-bae5-4625d58c3800",
       "name": {
         "en": "Dark Vitality"
       },
       "cost": "20",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DRUKHARI** model only. The bearer’s unit is always Empowered – you do not need to spend any Pain tokens to activate that unit’s Pain abilities."
       },
@@ -2463,13 +2471,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "133e68c0-7a20-5364-a90b-64cff4dfc85b",
+      "id": "c906b566-ac27-5ce5-ae6a-810af0c7504a",
       "name": {
         "en": "Sadistic Fulcrum"
       },
       "cost": "15",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DRUKHARI** model only. Each time you spend 1 Pain token to Empower the bearer’s unit in the Shooting phase, select one friendly **DRUKHARI TRANSPORT** within 6\" of the bearer’s unit; until the end of the phase, each time that **TRANSPORT** makes an attack, you can re‑roll the Hit roll."
       },
@@ -2481,13 +2490,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5a8b15a9-e5dd-5d97-b5e6-ae426b7d054f",
+      "id": "907e6ba9-f0c7-5e7d-bd4d-88aa6d3123cd",
       "name": {
         "en": "Labyrinthine Cunning"
       },
       "cost": "25",
       "keywords": ["Archon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ARCHON** model only. At the start of your Command phase, if the bearer is on the battlefield, you can do one of the following:\n\n■ Spend 1 Pain token and gain 1CP.\n■ Roll one D6: on a 4+, you gain 1CP."
       },
@@ -2499,13 +2509,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "73a88554-a2a4-51b1-b076-1c28ac5b681d",
+      "id": "8bb12efa-cb37-5d47-9adb-8c0d028e3b70",
       "name": {
         "en": "Spiteful Raider"
       },
       "cost": "10",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DRUKHARI** model only. Each time the bearer’s unit destroys an enemy unit in the Fight phase, if that enemy unit was within range of one or more objective markers when the bearer’s unit was selected to fight, you gain 1 additional Pain token."
       },
@@ -2517,13 +2528,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7ead718d-e9f4-56fb-a0ca-a0fa4b673fbf",
+      "id": "c25ae5bb-98cf-5e00-8ba3-1e0f200386eb",
       "name": {
         "en": "Eye of Spite"
       },
       "cost": "15",
       "keywords": ["Succubus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SUCCUBUS** model only. Improve the Attacks and Armour Penetration characteristics of the bearer’s melee weapons by 1. Each time the bearer’s unit is selected to fight, you can spend 1 Pain token; if you do, until the end of the phase, improve the Attacks and Armour Penetration characteristics of the bearer’s melee weapons by 2 instead."
       },
@@ -2535,13 +2547,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1d65e7ed-5656-5c17-be22-409ac3214d94",
+      "id": "0cc2cc1e-d364-5411-8edf-2eee2704210c",
       "name": {
         "en": "Crucible of Malediction"
       },
       "cost": "15",
       "keywords": ["Haemonculus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HAEMONCULUS** model only. Once per battle, in your Shooting phase, the bearer can use this Enhancement. If it does, you can spend 1 Pain token. Then, each enemy unit within 12\" of the bearer must take a Battle‑shock test, subtracting 1 from that test if you spent 1 Pain token. Each time a **PSYKER** unit fails that test, it suffers 3 mortal wounds."
       },
@@ -2553,13 +2566,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dc47a6ff-a82a-5374-86e7-fcc0cc4da02e",
+      "id": "e8f70a67-70e3-575b-abbd-b6089d68bfae",
       "name": {
         "en": "Nightmare Shroud"
       },
       "cost": "20",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DRUKHARI** model only. Each time the bearer’s unit disembarks from a **TRANSPORT**, until the end of the turn, enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2571,13 +2585,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "299ed59c-451b-57ec-9517-9579aa162279",
+      "id": "ce516bc3-a9ba-59df-853d-85c5bbe938e7",
       "name": {
         "en": "Archraider"
       },
       "cost": "15",
       "keywords": ["Drukhari", "Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HARLEQUINS** or **DRUKHARI** model only. In the Declare Battle Formations step, if the bearer starts the battle embarked within a **DEDICATED TRANSPORT**, that **DEDICATED TRANSPORT** has the Scouts 9\" ability."
       },
@@ -2589,13 +2604,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "47f62c0a-436a-5689-9641-2812b3cab45d",
+      "id": "877748b4-170a-5aa3-89e9-0b0793ad1495",
       "name": {
         "en": "Webway Walker"
       },
       "cost": "15",
       "keywords": ["Drukhari", "Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HARLEQUINS** or **DRUKHARI** model only. Models in the bearer’s unit have the Deep Strike ability. Each time the bearer’s unit is set up on the battlefield using the Deep Strike ability, if that unit is currently losing the wager, until the end of the turn, you can re‑roll Charge rolls made for that unit."
       },
@@ -2607,13 +2623,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d2021261-46ef-557d-934c-213f0b807c5b",
+      "id": "11218ffe-0a57-5ef5-9993-6885d2e8bfd9",
       "name": {
         "en": "Reaper’s Cowl"
       },
       "cost": "25",
       "keywords": ["Harlequins"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HARLEQUINS** model only. Models in the bearer’s unit have the Stealth and Infiltrators abilities."
       },
@@ -2625,13 +2642,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "057a9bb3-8145-5d38-bcca-1342fe4ec799",
+      "id": "04d9bfa3-563b-5a05-82d4-1766bee351dd",
       "name": {
         "en": "Conductor of Torment"
       },
       "cost": "20",
       "keywords": ["Drukhari"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DRUKHARI** model only. In your Command phase, you can do one of the following:\n\n■ If your **DRUKHARI** units are currently losing the wager, you can gain 1 Pain token. If you do, **DRUKHARI** units from your army are now winning the wager.\n■ If your **DRUKHARI** units are currently winning the wager, you can discard 1 Pain token. If you do, **HARLEQUINS** units from your army are now winning the wager."
       },
@@ -2643,13 +2661,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "39b3f489-bb41-5ef2-a1eb-f3de3124dadf",
+      "id": "597afefd-6a24-59d1-ab53-ec77c42d9d8a",
       "name": {
         "en": "Pharmacophex"
       },
       "cost": "15",
       "keywords": ["Succubus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SUCCUBUS** model only. At the start of your Command phase, after selecting which Combat Drugs will be active for your army, roll one D6 and consult the Combat Drugs list (see Detachment Rule). The result rolled applies to the bearer’s unit until the start of your next Command phase in addition to any other Combat Drugs that are active for your army. If you randomly select one that is already active for your army, it has no additional effect."
       },
@@ -2661,13 +2680,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f2c5c6ba-c900-54d4-9ed1-b6f710e9c2c9",
+      "id": "9b92ce83-f70d-592e-a80b-2083b86a5fde",
       "name": {
         "en": "Chronoshard"
       },
       "cost": "15",
       "keywords": ["Succubus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SUCCUBUS** model only. Once per battle, at the start of the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, models in the bearer’s unit have the Fights First ability."
       },
@@ -2679,13 +2699,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3c35ae68-b563-5d04-9312-86ec29c6de42",
+      "id": "bb775f64-d532-58aa-9b25-29acff767551",
       "name": {
         "en": "Periapt of Torments"
       },
       "cost": "25",
       "keywords": ["Succubus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SUCCUBUS** model only. Enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2697,13 +2718,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "86ed5e59-091a-505a-ad6e-263d7f4dc522",
+      "id": "87a5dd44-56d8-5c0f-87ef-6e50556b56b7",
       "name": {
         "en": "Morghenna’s Curse"
       },
       "cost": "20",
       "keywords": ["Succubus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SUCCUBUS** model only. Improve the Armour Penetration and Damage characteristics of the bearer’s melee weapons by 1."
       },
@@ -2715,13 +2737,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "99296b0d-c7d4-5861-854b-e00da1b1db6f",
+      "id": "7c8bfc07-c400-5003-9371-956773bb6197",
       "name": {
         "en": "Master Regenesist"
       },
       "cost": "25",
       "keywords": ["Haemonculus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HAEMONCULUS** model only. Each time the bearer uses its Fleshcraft ability, you can return up to D3+3 destroyed Bodyguard models to the bearer’s unit instead of D3+1."
       },
@@ -2733,13 +2756,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a41a6821-5e27-5c2f-9701-11ca22f64ee0",
+      "id": "0c97162d-cc45-566b-b9a9-8369c5a34fdc",
       "name": {
         "en": "Master Nemesine"
       },
       "cost": "5",
       "keywords": ["Haemonculus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HAEMONCULUS** model only. The bearer’s weapons have the **[ANTI‑BEAST 2+]** and **[ANTI‑MONSTER 4+]** abilities."
       },
@@ -2751,13 +2775,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "da147a32-4485-502c-ab79-3845af188228",
+      "id": "1c209ac4-caad-530b-a451-74ee90cc7023",
       "name": {
         "en": "Master Artisan"
       },
       "cost": "20",
       "keywords": ["Haemonculus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HAEMONCULUS** model only. Add 1 to the bearer’s Wounds characteristic and add 1 to the Toughness characteristic of models in the bearer’s unit."
       },
@@ -2769,13 +2794,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9c7ef116-0dd4-5710-9f84-229ea7d9ee34",
+      "id": "724c5a16-7e69-5c8a-a42c-740d990c99c8",
       "name": {
         "en": "Master Repugnomancer (Aura)"
       },
       "cost": "15",
       "keywords": ["Haemonculus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**HAEMONCULUS** model only. Add 3\" to the range of the bearer’s Fear Incarnate ability, and each time a friendly **DRUKHARI** unit within 9\" of the bearer fails a Battle‑shock test or is destroyed, roll one D6: on a 4+, you gain 1 Pain token."
       },
@@ -2787,13 +2813,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4d27ff03-30b9-5929-a733-e1e642823fc4",
+      "id": "8b7961d1-c958-56f9-81b9-c8b2bef7a234",
       "name": {
         "en": "Leechbite Plate"
       },
       "cost": "5",
       "keywords": ["Archon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ARCHON** model only. The bearer has a Save characteristic of 3+. At the start of either player’s Command phase, you can spend 1 Pain token: if you do, the bearer regains all of its lost wounds."
       },
@@ -2805,13 +2832,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0a33dc74-7a18-57f8-994d-b6afb684bea6",
+      "id": "281b01dc-31cf-5ce3-8209-58211a44e3d7",
       "name": {
         "en": "Webway Awl"
       },
       "cost": "25",
       "keywords": ["Archon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ARCHON** model only. Models in the bearer’s unit have the Deep Strike ability, and you can target the bearer’s unit with the Rapid Ingress Stratagem for 0CP."
       },
@@ -2823,13 +2851,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cc500f15-d7c4-5a65-88f0-a5074fd05497",
+      "id": "2309a6f3-fb44-584d-a5e1-55e4b098fc41",
       "name": {
         "en": "Informant Network"
       },
       "cost": "30",
       "keywords": ["Archon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ARCHON** model only. At the start of the Declare Battle Formations step, select up to three **KABALITE WARRIORS** and/or **HAND OF THE ARCHON** units from your army; those units gain the Infiltrators ability."
       },
@@ -2841,13 +2870,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2ade1e65-19e7-53c4-9e61-89ad1f35de5a",
+      "id": "c483686e-57fc-5335-a7c5-f3346e1a8c0e",
       "name": {
         "en": "Towering Arrogance"
       },
       "cost": "20",
       "keywords": ["Archon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ARCHON** model only. While the bearer is leading a unit, improve the Leadership and Objective Control characteristics of models in that unit by 1."
       },
@@ -3153,7 +3183,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **COURT OF THE ARCHON** ■ **HAND OF THE ARCHON** ■ **INCUBI** ■ **KABALITE WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Hand of the Archon",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Incubi",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kabalite Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3d07f339-ebba-5e0e-85a9-016952e80876",
@@ -3526,7 +3573,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **INCUBI**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Incubi",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d41a6f29-d084-508a-b020-5f207c0c8e90",
@@ -3711,7 +3765,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WRACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Wracks",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b3b41fc4-05ac-5c0a-a27d-34855aa0bf49",
@@ -5454,7 +5515,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **HAND OF THE ARCHON** ■ **INCUBI** ■ **KABALITE WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Hand of the Archon",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Incubi",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kabalite Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "e69027cf-35e4-500e-ab20-0fb01cd281b0",
@@ -5621,7 +5699,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WYCHES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Wyches",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "163eda0b-b737-5705-8fcc-32284892df01",
@@ -7813,7 +7898,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WYCHES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Wyches",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "1e30664e-db2c-535b-bb85-4d6759053a26",

--- a/11th/gdc/emperors_children.json
+++ b/11th/gdc/emperors_children.json
@@ -7,7 +7,7 @@
     "header": "#1A3037"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.680Z",
+  "updated": "2026-07-28T17:03:11.561Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2278,7 +2278,7 @@
   ],
   "enhancements": [
     {
-      "id": "b2c3c50a-f01b-5611-8ec6-a546168e2a67",
+      "id": "24adc4fd-6fb2-5a90-ae9d-44c3962102c5",
       "name": {
         "en": "Beguiling Grotesquerie (Upgrade)",
         "de": "Betörend grotesk (Aufwertung)",
@@ -2292,6 +2292,7 @@
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Flawless Blades</k> unit only. Enemy units cannot target this unit with <b>snap shooting</b> attacks.",
         "de": "Nur für eine <k>Erlesene</k>-<k>Klingen</k>-Einheit. Feindliche Einheiten können gegen diese Einheit keine <b>Eiliger</b>-<b>Beschuss</b>-Attacken ausführen.",
@@ -2310,7 +2311,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4efba9fa-bb3d-5fbe-8d3f-08784155e81a",
+      "id": "a74fdb27-0670-5d78-804f-d3ab420b24ce",
       "name": {
         "en": "Frenzied Ferocity (Upgrade)",
         "de": "Rasende Wildheit (Aufwertung)",
@@ -2324,6 +2325,7 @@
       "cost": "15",
       "keywords": ["Terminator Squad", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Emperor’s Children Terminator Squad</k> unit only. This unit’s attacks have <k>[Sustained Hits 1]</k>.",
         "de": "Nur für eine <k>Emperor’s</k>-<k>Children</k>-<k>Terminatortrupp</k>-Einheit. Attacken dieser Einheit haben <k>[Trefferhagel 1]</k>.",
@@ -2342,7 +2344,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9c5fbdca-4ef8-518f-a3ce-98db165e2374",
+      "id": "3fb2f06b-2270-595d-956d-97e7a1f4fb8b",
       "name": {
         "en": "Euphoric Crown",
         "de": "Krone der Euphorie",
@@ -2356,6 +2358,7 @@
       "cost": "20",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Lord Exultant</k> model only. This model’s melee attacks have +1 <b>S</b>.",
         "de": "Nur für ein <k>Fürst</k>-<k>des</k>-<k>Überschwangs</k>-Modell. Nahkampfattacken dieses Modells haben +1 <b>S</b>.",
@@ -2374,7 +2377,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "01a2d13b-73ca-5840-b662-48a5769e29ef",
+      "id": "62a4e845-ac9b-5573-b270-a0cd0b223ac6",
       "name": {
         "en": "Howling Plate",
         "de": "Kreischende Rüstung",
@@ -2388,6 +2391,7 @@
       "cost": "20",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Lord Exultant</k> model only. This unit’s ranged attacks have +1 <b>AP</b>.",
         "de": "Nur für ein <k>Fürst</k>-<k>des</k>-<k>Überschwangs</k>-Modell. Die Fernkampfattacken dieser Einheit haben +1 <b>DS</b>.",
@@ -2406,7 +2410,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "88bd8282-7da6-54db-bf28-9701e76cf2cf",
+      "id": "88cc8546-6b3b-5a21-91f3-cc8aa724f1f6",
       "name": {
         "en": "Eager Patrons (Upgrade)",
         "de": "Ungeduldige Gönner (Aufwertung)",
@@ -2420,6 +2424,7 @@
       "cost": "20",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Flawless Blades</k> unit only. This unit has +2\" <b>M</b>.",
         "de": "Nur für eine <k>Erlesene</k>-<k>Klingen</k>-Einheit. Diese Einheit hat +2\" <b>B</b>.",
@@ -2438,7 +2443,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7ec08191-c0c6-5adb-8ecc-14d61fb12101",
+      "id": "3ea0ed08-371c-5d57-b321-c95b776031cc",
       "name": {
         "en": "Cacophonic Accompaniment",
         "de": "Kakofonischer Begleiter",
@@ -2452,6 +2457,7 @@
       "cost": "20",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Lord Kakophonist</k> model only. \r<ul><li>This model has <b>Deep Strike</b>.</li>\r<li>This unit’s ranged attacks have <k>[Ignores Cover]</k>.</li></ul>",
         "de": "Nur für ein <k>Fürst</k>-<k>der</k>-<k>Kakofonie</k>-Modell. \r<ul><li>Dieses Modell hat <b>Schocktruppen</b>.</li>\r<li>Fernkampfattacken dieser Einheit haben <k>[Deckung ignorieren]</k>.</li></ul>",
@@ -2470,13 +2476,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "90e47e4c-5375-5ee7-841c-151b9ac0ee91",
+      "id": "1a39a862-5a66-5624-b7d5-1f7f83c33b12",
       "name": {
         "en": "Steeped in Suffering"
       },
       "cost": "20",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Each time a model in the bearer’s unit makes an attack that targets an enemy unit below its Starting Strength, add 1 to the Hit roll. If that target is also Below Half-strength, add 1 to the Wound roll as well."
       },
@@ -2488,13 +2495,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "08a014ad-3db9-5868-94df-99d268394abf",
+      "id": "0b8bf59f-1469-56ae-8653-0b469623ab47",
       "name": {
         "en": "Intoxicating Musk"
       },
       "cost": "20",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Each time a melee attack targets the bearer’s unit, if the Strength characteristic of that attack is greater than the Toughness characteristic of that unit, subtract 1 from the Wound roll."
       },
@@ -2506,13 +2514,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2c5782f0-d01d-5a55-af09-1a814083e0b4",
+      "id": "b95a9a1f-7272-5226-953d-b6e652236838",
       "name": {
         "en": "Tactical Perfection"
       },
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. After both players have deployed their armies, select up to two **EMPEROR’S CHILDREN** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -2524,13 +2533,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1c90f147-7e8f-5f83-b14f-4d600cc7ed64",
+      "id": "0a02647a-fa33-5ec4-bf5b-ec34f45afd94",
       "name": {
         "en": "Loathsome Dexterity"
       },
       "cost": "10",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Each time a model in the bearer’s unit makes a Normal, Advance or Fall Back move, it can move through enemy models. When doing so, it can move within Engagement Range of such models but cannot end that move within Engagement Range of them, and any Desperate Escape test is automatically passed."
       },
@@ -2542,13 +2552,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ebc4d6a7-9ff9-57cc-b192-7fc1ff128d0c",
+      "id": "0b41aec2-0f69-5128-8dd8-2276505902bd",
       "name": {
         "en": "Faultless Opportunist"
       },
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. You can target this unit with the **Heroic Intervention stratagem**, regardless of any other uses of that **stratagem** this phase. If you do:\n\n▪ That use is -1 CP.\n\n▪ That use does not prevent any uses of that **stratagem** on other units this phase."
       },
@@ -2560,13 +2571,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "26af5bb2-b492-58c0-9d1b-27f1199e828a",
+      "id": "8dc938f6-5588-5f05-a0aa-bd7365509c1c",
       "name": {
         "en": "Blinding Speed"
       },
       "cost": "25",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Once per battle, at the start of the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, models in the bearer’s unit have the Fights First ability."
       },
@@ -2578,13 +2590,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b3abd724-13d8-5f04-9008-f4965a904944",
+      "id": "4f2670fd-1d61-508b-878e-ef7eec8d950f",
       "name": {
         "en": "Distortion"
       },
       "cost": "25",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Add 1 to the Attacks and Damage characteristics of melee weapons equipped by the bearer."
       },
@@ -2596,13 +2609,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fb834bed-a388-5c6a-bdb3-9b9b0ed4244b",
+      "id": "3eaa513d-00c9-55ff-917b-9872ec76d672",
       "name": {
         "en": "Rise to the Challenge"
       },
       "cost": "30",
       "keywords": ["Infantry", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN INFANTRY** model only. Once per battle, at the end of the Fight phase, if the bearer is within Engagement Range of three or more enemy models, it can use this Enhancement. If it does, the bearer can fight one additional time. When doing so, you can select one ability using the Exquisite Swordsmanship Detachment rule to apply to those attacks."
       },
@@ -2614,13 +2628,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "adca4395-3bff-5c48-acb6-a1773fd3495d",
+      "id": "8babde3c-c087-5232-a28f-914fa546adff",
       "name": {
         "en": "Sublime Prescience"
       },
       "cost": "25",
       "keywords": ["Infantry", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN INFANTRY** model only. Once per turn, in your Movement phase, the bearer can use this Enhancement. If it does, select one friendly **EMPEROR’S CHILDREN TRANSPORT** that is in Strategic Reserves. Until the end of the phase, for the purposes of setting up that **TRANSPORT** on the battlefield, treat the current battle round number as being one higher than it actually is."
       },
@@ -2632,13 +2647,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d99dd616-8d8c-5381-9156-4612429aea7d",
+      "id": "2bf0fa02-7798-50be-9a24-faca927bda1a",
       "name": {
         "en": "Spearhead Striker"
       },
       "cost": "20",
       "keywords": ["Infantry", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN INFANTRY** model only. Each time the bearer disembarks from a **TRANSPORT,** until the end of the turn, you can re-roll Charge rolls made for the bearer’s unit and enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2650,13 +2666,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dc989e31-6cb7-59c5-9e79-8c01058806f5",
+      "id": "217e11e6-dd51-5c98-8617-02143f5b9d2a",
       "name": {
         "en": "Accomplished Tactician"
       },
       "cost": "35",
       "keywords": ["Infantry", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN INFANTRY** model only. Once per turn, in your opponent’s Shooting phase, just after an enemy unit has shot, you can select one friendly **EMPEROR’S CHILDREN** unit within 9\" of the bearer that was hit by one or more of those attacks, then select one friendly **TRANSPORT** that unit is wholly within 6\" of and is able to embark within. That **EMPEROR’S CHILDREN** unit can embark within that **TRANSPORT.**"
       },
@@ -2668,13 +2685,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2656fadf-e423-576f-9428-1d66ae461d09",
+      "id": "2b8d98c0-655c-59da-a863-c872e8fe9bd7",
       "name": {
         "en": "Heretek Adept"
       },
       "cost": "35",
       "keywords": ["Infantry", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN INFANTRY** model only. Once per battle round, when a saving throw is failed for a friendly **EMPEROR’S CHILDREN VEHICLE** model within 6\" of the bearer, you can change the Damage characteristic of that attack to 0."
       },
@@ -2686,13 +2704,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f850b94c-bcc3-52b9-b819-be5d2371088c",
+      "id": "caa05d6e-5fe2-5151-82fa-6652a118d7b5",
       "name": {
         "en": "Empyric Suffusion"
       },
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR'S CHILDREN** model only. When you target this unit with the **Heroic Intervention stratagem**, that use is -1 CP."
       },
@@ -2704,13 +2723,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fb7a4719-65c7-5e1c-9f6d-3205a77bce6f",
+      "id": "c1fafb51-9a68-5e11-bea2-53b2226a62fc",
       "name": {
         "en": "Dark Blessings"
       },
       "cost": "10",
       "keywords": ["Infantry", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN INFANTRY** model only. Once per battle, just after an enemy unit has selected its targets, the bearer can use this Enhancement. If it does, until the end of the phase, the bearer has a 3+ invulnerable save."
       },
@@ -2722,13 +2742,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f460bfd5-3d75-5564-8fbf-e3510f334cca",
+      "id": "b1d04762-e8c7-5d36-af61-84a95336cb70",
       "name": {
         "en": "Possessed Blade"
       },
       "cost": "25",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. At the start of the battle, select one melee weapon equipped by the bearer; add 1 to the Attacks characteristic of that weapon. In addition, each time the bearer is selected to fight, it can use this Enhancement. If it does, while resolving those attacks, add 1 to the Damage characteristic of that weapon and that weapon has the **[DEVASTATING WOUNDS]** and **[HAZARDOUS]** abilities."
       },
@@ -2740,13 +2761,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "12485191-ead0-549d-be84-59e8a5ab164b",
+      "id": "487a0f1c-d22b-511d-b4a6-36cd283369eb",
       "name": {
         "en": "Warp Walker"
       },
       "cost": "30",
       "keywords": ["Emperor’s Children", "Keeper of Secrets"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** or **KEEPER OF SECRETS** model only. Each time the bearer’s unit Advances, do not make an Advance roll. Instead, until the end of the phase, add 6\" to the Move characteristic of models in that unit. Each time a model in the bearer’s unit makes a Normal, Advance or Fall Back move, it can move through enemy models. When doing so, it can move within Engagement Range of such models but cannot end that move within Engagement Range of them, and any Desperate Escape test is automatically passed."
       },
@@ -2758,13 +2780,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b344197e-9b2b-5ed4-a049-88f73fa83483",
+      "id": "8f76e73a-48c6-5ff9-b4ae-2029781a7b99",
       "name": {
         "en": "Pledge of Eternal Servitude"
       },
       "cost": "25",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. The first time the bearer is destroyed, take a Leadership test for the bearer at the end of the phase. If that test is passed, set the bearer back up on the battlefield, as close as possible to where it was destroyed and not within Engagement Range of one or more enemy units, with D6 wounds remaining (up to its Wounds characteristic)."
       },
@@ -2776,13 +2799,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c1db531-d45a-53b4-8ff5-7803d1c1834b",
+      "id": "b29cc47c-7425-5975-a3dd-79b24c68e4ad",
       "name": {
         "en": "Pledge of Dark Glory"
       },
       "cost": "25",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. While the bearer is leading a unit, improve the Leadership and Objective Control characteristics of models in that unit by 1."
       },
@@ -2794,13 +2818,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2420db88-b2e8-585a-86af-64278758926c",
+      "id": "dfb19287-4c63-570a-a1b9-371207bd000c",
       "name": {
         "en": "Pledge of Mortal Pain"
       },
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. At the start of your Shooting phase, select one enemy unit within 12\" of and visible to the bearer. That unit must take a Leadership test, subtracting 2 from the result if it is Battle-shocked: if failed, that enemy unit suffers 3 mortal wounds."
       },
@@ -2812,13 +2837,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bec49b8f-e068-5917-8919-55e9078c19a9",
+      "id": "e0a5122c-eff4-574e-90a6-c27776101c6d",
       "name": {
         "en": "Pledge of Unholy Fortune"
       },
       "cost": "30",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Once per turn, just after making a Hit roll, a Wound roll or a saving throw for a model in the bearer’s unit, if the bearer is not Battle-shocked, it can use this Enhancement. If it does, treat the result as an unmodified roll of 6 instead."
       },
@@ -2830,13 +2856,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6e9f9384-93aa-526f-a6ef-ccb28f2f46f8",
+      "id": "20583488-9b1a-5bda-849d-ef80d4aab6f4",
       "name": {
         "en": "Eager to Prove"
       },
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. You can re-roll Charge rolls made for the bearer’s unit. While the bearer’s unit is your army’s Favoured Champions, add 2\" to the Move characteristic of models in that unit."
       },
@@ -2848,13 +2875,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b36cf03c-c831-5cff-b967-d414d7d2cba1",
+      "id": "73e0ef95-c1f1-5873-bc6e-5b1950892b8f",
       "name": {
         "en": "Repulsed by Weakness"
       },
       "cost": "25",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Each time an enemy unit (excluding **MONSTERS** and **VEHICLES**) within Engagement Range of the bearer’s unit Falls Back, models in that enemy unit must take Desperate Escape tests. When doing so, if the bearer’s unit is your army’s Favoured Champions, subtract 1 from each of those Desperate Escape tests."
       },
@@ -2866,13 +2894,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "39b6fa61-fa68-5e55-87df-038fdd71be9a",
+      "id": "f63f079e-9727-5e05-9d1f-a252c8396d14",
       "name": {
         "en": "Proud and Vainglorious"
       },
       "cost": "20",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. You can re-roll Battle-shock and Leadership tests taken for the bearer’s unit. While the bearer’s unit is your army’s Favoured Champions, add 1 to the Objective Control characteristic of models in that unit."
       },
@@ -2884,13 +2913,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "189f87df-53e3-5494-bedd-241514e5e986",
+      "id": "41909ad2-b4c4-50c9-9d10-80da6b7da09b",
       "name": {
         "en": "Slayer of Champions"
       },
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. The bearer’s melee weapons have the **[PRECISION]** ability, and each time the bearer makes a melee attack that targets a **CHARACTER** unit, improve the Strength and Armour Penetration characteristics of that attack by 1."
       },
@@ -2902,13 +2932,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1bc92f5b-1c72-5742-8029-40471c8afd81",
+      "id": "6d8d13ad-cca9-5621-ba51-2c2f55d0ca98",
       "name": {
         "en": "Tears of the Phoenix"
       },
       "cost": "25",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. Each time a model in the bearer’s unit makes a melee attack, you can ignore any or all modifiers to that attack’s Weapon Skill characteristic and any or all modifiers to the Hit roll and Wound roll."
       },
@@ -2920,13 +2951,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c3d8cd54-a4f3-5eb3-b0f7-dfb7912fb42e",
+      "id": "90317c17-03c6-53f0-a794-6e5f021f5ca5",
       "name": {
         "en": "Exalted Patron"
       },
       "cost": "15",
       "keywords": ["Lord Exultant"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LORD EXULTANT** model only. Add 1\" to the Move characteristic of the bearer."
       },
@@ -2938,13 +2970,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0822640a-d687-58c9-b2f0-2cde23da0d5e",
+      "id": "b8966815-0d09-545e-b9f5-2a555ccad148",
       "name": {
         "en": "Soulstain Made Manifest"
       },
       "cost": "15",
       "keywords": ["Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN** model only. At the start of the Fight phase, you can select one enemy unit within Engagement Range of the bearer; that unit must take a Battle‑shock test, subtracting 1 from the result."
       },
@@ -2956,13 +2989,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7404603f-3925-53a3-a205-67078a07eab7",
+      "id": "01c88b81-71f9-59b7-8076-1bec0205bec0",
       "name": {
         "en": "Spiritsliver"
       },
       "cost": "20",
       "keywords": ["Daemon Prince", "Emperor’s Children"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EMPEROR’S CHILDREN DAEMON PRINCE** model only. Add 1 to the Strength and Attacks characteristics of the bearer’s melee weapons."
       },
@@ -6120,7 +6154,19 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **INFRACTORS** ■ **TORMENTORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Infractors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tormentors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a8ed149c-89a1-5abf-96ea-a843787fa9ab",
@@ -6328,7 +6374,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CHAOS TERMINATORS** ■ **NOISE MARINES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Chaos Terminators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Noise Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "42585cac-c2dd-5794-b249-0d5f945d8c7a",
@@ -6510,7 +6568,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **FLAWLESS BLADES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Flawless Blades",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "90f24438-6cf8-523c-969d-a952f329016a",
@@ -7177,7 +7242,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **INFRACTORS** ■ **NOISE MARINES** ■ **TORMENTORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Infractors",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Noise Marines",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tormentors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "659c16b1-cb74-5c9b-ba46-7e1e76cd1f01",

--- a/11th/gdc/faqs.json
+++ b/11th/gdc/faqs.json
@@ -2,7 +2,7 @@
   "source": "40k-11e",
   "cardType": "faq",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:13.924Z",
+  "updated": "2026-07-28T17:03:31.987Z",
   "faqs": [
     {
       "id": "47c0ea39-d74a-4379-afeb-1020ac3db03e",

--- a/11th/gdc/greyknights.json
+++ b/11th/gdc/greyknights.json
@@ -7,7 +7,7 @@
     "header": "#4a5e67"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.241Z",
+  "updated": "2026-07-28T17:03:06.362Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2041,7 +2041,7 @@
   ],
   "enhancements": [
     {
-      "id": "433e557e-66cf-5a8c-9931-6b0d1bb7a0bc",
+      "id": "e138d09d-2e6a-5570-a0b7-dad71e0eea5e",
       "name": {
         "en": "Precognicient Volleys (Upgrade)",
         "de": "Hellseherische Salven (Aufwertung)",
@@ -2055,6 +2055,7 @@
       "cost": "10",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Purgation Squad</k> unit only. This unit’s <b>snap shooting</b> attacks hit on unmodified <b>hit rolls</b> of 5+.",
         "de": "Nur für eine <k>Purgatortrupp</k>-Einheit. <b>Eiliger-Beschuss</b>-Attacken dieser Einheit treffen bei unmodifizierten <b>Trefferwürfen</b> von 5+.",
@@ -2073,7 +2074,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e685ee20-f440-546c-b0ef-2f54324b11f3",
+      "id": "64ab23b1-8cba-5eb1-80c1-fce74f0c964a",
       "name": {
         "en": "Predestined Coordinates (Upgrade)",
         "de": "Prophezeite Koordinaten (Aufwertung)",
@@ -2087,6 +2088,7 @@
       "cost": "10",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Interceptor Squad</k> unit only. In your first Movement phase, this unit can make an <b>ingress move</b>.",
         "de": "Nur für eine <k>Interceptortrupp</k>-Einheit. In deiner ersten Bewegungsphase kann diese Einheit eine <b>Einsatzbewegung</b> ausführen.",
@@ -2105,7 +2107,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c243100e-525e-559d-8d02-c1b422d04eb4",
+      "id": "a0a5c73c-da78-50e3-b6ee-2e2bb49eb8b7",
       "name": {
         "en": "Astral Overlap (Upgrade)",
         "de": "Astrale Überlappung (Aufwertung)",
@@ -2119,6 +2121,7 @@
       "cost": "10",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Interceptor Squad</k> unit only. This unit has <b>Stealth</b>.",
         "de": "Nur für eine <k>Interceptortrupp</k>-Einheit. Diese Einheit hat <b>Tarnung</b>.",
@@ -2137,7 +2140,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ae8431bb-1ffc-5cd2-a4de-963a73f3f55d",
+      "id": "5979b54e-27f6-5a78-93c2-bff04bcbd0cc",
       "name": {
         "en": "Psychic Celerity",
         "de": "Psionische Schnelligkeit",
@@ -2151,6 +2154,7 @@
       "cost": "15",
       "keywords": ["Terminator"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Terminator</k> model only. This unit has +1 to <b>charge rolls</b>.",
         "de": "Nur für ein <k>Terminator</k>-Modell. Diese Einheit hat +1 auf <b>Angriffswürfe</b>.",
@@ -2169,7 +2173,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dee2c4de-f2f3-519a-bee1-d0e83574230d",
+      "id": "79fd555d-47e9-5a5f-a7b2-7ca656d15d54",
       "name": {
         "en": "Boons of Deimos (Upgrade)",
         "de": "Gaben des Deimos (Aufwertung)",
@@ -2183,6 +2187,7 @@
       "cost": "20",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Purgation Squad</k> unit only. This unit’s ranged attacks have +2 <b>S</b>.",
         "de": "Nur für eine <k>Purgatortrupp</k>-Einheit. Die Fernkampfattacken dieser Einheit haben +2 <b>S</b>.",
@@ -2201,7 +2206,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "64ee9d84-5448-5aee-b69c-f565ee61cce2",
+      "id": "1cc93e4d-9d65-5439-a200-1faa9414d431",
       "name": {
         "en": "Vigilance of Titan",
         "de": "Titans Wachsamkeit",
@@ -2215,6 +2220,7 @@
       "cost": "20",
       "keywords": ["Terminator"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Terminator</k> model only. At the start of your Shooting phase, you can select one <b>visible</b> enemy unit within 12\" of this unit. That enemy unit has +6\" <b>detection range</b>.",
         "de": "Nur für ein <k>Terminator</k>-Modell. Zu Beginn deiner Fernkampfphase kannst du eine für diese Einheit <b>sichtbare</b> feindliche Einheit innerhalb von 12\" wählen. Jene feindliche Einheit hat +6\" <b>Entdeckungsreichweite</b>.",
@@ -2233,13 +2239,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7e698d92-ec5d-5bcd-b02e-cf23710fc022",
+      "id": "ede05d9c-274c-5f78-a142-ce4d8ee29177",
       "name": {
         "en": "Driven by Duty"
       },
       "cost": "10",
       "keywords": ["Walker", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS WALKER** model only. Each time the bearer’s unit Piles In or Consolidates, the bearer can move up to 6\" instead of up to 3\"."
       },
@@ -2251,13 +2258,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "22380042-ef60-5b99-bc79-777b0bc2fe80",
+      "id": "16d91493-493d-55a4-bd5a-3dcebe1d3d12",
       "name": {
         "en": "Banishing Wave (Psychic)"
       },
       "cost": "20",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Each time the bearer’s unit is set up using the Deep Strike ability, roll one D6 for each enemy unit within 12\" of the bearer: on a 2-5, that unit suffers 1 mortal wound; on a 6, that unit suffers D3 mortal wounds."
       },
@@ -2269,13 +2277,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6d48ba7b-4d22-59d8-a13c-88020d1ba840",
+      "id": "fe55cbdb-e5c8-528e-8694-a85d4e05ff20",
       "name": {
         "en": "Blinding Aura"
       },
       "cost": "10",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Each time the bearer’s unit is set up using the Deep Strike ability, until the end of the turn, enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2287,13 +2296,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6050cd10-80b7-57f3-8314-07839c953fd9",
+      "id": "87066016-cf89-5dcb-b4a6-9568396c8f0b",
       "name": {
         "en": "Quickening Foci"
       },
       "cost": "15",
       "keywords": ["Infantry", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS INFANTRY** model only. In your Movement phase, each time the bearer’s unit disembarks from a **TRANSPORT,** until the end of the turn, you can re-roll Charge rolls made for that unit."
       },
@@ -2305,13 +2315,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "33054cfa-b949-5e09-a912-e0354d8d9658",
+      "id": "46a7efb2-334c-5de3-a506-dca767f11f97",
       "name": {
         "en": "Purity of Purpose"
       },
       "cost": "15",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Each time the bearer’s unit is set up using the Deep Strike ability, until the end of the turn, you can re-roll Charge rolls made for the bearer’s unit."
       },
@@ -2323,13 +2334,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "688475f1-a7d4-5ea6-8c63-ffa0dfa2617c",
+      "id": "238b1869-2a62-5398-bcbf-0961c08cd6be",
       "name": {
         "en": "Sigil of Exigence"
       },
       "cost": "30",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Once per battle, in your opponent’s Shooting phase, when the bearer’s unit is selected as the target of a ranged attack, you can remove the bearer’s unit from the battlefield and then set it back up again anywhere on the battlefield that is more than 8\" horizontally away from all enemy units. If the bearer’s unit is no longer an eligible target, your opponent can then select new targets for any attacks that had targeted the bearer’s unit."
       },
@@ -2341,13 +2353,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2708640e-91a8-527e-bf09-ff2924a36e5b",
+      "id": "191cb497-91ba-5125-9e45-e0c12b38b1fc",
       "name": {
         "en": "Tome of Forbidden Ways"
       },
       "cost": "25",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. While the bearer is on the battlefield or in Strategic Reserves, add 1 to the number of units from your army that you can select for the Gate of Infinity rule."
       },
@@ -2359,13 +2372,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ac02728c-dbd6-5eb9-b89f-b7a55b7d4647",
+      "id": "5bd2f294-2fb2-5247-9612-55143a241f80",
       "name": {
         "en": "Spiritus Machina"
       },
       "cost": "25",
       "keywords": ["Infantry", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS INFANTRY** model only. In your Shooting phase, each time the bearer’s unit is selected to shoot, if the bearer’s unit disembarked from a **TRANSPORT** this turn, until the end of the phase, each time a model in the bearer’s unit makes an attack, you can re-roll the Wound roll."
       },
@@ -2377,13 +2391,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c63fd53-e7a8-5862-bff9-f041c75ccd98",
+      "id": "c16f0e00-e3b1-5c37-b28c-57c6f090a2ff",
       "name": {
         "en": "Mandulian Reliquary"
       },
       "cost": "20",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. While the bearer’s unit is not Battle‑shocked, add 3 to the bearer’s Objective Control characteristic."
       },
@@ -2395,13 +2410,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d8d5c4c2-7628-5096-bfe7-3f4e00a2b32b",
+      "id": "de51cddd-8310-52a1-b3ce-54926a513884",
       "name": {
         "en": "Radiant Champion"
       },
       "cost": "15",
       "keywords": ["Infantry", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS INFANTRY** model only. The bearer’s melee weapons have the **[PRECISION]** ability, and while the bearer is wholly within your army’s Hallowed Ground, each time a melee attack made by the bearer scores a wound, the target of that attack suffers 1 mortal wound in addition to any normal damage."
       },
@@ -2413,13 +2429,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c89e096c-e12d-50d4-a727-d0ec00988bca",
+      "id": "19dd6afe-08fa-5e0e-a41d-caeb25428165",
       "name": {
         "en": "Phial of the Abyss"
       },
       "cost": "15",
       "keywords": ["Infantry", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS INFANTRY** model only. Models in the bearer’s unit have the Stealth ability."
       },
@@ -2431,13 +2448,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "771e05f2-f57c-5e6b-a870-0f206c5c39ff",
+      "id": "ac6e38f0-8e3f-5519-9abe-50f5e25ee6a2",
       "name": {
         "en": "Paragon of Sanctity"
       },
       "cost": "10",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Once per battle, at the start of any phase, the bearer can select one friendly **GREY KNIGHTS** unit within 18\" of and visible to it. If it does, until the end of the phase, that unit is within your army’s Hallowed Ground."
       },
@@ -2449,13 +2467,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "261d2b3f-98b6-5afb-ad69-d71787676589",
+      "id": "65e0cd22-3d79-5be6-86f9-ed2df64f907a",
       "name": {
         "en": "Eye of the Augurium"
       },
       "cost": "25",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. You can target this unit with the **Heroic Intervention stratagem**, regardless of any other uses of that **stratagem** this phase. If you do:\n\n▪ That use is -1 CP.\n▪ That use does not prevent any uses of that **stratagem** on other units this phase."
       },
@@ -2467,13 +2486,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "05ba5e14-52c6-5ec0-b3c1-3fce9e32fa14",
+      "id": "1e53a742-b00d-5dc6-b55b-51110f350139",
       "name": {
         "en": "Inescapable Judgement (Psychic)"
       },
       "cost": "20",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Each time an enemy unit within Engagement Range of the bearer’s unit Falls Back, the bearer can use this Enhancement. If it does, roll one D6: on a 2-5, that enemy unit suffers D3 mortal wounds; on a 6, that enemy unit suffers D3+3 mortal wounds. These mortal wounds are Psychic Attacks."
       },
@@ -2485,13 +2505,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3a88daa3-6c80-5370-b9f6-6ea50fff0914",
+      "id": "16c80a1b-9082-56f7-b0cd-ff41a48f8955",
       "name": {
         "en": "Sanctic Reaper"
       },
       "cost": "15",
       "keywords": ["Terminator", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS TERMINATOR** model only. Add 3 to the Attacks characteristic of the bearer’s melee weapons."
       },
@@ -2503,13 +2524,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "adc06d6b-fe6b-597d-87f6-bb73d4561209",
+      "id": "0ff25c9c-9c03-52e5-897c-61c5ff1c3099",
       "name": {
         "en": "Nemesis Rounds"
       },
       "cost": "10",
       "keywords": ["Terminator", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS TERMINATOR** model only. Each time you target the bearer’s unit with the Fire Overwatch Stratagem, hits are scored on unmodified Hit rolls of 5+ while resolving that Stratagem."
       },
@@ -2521,13 +2543,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7a6bbb32-f9f7-5bcf-b62a-5cb691602454",
+      "id": "567c1756-23c9-57c5-a263-b74fc97d6eab",
       "name": {
         "en": "Sigil of the Hunt"
       },
       "cost": "10",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. In your Shooting phase, each time a model in the bearer’s unit makes an attack, re-roll a Hit roll of 1."
       },
@@ -2539,13 +2562,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "67012e18-c380-5087-803d-c11c70f4e4af",
+      "id": "3cb975af-2ca8-56a4-8ff1-86cab4461994",
       "name": {
         "en": "Ephemeral Tome"
       },
       "cost": "15",
       "keywords": ["Infantry", "Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS INFANTRY** model only. At the start of your Shooting phase, if the bearer’s unit is not within Engagement Range of one or more enemy units, the bearer can use this Enhancement. If it does, the bearer’s unit can make a Normal move of up to D6\", and until the end of the turn, the bearer’s unit is not eligible to declare a charge."
       },
@@ -2557,13 +2581,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e5d98985-7d49-5bfb-b71a-37161ebb1fdc",
+      "id": "0be380bb-0028-5f78-9628-0dff8c7e08b5",
       "name": {
         "en": "Sixty-sixth Seal"
       },
       "cost": "25",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. In your Shooting phase, each time a model in the bearer’s unit makes an attack, improve the Armour Penetration characteristic of that attack by 1."
       },
@@ -2575,13 +2600,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fbe9b45b-68f3-53cf-8b16-434406918e99",
+      "id": "f612bb94-ebcb-5d32-a09f-4e7e42d3e753",
       "name": {
         "en": "Pyresoul (Psychic)"
       },
       "cost": "20",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. At the start of your Shooting phase, the bearer can use this Enhancement. If it does, select one enemy unit within 24\" of and visible to the bearer; that unit suffers D3 mortal wounds."
       },
@@ -2593,13 +2619,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f77cb135-1180-556c-b308-22c2be67275c",
+      "id": "5597fa1e-8969-5e85-b7f3-9855057cd55d",
       "name": {
         "en": "Grimoire of Conjunctions"
       },
       "cost": "10",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Once per battle, at the start of the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, add 4 to the Strength characteristic of melee weapons equipped by the bearer."
       },
@@ -2611,13 +2638,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "59814a1b-a2ce-5166-8fac-b068d339073e",
+      "id": "62c95e5a-332e-58cb-9dcb-fc11c1967553",
       "name": {
         "en": "Shield of Prophecy"
       },
       "cost": "20",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Once per battle, at the start of the battle round, the bearer can use this Enhancement. If it does, until the end of the battle round, add 2 to the Toughness characteristic of models in the bearer’s unit."
       },
@@ -2629,13 +2657,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "52fd3cc6-eeb8-57ce-bd47-99858f432c12",
+      "id": "fc7a6dac-e442-5f84-9ea8-682a94a9b236",
       "name": {
         "en": "One Foot in the Future"
       },
       "cost": "15",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. When this unit ends an **ingress move**, you can use this ability. If you do:\n▪ This unit can make a **normal move** of up to D6\".\n▪ Until the end of the turn, this unit is not **eligible to declare a charge**."
       },
@@ -2647,13 +2676,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a3f8faa3-8507-546a-a122-50c66d0170b8",
+      "id": "ac4c7613-d65c-51b5-8037-75bd8368bd69",
       "name": {
         "en": "Doomseer’s Amulet"
       },
       "cost": "25",
       "keywords": ["Grey Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GREY KNIGHTS** model only. Each time the bearer’s unit is set up in your Reinforcements step, the bearer can use this Enhancement. If it does, select one enemy unit within 12\" of and visible to the bearer. That enemy unit must take a Battle-shock test, subtracting 1 from that test."
       },
@@ -2920,7 +2950,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BROTHERHOOD TERMINATOR SQUAD** ■ **PALADIN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Brotherhood Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Paladin Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "116708b0-8e85-502e-bade-efc6cffe2251",
@@ -3099,7 +3141,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PURGATION SQUAD** ■ **STRIKE SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Purgation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Strike Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a196334f-705a-5c01-939c-29532382942a",
@@ -3277,7 +3331,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BROTHERHOOD TERMINATOR SQUAD** ■ **PALADIN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Brotherhood Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Paladin Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "ed58e505-b825-5724-83a6-a0271413d051",
@@ -3515,7 +3581,19 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BROTHERHOOD TERMINATOR SQUAD** ■ **PALADIN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Brotherhood Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Paladin Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "eeb060e8-3807-55c1-a07d-c836e0cd370d",
@@ -3742,7 +3820,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PURGATION SQUAD** ■ **PURIFIER SQUAD** ■ **STRIKE SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Purgation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Purifier Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Strike Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "09b7e6e4-9a1c-5fa8-bcd2-119f1feda5fe",
@@ -4320,7 +4415,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PURIFIER SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Purifier Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f29aef55-8607-5cfb-8bac-1d235c1ca41a",
@@ -4575,7 +4677,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BROTHERHOOD TERMINATOR SQUAD** ■ **PALADIN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Brotherhood Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Paladin Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "451119d5-36e0-50e4-936c-0bc8cf5eef22",
@@ -5184,7 +5298,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BROTHERHOOD TERMINATOR SQUAD** ■ **PALADIN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Brotherhood Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Paladin Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "ce388f5e-eacb-5433-a787-d00ca5b0b4bf",

--- a/11th/gdc/gsc.json
+++ b/11th/gdc/gsc.json
@@ -7,7 +7,7 @@
     "header": "#391625"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.561Z",
+  "updated": "2026-07-28T17:03:11.326Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2117,7 +2117,7 @@
   ],
   "enhancements": [
     {
-      "id": "4deefff4-96f0-5304-b92c-4ac623aac03c",
+      "id": "c713f198-0ab1-5c32-b698-ffe2caad9568",
       "name": {
         "en": "Talons of the Sire",
         "de": "Krallen des Patriarchen",
@@ -2131,6 +2131,7 @@
       "cost": "15",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Patriarch</k> model only. This unit’s attacks can re‑roll <b>wound rolls</b> of 1.",
         "de": "Nur für ein <k>Patriarch</k>-Modell. Für Attacken dieser Einheit können <b>Verwundungswürfe</b> von 1 wiederholt werden.",
@@ -2149,7 +2150,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "030b80d8-b79f-505a-bd37-d1ede85198e9",
+      "id": "cf0ab64b-c1c1-5b57-a752-c80d9a36f53e",
       "name": {
         "en": "Inspired to Greatness",
         "de": "Zu Großem inspiriert",
@@ -2163,6 +2164,7 @@
       "cost": "15",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Magus</k>/<k>Primus</k> model only. This unit’s attacks can re‑roll <b>damage rolls</b>.",
         "de": "Nur für ein <k>Magus</k>-/<k>Primus</k>-Modell. Für Attacken dieser Einheit können <b>Schadenswürfe</b> wiederholt werden.",
@@ -2181,7 +2183,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "43dd720c-45cd-571a-b5bb-ee6af9bbcbbe",
+      "id": "f4aa01f0-3c00-5eae-b3e3-eab05e08be7c",
       "name": {
         "en": "Devious Disguises (Upgrade)",
         "de": "Verschlagene Verkleidung (Aufwertung)",
@@ -2195,6 +2197,7 @@
       "cost": "15",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Neophyte Hybrids</k> unit only. This unit has -3\" <b>detection range</b>.",
         "de": "Nur für eine <k>Neophyten-Hybriden</k>-Einheit. Diese Einheit hat -3\" <b>Entdeckungsreichweite</b>.",
@@ -2213,7 +2216,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c1e33911-8a35-5b94-b2cf-98274db14f21",
+      "id": "fc396d38-9d3e-5791-ae0d-215efbd24e4f",
       "name": {
         "en": "Contraband Munitions",
         "de": "Schwarzmarktmunition",
@@ -2227,6 +2230,7 @@
       "cost": "20",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Kelermorph/Reductus Saboteur</k> model only. This unit’s ranged attacks have +2 <b>S</b>.",
         "de": "Nur für ein <k>Kelermorph</k>-<k>/Reductus-Saboteur</k>-Modell. Fernkampf­attacken dieser Einheit haben +2 <b>S</b>.",
@@ -2245,7 +2249,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e8cd57b2-1e0e-5b63-a22c-bf01ab9e7a59",
+      "id": "32f0bbb4-861d-5bf8-a0d1-0a974f0f825d",
       "name": {
         "en": "Mark of the Star Children (Upgrade)",
         "de": "Zeichen der Sternenkinder (Aufwertung)",
@@ -2259,6 +2263,7 @@
       "cost": "30",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Purestrain Genestealers</k> unit only. This unit has:\r<ul><li>+1 <b>T</b>.</li>\r<li>4+ <b>Sv</b>.</li>\r<li>This unit’s melee attacks have +1 <b>S</b>.</li></ul>",
         "de": "Nur für eine <k>Reinerbige</k>-<k>Symbionten</k>-Einheit. Diese Einheit hat:\r<ul><li>+1 <b>W</b>.</li>\r<li>4+ <b>RW</b>.</li>\r<li>Nahkampfattacken dieser Einheit haben +1 <k>S</k>. </li></ul>",
@@ -2277,7 +2282,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7e7cdb45-95da-56d0-acd0-96c2248eadb3",
+      "id": "35ee45d6-0c28-58d6-beb2-9adfc45e662b",
       "name": {
         "en": "Gene-tailored Toxins",
         "de": "Maßgeschneiderte Toxine",
@@ -2291,6 +2296,7 @@
       "cost": "35",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Locus/Sanctus</k> model only. This model’s attacks have +1 <b>D</b>.",
         "de": "Nur für ein <k>Locus</k>-<k>/Sanctus</k>-Modell. Die Attacken dieses Modells haben +1 <b>SW</b>.",
@@ -2309,13 +2315,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9153ec8f-5fbf-595f-9eee-f5e035f998c2",
+      "id": "eaa75610-360b-5873-8082-aa1dffdc80fe",
       "name": {
         "en": "Prowling Agitant"
       },
       "cost": "15",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. In your opponent's Movement phase, if an enemy unit ends a move within 8” of this unit, if this unit is not within Engagement Range of one or more enemy units, this unit can make a Normal move of up to D6”.'"
       },
@@ -2327,13 +2334,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1388e500-e1d7-5cbb-a5d8-4f8ac6db95e1",
+      "id": "900da2ac-8147-5c3a-8d3a-0d355b516502",
       "name": {
         "en": "A Chink In Their Armour"
       },
       "cost": "20",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. Each time the bearer is set up on the battlefield as Reinforcements, until the end of your next Fight phase, ranged weapons equipped by models in the bearer’s unit have the **[LETHAL HITS]** ability."
       },
@@ -2345,13 +2353,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "19ba27af-e61c-5a8e-aa06-c391a18f0063",
+      "id": "1fb97a02-fe85-56ab-8152-a9d984fc110e",
       "name": {
         "en": "Our Time is Nigh"
       },
       "cost": "20",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. Once per battle, when the bearer’s unit declares a charge, the bearer can use this Enhancement. If it does, until the end of the phase, add 2 to Charge rolls made for the bearer’s unit."
       },
@@ -2363,13 +2372,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a474ddcc-0b37-51bc-80c4-46baca4509e4",
+      "id": "db880ecf-5895-5a73-a477-754f4b61082f",
       "name": {
         "en": "Assassination Edict"
       },
       "cost": "15",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. Each time a model in the bearer’s unit makes an attack that targets a **CHARACTER** unit, add 1 to the Hit roll."
       },
@@ -2381,13 +2391,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a065f139-223d-5d30-9efa-e84e24177a89",
+      "id": "a2b5d0e2-313c-5bcf-89ed-0b8302d8e881",
       "name": {
         "en": "Gene-sire’s Reliquant"
       },
       "cost": "5",
       "keywords": ["Primus", "Magus", "Acolyte Iconward"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MAGUS**, **PRIMUS** or **ACOLYTE ICONWARD** model only. You can re‐roll Battle‐shock tests taken for the bearer’s unit."
       },
@@ -2399,13 +2410,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "369032d0-7f2d-5157-8225-a6618afd18c9",
+      "id": "1aa705c7-3c7b-5f5e-bf78-b51886bb13c8",
       "name": {
         "en": "Denunciator of Tyrants"
       },
       "cost": "25",
       "keywords": ["Magus", "Acolyte Iconward", "Primus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MAGUS**, **PRIMUS** or **ACOLYTE ICONWARD** model only. Each time a model in the bearer’s unit makes an attack that targets a **CHARACTER** unit, add 1 to the Hit roll and add 1 to the Wound roll."
       },
@@ -2417,13 +2429,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c7211a47-665d-5395-b71d-2876865f6c1f",
+      "id": "1b451604-f987-513f-a626-ffdb4da5dd27",
       "name": {
         "en": "Deeds that Speak to the Masses"
       },
       "cost": "25",
       "keywords": ["Primus", "Magus", "Acolyte Iconward"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MAGUS**, **PRIMUS** or **ACOLYTE ICONWARD** model only. You start the battle with 2 additional Resurgence points."
       },
@@ -2435,13 +2448,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4755d751-bb02-537a-8011-27b33ca0e6e7",
+      "id": "b16552d0-a814-5096-984f-b3021e9ee6a6",
       "name": {
         "en": "Incendiary Inspiration"
       },
       "cost": "15",
       "keywords": ["Primus", "Acolyte Iconward", "Magus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MAGUS**, **PRIMUS** or **ACOLYTE ICONWARD** model only. The bearer’s unit is eligible to declare a charge in a turn in which it Advanced."
       },
@@ -2453,13 +2467,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "86cf6105-739c-5786-8d23-895f2a9391c4",
+      "id": "3ce9b292-fde9-5689-b4c2-3b903d9c5fb9",
       "name": {
         "en": "Predatory Instincts"
       },
       "cost": "20",
       "keywords": ["Abominant", "Biophagus", "Patriarch"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ABOMINANT**, **BIOPHAGUS** or **PATRIARCH** model only.\n<ul><li>Models in the bearer's unit have the Infiltrators ability.</li>\n<li>You can target this unit with the **Heroic Intervention stratagem**, regardless of any other uses of that **stratagem** this phase. If you do:</li>\n<ul><li>That use is -1 CP.</li>\n<li>That use does not prevent any uses of that **stratagem** on other units this phase.</li></ul></ul>"
       },
@@ -2471,13 +2486,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ce758897-69df-5be5-b925-f69f082f5de7",
+      "id": "e4c64241-077d-5916-bcfa-2e4bb15a57e2",
       "name": {
         "en": "Biomorph Adaptation"
       },
       "cost": "25",
       "keywords": ["Abominant", "Patriarch"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ABOMINANT** or **PATRIARCH** model only. Improve the Armour Penetration and Damage characteristics of melee weapons equipped by the bearer by 1."
       },
@@ -2489,13 +2505,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6382ab2a-2ade-5d14-98c5-1c3c939735b8",
+      "id": "10aeda5f-c67c-5017-b88f-1eab2372201c",
       "name": {
         "en": "Mutagenic Regeneration"
       },
       "cost": "10",
       "keywords": ["Abominant", "Patriarch", "Biophagus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ABOMINANT**, **BIOPHAGUS** or **PATRIARCH** model only. In each Command phase, one model in the bearer’s unit regains 1 lost wound."
       },
@@ -2507,13 +2524,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "655bd0be-a1d4-5ba9-982b-b2e06e3a5d1a",
+      "id": "b90b4826-6a14-588a-9a6a-59333ee075ce",
       "name": {
         "en": "Alien Majesty"
       },
       "cost": "15",
       "keywords": ["Abominant", "Patriarch", "Biophagus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ABOMINANT**, **BIOPHAGUS** or **PATRIARCH** model only. While an enemy unit is within Engagement Range of the bearer’s unit, subtract 1 from the Objective Control characteristic of models in that enemy unit (to a minimum of 1)."
       },
@@ -2525,13 +2543,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "638b6a0b-0412-5840-80d1-a188faad4be1",
+      "id": "7350d274-d039-51bb-a7d9-9381a2a8b98f",
       "name": {
         "en": "Serpentine Tactics"
       },
       "cost": "10",
       "keywords": ["Mounted", "Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS MOUNTED** model only. The bearer’s unit is eligible to shoot in a turn in which it Fell Back."
       },
@@ -2543,13 +2562,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e5337f3c-233d-50ab-a154-9cea2fe80ecc",
+      "id": "0913b0d1-7eda-567f-be22-042c4863f0e2",
       "name": {
         "en": "Cartographic Data-leech"
       },
       "cost": "10",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. While the bearer is embarked within a **TRANSPORT**, each time that **TRANSPORT** is selected to shoot, until the end of the phase, improve the Ballistic Skill characteristic of ranged weapons equipped by that **TRANSPORT** as a result of the Firing Deck ability by 1."
       },
@@ -2561,13 +2581,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d4caa359-67b2-5f1b-a6ae-99b73cc989db",
+      "id": "d1b7c336-9b20-5213-b0ea-0f8bda24e091",
       "name": {
         "en": "Starfall Shells"
       },
       "cost": "10",
       "keywords": ["Mounted", "Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS MOUNTED** model only. In your Shooting phase, after the bearer has shot, select one enemy unit hit by one or more of those attacks made with a cult sniper rifle. Until the start of your next Shooting phase, each time a model in that enemy unit makes an attack, subtract 1 from the Hit roll."
       },
@@ -2579,13 +2600,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4ff59797-7b8c-5f0d-8d1f-bf438b1f3f9b",
+      "id": "0e599713-8cae-5082-aaa1-4541422f1bf1",
       "name": {
         "en": "Assault Commando"
       },
       "cost": "15",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. Each time a model in the bearer’s unit makes a ranged attack, if it disembarked from a **TRANSPORT** this turn, you can re‐roll the Hit roll."
       },
@@ -2597,13 +2619,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c92a0439-eeb1-587c-9fa6-e867aeb791a0",
+      "id": "6d71a1bc-74cb-5d6a-81d5-5927aa947d55",
       "name": {
         "en": "Martial Espionage"
       },
       "cost": "25",
       "keywords": ["Infantry", "Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS INFANTRY** model only. Once per turn, when a friendly **ASTRA MILITARUM INFANTRY** or **ASTRA MILITARUM MOUNTED** unit within 9\" of the bearer is selected to shoot, the bearer can use this Enhancement. If it does, until the end of the phase, improve the Armour Penetration characteristic of ranged weapons equipped by models in that unit by 1."
       },
@@ -2615,13 +2638,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fd265b34-90ed-5fee-97d3-7fb52856469d",
+      "id": "da1a6cee-933e-57f4-ad9a-4b3bf797b497",
       "name": {
         "en": "Adaptive Reprisal"
       },
       "cost": "15",
       "keywords": ["Infantry", "Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS INFANTRY** model only. When you target this unit with the **Heroic Intervention stratagem**, that use is -1 CP."
       },
@@ -2633,13 +2657,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f423b99b-206f-5e37-9a7d-a38884e4cbf2",
+      "id": "483d99c5-36c8-560c-97ba-7aae6faf25ec",
       "name": {
         "en": "The Hero Returned"
       },
       "cost": "20",
       "keywords": ["Infantry", "Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS INFANTRY** model only. Improve the Leadership and Objective Control characteristics of models in the bearer’s unit by 1."
       },
@@ -2651,13 +2676,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2b2c7731-a91a-5b24-acbe-241ff62f8498",
+      "id": "13413356-51da-51aa-aab9-a55ef1f7c1e8",
       "name": {
         "en": "Fire-point Commander"
       },
       "cost": "10",
       "keywords": ["Infantry", "Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS INFANTRY** model only. Each time you target the bearer’s unit with the Fire Overwatch Stratagem, while resolving that Stratagem, hits are scored on unmodified Hit rolls of 5+."
       },
@@ -2669,13 +2695,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d3f26038-be15-58e2-aece-6cda803259aa",
+      "id": "a7175827-420e-5b6e-9d27-2c2131125918",
       "name": {
         "en": "Synaptic Auger"
       },
       "cost": "15",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. Each time the bearer would regain one or more lost wounds from the Psionic Parasitism Detachment rule, it regains up to twice that number of lost wounds instead."
       },
@@ -2687,13 +2714,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "06c06c0f-9b02-5547-9793-12893854eab8",
+      "id": "b94f4cdc-1676-5a7f-a68a-9795f13734b7",
       "name": {
         "en": "Enraptured Damnation"
       },
       "cost": "10",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. Enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2705,13 +2733,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "367bbec6-e10f-5881-ba4e-196f9657eb62",
+      "id": "78ad9859-71e5-5ae6-84fd-ca604d2fe453",
       "name": {
         "en": "Vanguard Tyrant"
       },
       "cost": "25",
       "keywords": ["Winged Hive Tyrant"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WINGED HIVE TYRANT** model only. Improve the Strength and Armour Penetration characteristics of melee weapons equipped by the bearer by 1."
       },
@@ -2723,13 +2752,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "84456dba-422a-52d2-b9ed-e3d4dbbf979f",
+      "id": "90f4fe4d-df4f-5f84-950e-226fee32ca90",
       "name": {
         "en": "Inhuman Integration"
       },
       "cost": "20",
       "keywords": ["Genestealer Cults"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GENESTEALER CULTS** model only. Weapons equipped by models in the bearer’s unit have the **[SUSTAINED HITS 1]** ability while targeting an enemy unit within 6\" of one or more friendly **TYRANIDS** units."
       },
@@ -3040,7 +3070,14 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ABERRANTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aberrants",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5d8d96bd-da91-5ee6-aad3-e9eea1a4c84e",
@@ -4038,7 +4075,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACOLYTE HYBRIDS WITH AUTOPISTOLS** ■ **ACOLYTE HYBRIDS WITH HAND FLAMERS** ■ **HYBRID METAMORPHS** ■ **NEOPHYTE HYBRIDS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "8402f9e4-eda8-559e-96fb-6a64a44110a0",
@@ -4582,7 +4641,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACOLYTE HYBRIDS WITH AUTOPISTOLS** ■ **ACOLYTE HYBRIDS WITH HAND FLAMERS** ■ **HYBRID METAMORPHS** ■ **NEOPHYTE HYBRIDS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "cfdb4aa9-ff45-5a9e-8a4e-ea6f50128ad3",
@@ -4796,6 +4877,33 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Aberrants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -4971,6 +5079,28 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -5908,7 +6038,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ATALAN JACKALS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Atalan Jackals",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "dfedd2b9-1c09-5540-b1eb-4db139e1a860",
@@ -6231,6 +6368,28 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -6408,7 +6567,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACOLYTE HYBRIDS WITH AUTOPISTOLS** ■ **ACOLYTE HYBRIDS WITH HAND FLAMERS** ■ **HYBRID METAMORPHS** ■ **NEOPHYTE HYBRIDS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "ec6bdc77-1eec-501e-be1a-1e4105102db9",
@@ -7060,6 +7241,28 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -7229,7 +7432,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PURESTRAIN GENESTEALERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Purestrain Genestealers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6bc7aa70-cfae-5340-ad63-c7e925499136",
@@ -7416,7 +7626,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ACOLYTE HYBRIDS WITH AUTOPISTOLS** ■ **ACOLYTE HYBRIDS WITH HAND FLAMERS** ■ **HYBRID METAMORPHS** ■ **NEOPHYTE HYBRIDS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Autopistols",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Acolyte Hybrids with Hand Flamers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hybrid Metamorphs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Neophyte Hybrids",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a070396e-3f03-567d-984c-8f65dc57e5ea",

--- a/11th/gdc/imperialknights.json
+++ b/11th/gdc/imperialknights.json
@@ -7,7 +7,7 @@
     "header": "#023e58"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:52.076Z",
+  "updated": "2026-07-28T17:03:06.045Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -1977,7 +1977,7 @@
   ],
   "enhancements": [
     {
-      "id": "790d79e8-d02f-52ac-8449-28bf3c0016fb",
+      "id": "46b8149a-0264-50a6-90b3-8395b87ed482",
       "name": {
         "en": "Ancestral Overbleed (Upgrade)",
         "de": "Ahnengeistübertragung (Aufwertung)",
@@ -1991,6 +1991,7 @@
       "cost": "10",
       "keywords": ["Armiger"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Armiger</k> unit only. When you target this unit with the <b>Fire Overwatch/Heroic Intervention stratagem</b>, that use is ‑1 <b>CP</b>.",
         "de": "Nur für eine <k>Knappe</k>-Einheit. Wenn du die <b>Gefechtsoption Abwehr­feuer geben/Heroische Intervention</b> mit dieser Einheit als Ziel einsetzt, kostet jener Einsatz ‑1 <b>BP</b>.",
@@ -2009,7 +2010,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7d594dda-7286-5383-87b4-6b319e24ee1f",
+      "id": "61fd76a9-aabb-5b3b-ac01-4bb8b438f06c",
       "name": {
         "en": "Knight of the Opus Machina (Aura)",
         "de": "Ritter des Opus Machina",
@@ -2023,6 +2024,7 @@
       "cost": "15",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Imperial Knights</k> model only. While a friendly <k>Adeptus Mechanicus</k> unit is within 6\" of this model, that <k>Adeptus Mechanicus</k> unit’s melee attacks have +1 <b>WS</b> and <b>AP</b>.",
         "de": "Nur für ein <k>Imperiale</k>-<k>Ritter</k>-Modell. Solange sich eine befreundete <k>Adeptus</k>-<k>Mechanicus</k>-Einheit innerhalb von 6\" um dieses Modell befindet, haben Nahkampfattacken jener <k>Adeptus</k>-<k>Mechanicus</k>-Einheit +1 <b>KG</b> und <b>DS</b>.",
@@ -2041,7 +2043,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6c5032dc-ee80-5ceb-be68-a10aa61da96e",
+      "id": "896d9b76-ad2c-5fb1-9a08-5b9fa074328d",
       "name": {
         "en": "Gyro-optimised Actuators (Upgrade)",
         "de": "Gyrooptimierter Bewegungsapparat (Aufwertung)",
@@ -2055,6 +2057,7 @@
       "cost": "15",
       "keywords": ["Armiger"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Armiger</k> unit only. This unit has <k>Mobile</k>.",
         "de": "Nur für eine <k>Knappe</k>-Einheit. Diese Einheit hat <k>Mobil</k>.",
@@ -2073,7 +2076,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "46269259-a3be-56e1-a17e-24a201c0dca7",
+      "id": "0f51fb69-3363-5061-86a6-fac63e126541",
       "name": {
         "en": "Magos Questoris",
         "de": "Questoris-Magos",
@@ -2087,6 +2090,7 @@
       "cost": "20",
       "keywords": ["Tech-Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Tech‑Priest</k> model only. When using this model’s <b>Sacristan Pledge</b> ability, the selected <k>Imperial Knights</k> model <b>heals</b> 2 additional wounds.",
         "de": "Nur für ein <k>Techpriester</k>-Modell. Wenn dieses Modell seine Fähigkeit <b>Eid der Sakristane</b> einsetzt, wird das gewählte <k>Imperiale</k>-<k>Ritter</k>-Modell um 2 zusätzliche Lebenspunkte <b>geheilt</b>.",
@@ -2105,7 +2109,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9d71a427-b0b3-58f7-ac1e-3e4af545da49",
+      "id": "f1998eca-968d-53a5-a8f2-7357748e84d1",
       "name": {
         "en": "Archeotech Autoloaders",
         "de": "Archäotech-Autolader",
@@ -2119,6 +2123,7 @@
       "cost": "25",
       "keywords": ["Dominus", "Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Imperial Knights Dominus</k> model only. This unit can re‑roll rolls to determine the <b>A</b> of a weapon.",
         "de": "Nur für ein <k>Imperiale</k>-<k>Ritter</k>-<k>Dominus</k>-Modell. Diese Einheit kann Würfe wiederholen, um die <b>A</b> einer Waffe zu bestimmen.",
@@ -2137,7 +2142,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "57a8a94f-9d90-5514-b4cb-251d9dd3dccb",
+      "id": "ba8d63c3-9271-567e-aa07-24819b38d3f8",
       "name": {
         "en": "Blessed Plate",
         "de": "Geweihte Panzerung",
@@ -2151,6 +2156,7 @@
       "cost": "30",
       "keywords": ["Dominus", "Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Imperial Knights Dominus</k> model only. This model has +1 <b>T</b>.",
         "de": "Nur für ein <k>Imperiale</k>-<k>Ritter</k>-<k>Dominus</k>-Modell. Dieses Modell hat +1 <b>W</b>.",
@@ -2169,13 +2175,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "14bd5b3b-0897-5fe5-9f8c-07a80e400430",
+      "id": "95f3734c-a94d-5d00-9855-ce28f8699bf7",
       "name": {
         "en": "Bearer of the Iron Chalice"
       },
       "cost": "20",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. At the end of your Movement phase, select one other **IMPERIAL KNIGHTS** model from your army that is within 12\" of and visible to the bearer. That selected model regains up to D3 lost wounds, or up to 3 lost wounds if your army is Honoured."
       },
@@ -2187,13 +2194,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8a86f2f2-e00b-5904-bf77-450c3574772a",
+      "id": "2c28a347-9701-53d0-9ae0-657be01f38dd",
       "name": {
         "en": "Bearer of the Evanescent Ion"
       },
       "cost": "15",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. At the end of your Movement phase, select one other **IMPERIAL KNIGHTS** model from your army that is within 12\" of and visible to the bearer. Until the start of your next Movement phase, that selected model has the Stealth ability."
       },
@@ -2205,13 +2213,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "27261679-3223-5201-ba40-3c5e8deba480",
+      "id": "b8fadecf-f29a-5d10-8703-1b80bcec9ed3",
       "name": {
         "en": "Bearer of the Judicant’s Helm"
       },
       "cost": "25",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. At the start of your Shooting phase, select one other **IMPERIAL KNIGHTS** model from your army that is within 12\" of and visible to the bearer. Until the end of the phase, ranged weapons equipped by that selected model have the **[IGNORES COVER]** ability."
       },
@@ -2223,13 +2232,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "da9ca7d7-a78f-5213-ac1b-dc1a2bf7cd9d",
+      "id": "ce3b68fe-d38e-54be-9c05-9650f60dd448",
       "name": {
         "en": "Bearer of the Lancer’s Sigil"
       },
       "cost": "25",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. At the start of your Charge phase, select one other **IMPERIAL KNIGHTS** model from your army that is within 12” of and visible to the bearer. Until the end of the phase, you can re‑roll Charge rolls made for that selected model."
       },
@@ -2241,13 +2251,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "503fca33-45f2-5a2b-9007-0405785252b7",
+      "id": "423f956d-5bbe-5ff9-a984-0e92c1f88bb5",
       "name": {
         "en": "Acquisitor-at-Arms"
       },
       "cost": "15",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. While the bearer is on your defensive line and there are no enemy units on your defensive line, add the bearer’s Objective Control characteristic to that of each model affected by the bearer’s Bondsman ability."
       },
@@ -2259,13 +2270,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "57790405-796c-562b-b8be-a36b4f761d62",
+      "id": "1217969e-e209-5bf9-abee-e1e2bacdc3ce",
       "name": {
         "en": "Purgation’s Hand"
       },
       "cost": "20",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. Each time the bearer makes a melee attack, if the bearer is on your defensive line, re‑roll a Hit roll of 1 and re-roll a Wound roll of 1."
       },
@@ -2277,13 +2289,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4b872e10-285a-54fe-babe-fe022ef825e8",
+      "id": "5d9f06d1-ee4c-5c98-a67e-78b750118cf4",
       "name": {
         "en": "Augury Halo"
       },
       "cost": "20",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. Each time the bearer makes a ranged attack, while the bearer is on your defensive line, weapons equipped by the bearer have the **[IGNORES COVER]** ability."
       },
@@ -2295,13 +2308,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "46b4d6c2-f434-5b5d-a8a2-e5b8f569ceea",
+      "id": "520c0dee-9836-50ae-989f-39618039dd53",
       "name": {
         "en": "Vengeful Tread"
       },
       "cost": "15",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. Once per turn, you can target the bearer with the Tank Shock Stratagem for 0CP."
       },
@@ -2313,13 +2327,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "90339d5c-61db-5689-bdc4-78ec4cac3bee",
+      "id": "fbf00b30-9431-5710-a42b-71c04206546a",
       "name": {
         "en": "Herald of Triumph"
       },
       "cost": "15",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. When the bearer ends a Charge move, it can use this Enhancement. If it does, this Enhancement is expended, then each enemy unit within Engagement Range of the bearer must take a Battle‑shock test, subtracting 1 from the result."
       },
@@ -2331,13 +2346,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c461e8e-8730-5b73-8405-508e7c993e56",
+      "id": "961e3ae7-7406-5189-b43a-5b35f210156f",
       "name": {
         "en": "Wyrmslayer Divination"
       },
       "cost": "10",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. In your Shooting phase, when the bearer is selected to shoot, it can use this Enhancement. If it does, this Enhancement is expended, then until the end of the phase, each time it makes an attack that targets a unit that can **FLY**, you can re‑roll the Hit roll."
       },
@@ -2349,13 +2365,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "28c14fec-af11-5c91-a4bd-14280c681235",
+      "id": "327298b2-3840-5c26-8017-ecaad98e8899",
       "name": {
         "en": "Pennant of Silvered Fury"
       },
       "cost": "15",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. When the bearer is selected to fight, it can use this Enhancement. If it does, this Enhancement is expended, then until the end of the phase, melee weapons equipped by the bearer have the **[SUSTAINED HITS 2]** ability."
       },
@@ -2367,13 +2384,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "09bf184f-9931-58b6-a3b8-b936997cb135",
+      "id": "d7f686d8-d3fc-547b-b947-4cc13676e178",
       "name": {
         "en": "Crushing Condemnation"
       },
       "cost": "10",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. When the bearer is selected to fight, after resolving its attacks, if one or more enemy units were destroyed by those attacks, the bearer can use this Enhancement. If it does, this Enhancement is expended, then select one enemy unit that is not within Engagement Range of any units from your army and is within 12\" of and visible to the bearer. Roll six D6: for each 4+, that enemy unit suffers 1 mortal wound."
       },
@@ -2385,13 +2403,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a8f61779-cfd0-52a5-a207-ad884b029a21",
+      "id": "14d3dfeb-cf75-5523-9c55-a0accaeb693c",
       "name": {
         "en": "Mentor’s Pride"
       },
       "cost": "20",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. While two or more **ARMIGER** models are under the effects of the bearer’s Bondsman ability, each time each of those **ARMIGER** models makes an attack, you can re‑roll a Hit roll of 1."
       },
@@ -2403,13 +2422,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "00b77d02-d9fb-564a-9559-f09be4826e7f",
+      "id": "86b97438-9e5f-518b-aaa9-2765f30f4c07",
       "name": {
         "en": "Fables of Nightmare"
       },
       "cost": "10",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. While two or more **ARMIGER** models are under the effects of the bearer’s Bondsman ability, melee weapons equipped by those **ARMIGER** models have the **[PRECISION]** ability."
       },
@@ -2421,13 +2441,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dc930081-3e19-5f76-ac6c-127a98f377ee",
+      "id": "ee9136a8-9383-5ca9-b964-93df6be2b1c9",
       "name": {
         "en": "Tales of Heroism"
       },
       "cost": "10",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. While two or more **ARMIGER** models are under the effects of the bearer’s Bondsman ability, each time one of those **ARMIGER** models makes a melee attack, you can ignore any or all modifiers to the Hit roll and/or the Wound roll."
       },
@@ -2439,13 +2460,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "07caefe1-6305-5a99-aef7-6559ec0a7bd6",
+      "id": "d2b9ea01-b021-54db-88d2-8b2713e0b77e",
       "name": {
         "en": "Martial Tuition"
       },
       "cost": "15",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. While two or more **ARMIGER** models are under the effects of the bearer’s Bondsman ability, once per turn, you can target one of those **ARMIGER** models with the Counter‑offensive Stratagem for 0CP."
       },
@@ -2457,13 +2479,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e71af31e-3d8b-5dc6-9bdb-5fd92dbaea3d",
+      "id": "490219cb-97a8-551c-815c-bad981e2fb0e",
       "name": {
         "en": "Mysterious Guardian"
       },
       "cost": "35",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. (Once per battle, per army) At the end of your opponent’s turn, if this unit is unengaged, you can use this ability. If you do:\n▪Place this unit in **strategic reserves**.\n▪This unit has **Deep Strike** until the start of your next Shooting phase.\n▪This unit must make an ingress move in your next Movement phase (including in your first turn).’"
       },
@@ -2475,13 +2498,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "431d5d75-45b6-56b5-9ca7-7d598268a645",
+      "id": "4662e900-a5f9-5c11-9ca7-87926b440656",
       "name": {
         "en": "Sanctuary"
       },
       "cost": "20",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. The bearer has a 5+ invulnerable save."
       },
@@ -2493,13 +2517,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "adf95f39-c951-5db1-8d92-5878e5852dcb",
+      "id": "506321c5-fe6d-502e-a158-3371f51c44ad",
       "name": {
         "en": "Bringer of Justice"
       },
       "cost": "30",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. Improve the Attacks characteristic of melee weapons equipped by the bearer by 2, and each time the bearer makes a melee attack, add 1 to the Hit roll."
       },
@@ -2511,13 +2536,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4a2247d8-eb7e-5eb0-8f08-cadf0fd1a700",
+      "id": "bf304ae9-60dc-5afd-956a-014c2c24989c",
       "name": {
         "en": "Hunter’s Eye"
       },
       "cost": "25",
       "keywords": ["Imperial Knights"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IMPERIAL KNIGHTS** model only. Ranged weapons equipped by the bearer have the **[IGNORES COVER]** ability."
       },

--- a/11th/gdc/keywords.json
+++ b/11th/gdc/keywords.json
@@ -2,7 +2,7 @@
   "source": "40k-11e",
   "cardType": "keywords",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:10.833Z",
+  "updated": "2026-07-28T17:03:35.927Z",
   "keywords": [
     {
       "key": "anti",

--- a/11th/gdc/missions/chapter_approved_2026_2027.json
+++ b/11th/gdc/missions/chapter_approved_2026_2027.json
@@ -12,7 +12,7 @@
   },
   "source": "40k-11e",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:03.763Z",
+  "updated": "2026-07-28T17:03:23.770Z",
   "isCombatPatrol": false,
   "primaryMissionScoreGameLimit": 45,
   "primaryMissionScoreBattleRoundLimit": 15,

--- a/11th/gdc/missions/combat_patrol.json
+++ b/11th/gdc/missions/combat_patrol.json
@@ -12,7 +12,7 @@
   },
   "source": "40k-11e",
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:15:03.784Z",
+  "updated": "2026-07-28T17:03:23.794Z",
   "isCombatPatrol": true,
   "primaryMissionScoreGameLimit": 45,
   "primaryMissionScoreBattleRoundLimit": 15,

--- a/11th/gdc/necrons.json
+++ b/11th/gdc/necrons.json
@@ -7,7 +7,7 @@
     "header": "#04532a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.903Z",
+  "updated": "2026-07-28T17:03:10.061Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2726,7 +2726,7 @@
   ],
   "enhancements": [
     {
-      "id": "986ad94b-7173-5099-9290-628e9ae842d4",
+      "id": "4da23ba5-692e-5c16-8839-ab46ebb9d6ad",
       "name": {
         "en": "Mortality Shroud (Aura) (Upgrade)",
         "de": "Sterblichkeitsschleier (Aura) (Aufwertung)",
@@ -2740,6 +2740,7 @@
       "cost": "10",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Obelisk</k> unit only. In your opponent’s Battle‑shock step, if an enemy unit within 8\" of this unit is below <b>starting strength</b>, that enemy unit makes a <b>battle‑shock roll</b>.",
         "de": "Nur für eine <k>Obelisk</k>-Einheit. Im Schritt „Erschütterung“ deines Gegners muss eine feindliche Einheit, wenn sie sich innerhalb von 8\" um diese Einheit befindet und unter <b>Sollstärke</b> ist, einen <b>Erschütterungswurf</b> ausführen.",
@@ -2758,7 +2759,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "74d7efed-9f9b-586b-95ec-ac0cee06b83a",
+      "id": "c7ebd9fd-8127-57b4-bd07-2d1b8c9ff151",
       "name": {
         "en": "Tools of Dominion (Upgrade)",
         "de": "Werkzeuge der Herrschaft (Aufwertung)",
@@ -2772,6 +2773,7 @@
       "cost": "15",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Immortals</k> unit only. This unit’s ranged attacks have <k>[Rapid Fire 1]</k>.",
         "de": "Nur für eine <k>Unsterbliche</k>-Einheit. Die Fernkampfattacken dieser Einheit haben <k>[Schnellfeuer 1]</k>.",
@@ -2790,7 +2792,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7c3a645d-3fe4-5231-95b7-4eb0d9692aef",
+      "id": "462defc9-b7b3-5347-9a11-c30d5f3abc9b",
       "name": {
         "en": "Enlivened Sentinels (Upgrade)",
         "de": "Gekräftigte Wächter (Aufwertung)",
@@ -2804,6 +2806,7 @@
       "cost": "20",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Necron Warriors</k> unit only. This unit has <b>Scouts 5\"</b>.",
         "de": "Nur für eine <k>Necronkrieger</k>-Einheit. Diese Einheit hat <b>Kundschafter 5\"</b>.",
@@ -2822,7 +2825,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "51f23749-765b-5cd6-bf0f-7b4f23fa77df",
+      "id": "06c8a2b1-36b1-525b-86f8-7f6618f4a5f8",
       "name": {
         "en": "Deepening Madness (Upgrade)",
         "de": "Wachsender Irrsinn (Aufwertung)",
@@ -2836,6 +2839,7 @@
       "cost": "20",
       "keywords": ["Mounted", "Destroyer Cult"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Destroyer Cult Mounted</k> unit only. This unit’s ranged attacks have <k>[Assault]</k>.",
         "de": "Nur für eine <k>berittene Destruktorkult</k>-Einheit. Fernkampfattacken dieser Einheit haben <k>[Sturm]</k>.",
@@ -2854,7 +2858,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f08a9f96-4a25-5907-83e3-bfd56ac13896",
+      "id": "27892177-61f2-5c79-8304-9909a85a632b",
       "name": {
         "en": "Prelocational Optimiser",
         "de": "Prälokalisierungsoptimierer",
@@ -2868,6 +2872,7 @@
       "cost": "25",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Necrons</k> model only. When this unit is <b>selected to shoot</b>, if this unit was set up using a Monolith’s <b>Eternity Gate</b> ability this turn, this unit’s ranged attacks have:\r<ul><li><k>[Lethal Hits]</k>.</li>\r<li><u>Or:</u> <k>[Sustained Hits 1]</k>.</li></ul>",
         "de": "Nur für ein <k>Necron</k>-Modell. Wenn diese Einheit <b>zum Schießen gewählt</b> wird und in diesem Zug durch die Fähigkeit <b>Tor der Ewigkeit</b> eines Monolithen aufgestellt wurde, haben ihre Fernkampfattacken:\n<ul><li><k>[Tödliche Treffer]</k>.</li>\n<li><u>Oder:</u> <k>[Trefferhagel 1]</k>.</li></ul>",
@@ -2886,7 +2891,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "61900df4-4562-57f7-aa84-e79e0bb7d42b",
+      "id": "8a1a9ddb-54a1-5390-a5b7-3eea7294a284",
       "name": {
         "en": "Recursive Reanimation (Upgrade)",
         "de": "Rekursive Reanimation (Aufwertung)",
@@ -2900,6 +2905,7 @@
       "cost": "5",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Tomb Blades</k> unit only. When this unit activates its <b>Reanimation Protocols</b>, +1 to the roll.",
         "de": "Nur für eine <k>Gruftklingen</k>-Einheit. Wenn diese Einheit ihre <b>Reanimationsprotokolle</b> aktiviert, addiere +1 auf den Wurf.",
@@ -2918,13 +2924,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "24eb2bc6-3092-54a3-b5fe-f0d9b13bd709",
+      "id": "d4085d5d-f60f-5619-9448-e09a0c0d9baa",
       "name": {
         "en": "Veil of Darkness"
       },
       "cost": "20",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**(Once per battle, per army) A**t the end of your opponent’s turn, if this unit is **unengaged**, you can use this ability. If you do:\n▪ Place this unit in **strategic reserves**.\n▪ This unit has **Deep Strike** until the start of your next Shooting phase.\n▪ This unit must make an **ingress move** in your next Movement phase (including in your first turn)."
       },
@@ -2936,13 +2943,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "615d5d93-73cb-5fb4-b0f6-aaeaf44e661f",
+      "id": "99c29c93-cfb6-5e60-a755-eea343aaf6e3",
       "name": {
         "en": "Nether-realm Casket"
       },
       "cost": "20",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. While the bearer is leading a unit, models in that unit have the Stealth ability."
       },
@@ -2954,13 +2962,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2b45f050-1906-5166-bf73-074538a73311",
+      "id": "dbebee83-08f5-5685-989c-9c7396b11518",
       "name": {
         "en": "Phasal Subjugator (Aura)"
       },
       "cost": "35",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. While a friendly **NECRONS** unit (excluding **CHARACTER** units) is within 6\" of the bearer, each time a model in that unit makes an attack, add 1 to the Hit roll."
       },
@@ -2972,13 +2981,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "786d835c-158e-5061-9580-c78e3af14e2c",
+      "id": "7f07ac14-7ddc-5ae3-96bd-365962c8fe05",
       "name": {
         "en": "Enaegic Dermal Bond"
       },
       "cost": "30",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. The bearer has the Feel No Pain 4+ ability"
       },
@@ -2990,13 +3000,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bb4a9f72-47cf-5033-89d6-df04b74d7c6d",
+      "id": "ec922dd9-6e51-53bf-86d1-944752a8c5c9",
       "name": {
         "en": "Eternal Madness"
       },
       "cost": "20",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. In the Fight phase, each time a model in the bearer’s unit is destroyed, if that model has not fought this phase, roll one D6: on a 4+, do not remove the destroyed model from play; it can fight after the attacking model’s unit has finished making its attacks, and is then removed from play."
       },
@@ -3008,13 +3019,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "46225941-24ed-5d2b-8c60-4c946fdf9086",
+      "id": "20785df6-57a6-5d81-86dd-538cf6d9de53",
       "name": {
         "en": "Ingrained Superiority"
       },
       "cost": "5",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. Each time a model in the bearer’s unit makes an attack, on a Critical Wound, improve the Armour Penetration characteristic of that attack by 1."
       },
@@ -3026,13 +3038,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2f5250e0-4f92-5a71-99e8-4fd6dcb2c44d",
+      "id": "4bb62d0e-aa5b-52c6-9c99-999772f0ec0a",
       "name": {
         "en": "Soulless Reaper"
       },
       "cost": "15",
       "keywords": ["Destroyer Cult"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DESTROYER CULT** model only. Each time an enemy unit within Engagement Range of the bearer’s unit is selected to Fall Back, roll one D6: on a 3+, that unit cannot Fall Back this phase and must Remain Stationary."
       },
@@ -3044,13 +3057,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "efb2b4b8-e861-518e-9dff-c3f3a9137c55",
+      "id": "e67e2823-eaa9-588d-8095-8ef4fa7ff1d7",
       "name": {
         "en": "Eldritch Nightmare"
       },
       "cost": "10",
       "keywords": ["Destroyer Cult"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DESTROYER CULT** model only. At the start of the Fight phase, each enemy unit within Engagement Range of the bearer must take a Battle-shock test."
       },
@@ -3062,13 +3076,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "222b176e-a099-5d99-8fca-7b01ac97f41f",
+      "id": "a53eb657-505c-5aeb-ac03-2bbb2e40c71e",
       "name": {
         "en": "Dimensional Sanctum"
       },
       "cost": "20",
       "keywords": ["Cryptek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRYPTEK** model only. Models in the bearer’s unit have the Infiltrators ability."
       },
@@ -3080,13 +3095,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "366d91f9-310f-5c53-88b6-090cd5ab0c5d",
+      "id": "6397de0f-8d86-53a2-ac1d-ad70646dae8c",
       "name": {
         "en": "Hyperphasic Fulcrum"
       },
       "cost": "15",
       "keywords": ["Cryptek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRYPTEK** model only. While the bearer is leading a unit, if that unit is wholly within your army’s Power Matrix, each time a model in that unit makes an attack, re-roll a Wound roll of 1."
       },
@@ -3098,13 +3114,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b25885fb-e80d-5606-8702-a6b62f5850d4",
+      "id": "c6a156b5-4bc1-5499-962f-a79f47be0a10",
       "name": {
         "en": "Autodivinator"
       },
       "cost": "15",
       "keywords": ["Cryptek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRYPTEK** model only. Each time your opponent gains a CP as the result of an ability, roll one D6: on a 2+, you also gain 1CP"
       },
@@ -3116,13 +3133,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "668e6d33-6d6c-52d3-ab8a-addca5de0b72",
+      "id": "906f1800-2cbc-5139-8539-9c33ee88ad50",
       "name": {
         "en": "Metalodermal Tesla Weave"
       },
       "cost": "10",
       "keywords": ["Cryptek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRYPTEK** model only. Once per phase, when an enemy unit selects the bearer’s unit as a target of a charge, roll one D6: on a 2-5, that enemy unit suffers D3 mortal wounds; on a 6, that enemy unit suffers 3 mortal wounds."
       },
@@ -3134,13 +3152,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "96c7b7c7-79d7-5541-845c-828975bd656a",
+      "id": "6fbfabb0-a8b0-575e-895c-db821b8bd37e",
       "name": {
         "en": "Honourable Combatant"
       },
       "cost": "10",
       "keywords": ["Overlord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OVERLORD** model only. Each time the bearer’s unit destroys an enemy **CHARACTER** unit, your opponent loses 1CP if they have any."
       },
@@ -3152,13 +3171,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f136e89b-2dd6-5d7f-861c-41cd1f484dfd",
+      "id": "2900511c-26b6-506c-9e0e-ad050e205e75",
       "name": {
         "en": "Unflinching Will"
       },
       "cost": "20",
       "keywords": ["Overlord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OVERLORD** model only. The bearer’s melee weapons have the **[PRECISION]** and **[ANTI-INFANTRY 5+]** abilities."
       },
@@ -3170,13 +3190,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "82c7ae8b-fda7-5673-92da-baa09e1bcde6",
+      "id": "d1964c81-ca98-5a43-978e-152223e5527e",
       "name": {
         "en": "Warrior Noble"
       },
       "cost": "15",
       "keywords": ["Overlord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OVERLORD** model only. Each time a melee attack targets the bearer’s unit, subtract 1 from the Hit roll."
       },
@@ -3188,13 +3209,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ea271a01-5a23-57f3-b21d-b4798dbb8617",
+      "id": "b80285b9-fa99-5938-92ea-95a374d888f1",
       "name": {
         "en": "Eternal Conqueror"
       },
       "cost": "25",
       "keywords": ["Overlord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OVERLORD** model only. Each time a model in the bearer’s unit makes an attack that targets an enemy unit within range of an objective marker, you can re-roll the Hit roll."
       },
@@ -3206,13 +3228,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "abe90f31-0dcb-5e95-ae61-d10ebcc2b018",
+      "id": "af68dafc-237c-5909-abaa-b03f5528b7ed",
       "name": {
         "en": "Dimensional Overseer"
       },
       "cost": "25",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. While the bearer is on the battlefield or in Strategic Reserves, add one to the number of units from your army that you can select for the Hyperphasing rule."
       },
@@ -3224,13 +3247,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d3f6e360-3db0-5c0f-95ac-328b72da22aa",
+      "id": "200e6b8b-a05c-5dfd-a0ac-722b66bd8dc0",
       "name": {
         "en": "Arisen Tyrant"
       },
       "cost": "25",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. Each time a model in the bearer’s unit makes an attack, re-roll a Hit roll of 1. If the bearer’s unit was set up on the battlefield this turn, you can re-roll the Hit roll instead."
       },
@@ -3242,13 +3266,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f26575fb-193b-5f65-ac03-880f3765f1e3",
+      "id": "dc02c094-29d5-5d96-b6a4-bc57b1c12613",
       "name": {
         "en": "Hyperspatial Transfer Node"
       },
       "cost": "15",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. Each time the bearer’s unit Advances, do not make an Advance roll for it. Instead, until the end of the phase, add 6\" to the Move characteristic of models in the bearer’s unit."
       },
@@ -3260,13 +3285,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d2b9a498-b028-5320-a2aa-79f022f0f15c",
+      "id": "c89e4fbb-8873-5574-a303-ef7c3ac099d1",
       "name": {
         "en": "Osteoclave Fulcrum"
       },
       "cost": "20",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. Models in the bearer’s unit have the Deep Strike ability."
       },
@@ -3278,13 +3304,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "82041591-cb27-5faa-84dc-537ad474904f",
+      "id": "a6b333fd-72fe-53ad-93c0-9f9c00236a98",
       "name": {
         "en": "Dread Majesty (Aura)"
       },
       "cost": "30",
       "keywords": ["Overlord", "Catacomb Command Barge"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**OVERLORD** or **CATACOMB COMMAND BARGE** model only. While a friendly **NECRONS** unit (excluding **MONSTER** and **TITANIC** units) is within 6\" of the bearer, each time a model in that unit makes an attack, re‑roll a Hit roll of 1 and re‑roll a Wound roll of 1."
       },
@@ -3296,13 +3323,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "517f3e1c-370e-5fce-887c-758a14654ebf",
+      "id": "50c90a4f-3cfd-5872-a313-4b6ea82a57f1",
       "name": {
         "en": "Miniaturised Nebuloscope"
       },
       "cost": "15",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. Ranged weapons equipped by models in the bearer’s unit have the **[IGNORES COVER]** ability."
       },
@@ -3314,13 +3342,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "13a5bc3f-555a-53b3-85ba-3868affcd1f5",
+      "id": "d9459c14-56d6-5b6b-ab5e-5fefbcff8849",
       "name": {
         "en": "Demanding Leader"
       },
       "cost": "10",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. In your Command phase, select one friendly **NECRONS VEHICLE** or **NECRONS MOUNTED** unit (excluding **TITANIC** units) within 6\" of the bearer. Until the start of your next Command phase, that unit is eligible to shoot in a turn in which it Fell Back."
       },
@@ -3332,13 +3361,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "53c992ba-2e07-52c4-ad7e-9691d898644b",
+      "id": "2374c36f-54cc-56eb-b688-4468cea68c4b",
       "name": {
         "en": "Chrono-impedance Fields"
       },
       "cost": "25",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. In your Command phase, select one friendly **NECRONS VEHICLE** or **NECRONS MOUNTED** unit (excluding **TITANIC** units) within 6\" of the bearer. Until the start of your next Command phase, each time an attack is allocated to a model in that unit, subtract 1 from the Damage characteristic of that attack."
       },
@@ -3350,13 +3380,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6fcd10ee-05c4-510d-8228-482434257747",
+      "id": "4b389eff-917f-5805-ba45-9fede2df4a69",
       "name": {
         "en": "Destroyer Ankh"
       },
       "cost": "20",
       "keywords": ["Catacomb Command Barge", "Overlord"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CATACOMB COMMAND BARGE** or **OVERLORD** model only. The bearer has the **DESTROYER CULT** keyword. Add 2\" to the Move characteristic of models in the bearer’s unit and add 2 to the Attacks characteristic of melee weapons equipped by the bearer."
       },
@@ -3368,13 +3399,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "efd1c481-93ee-5d4b-90a3-02316053c653",
+      "id": "c732feaa-faf2-5731-b402-052814fdd71c",
       "name": {
         "en": "Murdermind"
       },
       "cost": "15",
       "keywords": ["Cryptek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRYPTEK** model only. The bearer has the **DESTROYER CULT** keyword. Add 3\" to the Move characteristic of the bearer."
       },
@@ -3386,13 +3418,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f1fb8690-dea0-531d-ad49-cf21f29e4dfc",
+      "id": "8d71f910-697e-50e0-9bea-a7c734ecae52",
       "name": {
         "en": "Mark of the Nekrosor"
       },
       "cost": "20",
       "keywords": ["Destroyer Cult"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DESTROYER CULT** model only. Each time a model in the bearer’s unit makes an attack, add 1 to the Hit roll."
       },
@@ -3404,13 +3437,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e4eebc87-10ae-56b8-9bc7-1f4d0270c658",
+      "id": "5e9a77a7-b835-53ab-b7b7-25f2c8a452f2",
       "name": {
         "en": "Cursed Circlet"
       },
       "cost": "25",
       "keywords": ["Destroyer Cult"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DESTROYER CULT** model only. In your opponent’s Shooting phase, when an enemy unit has shot, if a model in this unit was **destroyed** by those attacks, this unit can make a **surge move** of up to D6”."
       },
@@ -3422,13 +3456,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "300633a0-a1d9-5a37-a116-9cc6c6d9318c",
+      "id": "c8705359-1575-5cf4-b33b-7eed2af3cac7",
       "name": {
         "en": "Quantum Abacus"
       },
       "cost": "15",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. Each time you select the bearer’s unit as the target of a Stratagem, roll one D6, adding 1 if it is within range of one or more objectives: on a 4+, you gain 1CP."
       },
@@ -3440,13 +3475,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ec42d171-fed1-5ac2-9f4d-f931bfddaf98",
+      "id": "2f8d622c-90eb-5961-be5b-95ce8dae0676",
       "name": {
         "en": "Atomic Disintegrators"
       },
       "cost": "10",
       "keywords": ["Cryptek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRYPTEK** model only. In your Shooting phase, each time the bearer’s unit is selected to shoot, when selecting an ability for the Technosorcerous Augmentations Detachment rule, you can also select from the following abilities: **[ANTI‑MONSTER 5+]**, **[ANTI‑VEHICLE 5+]**."
       },
@@ -3458,13 +3494,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "825e4c26-e7e6-543e-8ecc-da6d37252973",
+      "id": "c4b6ddee-7aa6-5abc-8c02-6def3ff251bc",
       "name": {
         "en": "Gauntlet of Compression"
       },
       "cost": "20",
       "keywords": ["Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**NECRONS** model only. Add 6\" to the Range characteristic of ranged weapons equipped by models in the bearer’s unit."
       },
@@ -3476,13 +3513,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ef024790-a6a8-5565-8196-270866b7b516",
+      "id": "383ae074-a7c5-56b2-b3bb-8042a485e740",
       "name": {
         "en": "Gravitic Bolas"
       },
       "cost": "15",
       "keywords": ["Cryptek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CRYPTEK** model only. In your Shooting phase, after the bearer has shot, select one enemy unit hit by one or more of those attacks (excluding **TITANIC** units); until the start of your next turn, that enemy unit is pinned. While a unit is pinned, subtract 2 from that unit’s Move characteristic and subtract 2 from Charge rolls made for that unit."
       },
@@ -3494,13 +3532,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e1639174-1587-521a-a1b5-dff6ced9e4ba",
+      "id": "0032c15c-0d9f-5f7f-b961-287d32f28540",
       "name": {
         "en": "Singularity Matrix"
       },
       "cost": "45",
       "keywords": ["DNU", "Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**C’TAN SHARD OF THE DECEIVER** model only. This model has the following ability:\n\n**Lord of Deceit (Aura)**: Once per turn, when your opponent targets a unit from their army within 12” of this model with a **stratagem**, you can use this ability. If you do increase the CP cost of that use of that **stratagem** by 1CP.'"
       },
@@ -3512,13 +3551,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d27452f8-ab67-5c18-8c21-c240188d2204",
+      "id": "f51cf3a5-8a00-5be6-a3d7-0681f6a18526",
       "name": {
         "en": "Quantum Goad"
       },
       "cost": "45",
       "keywords": ["DNU", "Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**C'TAN SHARD OF THE NIGHTBRINGER** model only. This model is eligible to declare a charge in a turn in which it Advanced."
       },
@@ -3530,13 +3570,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "59a004ac-0462-5639-b7c8-d49702339d81",
+      "id": "bd9bdaeb-3a8e-5f8f-8768-9182486de9d6",
       "name": {
         "en": "Animus Damper"
       },
       "cost": "35",
       "keywords": ["DNU", "Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**C'TAN SHARD OF THE VOIDDRAGON** model only. Once per turn, at the start of your opponent’s Shooting phase, select one enemy Vehicle unit visible to the bearer. That unit must take a Leadership test. Until the end of the phase, each time a model in that unit makes an attack, subtract 1 from the Hit roll and, if that Leadership test was failed, subtract 1 from the Wound roll as well."
       },
@@ -3548,13 +3589,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e4afbe15-26a6-55a8-824c-a0d1b01280d9",
+      "id": "1e2b0519-eeac-5062-a529-1b6bc12a75c5",
       "name": {
         "en": "Reletavistic Tether"
       },
       "cost": "40",
       "keywords": ["DNU", "Necrons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TRANSCENDENT C’TAN** model only. In your turn, when this unit makes an **ingress/advance move** using its **Transdimensional Displacement** ability, this unit can end that move more than 6\" horizontally from all enemy units (instead of more than 8\"). When this unit ends that move within 8\" of an enemy unit, this unit is not **eligible to declare a charge** until the end of the turn"
       },
@@ -6183,7 +6225,19 @@
       "additionalCost": {
         "cost": "10",
         "afterSelections": 1
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "dca6f6bb-b1c6-53fb-8cb2-e75d238522f6",
@@ -7320,6 +7374,23 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Canoptek Macrocytes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -8200,7 +8271,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IMMORTALS** ■ **LYCHGUARD** ■ **NECRON WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lychguard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2bbffcec-ad3b-5277-802d-1c9e486a0666",
@@ -8778,7 +8866,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **LOKHUST DESTROYERS** ■ **LOKHUST HEAVY DESTROYERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Lokhust Destroyers",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lokhust Heavy Destroyers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "ec70c87c-6091-5671-81a8-403c0bf283f7",
@@ -10220,6 +10320,18 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -10480,7 +10592,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IMMORTALS** ■ **LYCHGUARD** ■ **NECRON WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lychguard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "605f4267-f9af-50b4-bd76-8820bd1315cb",
@@ -10643,7 +10772,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IMMORTALS** ■ **LYCHGUARD** ■ **NECRON WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lychguard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b6d6c4a7-4a8c-562e-a839-3fd476ce08a0",
@@ -10814,6 +10960,18 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -10988,6 +11146,18 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -11149,7 +11319,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IMMORTALS** ■ **NECRON WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9e73708e-63b1-5a21-8c87-734ae7a9c16d",
@@ -11732,7 +11914,14 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SKORPEKH DESTROYERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Skorpekh Destroyers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "c802633b-69bf-578d-bcd0-d6fe7f8df65b",
@@ -11911,7 +12100,24 @@
       "additionalCost": {
         "cost": "10",
         "afterSelections": 1
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Canoptek Wraiths",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "aaf70701-a3e2-5308-994f-7310ec7d0018",
@@ -13043,7 +13249,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IMMORTALS** ■ **LYCHGUARD** ■ **NECRON WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Immortals",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lychguard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Necron Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9a78c91e-bc1a-5f50-ac1b-d36016a80465",

--- a/11th/gdc/orks.json
+++ b/11th/gdc/orks.json
@@ -7,7 +7,7 @@
     "header": "#465b18"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.286Z",
+  "updated": "2026-07-28T17:03:08.598Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2916,7 +2916,7 @@
   ],
   "enhancements": [
     {
-      "id": "1e370850-9a00-51bd-87ad-575b36d249ba",
+      "id": "d6731f9d-e181-5432-8c43-6504adbc2ad1",
       "name": {
         "en": "Boarding Ramps (Upgrade)",
         "de": "Enterplanken (Aufwertung)",
@@ -2930,6 +2930,7 @@
       "cost": "10",
       "keywords": ["Wagon"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Wagon</k> unit only. When a unit embarked within this unit is selected to make a <b>disembark move</b>, that unit has +1 to <b>charge rolls</b> until the end of the turn.",
         "de": "Nur für eine <k>Panza</k>-Einheit. Wenn eine Einheit an Bord dieser Einheit gewählt wird, eine <b>Ausstiegsbewegung</b> auszuführen, hat jene Einheit bis zum Ende des Zugs +1 auf <b>Angriffswürfe</b>.",
@@ -2948,7 +2949,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cbd3565e-1c33-5f75-a78c-ad4f4c2b2597",
+      "id": "ee3cea60-7d9f-54e6-94a1-569479140b58",
       "name": {
         "en": "Slippery Git",
         "de": "Schlüpfriges Aas",
@@ -2962,6 +2963,7 @@
       "cost": "15",
       "keywords": ["Warboss", "Infantry"],
       "excludes": ["Mega Armour"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>INFANTRY WARBOSS</k> model only (excluding <k>MEGA ARMOUR</k> models).This model has <b>Infiltrators</b> and <b>Stealth</b>.",
         "de": "Nur für ein <k>INFANTERIE-WAAAGHOSS</k>-Modell (ausgenommen <k>MEGARÜSTUNG</k>-Modelle). Dieses Modell hat <b>Infiltratoren</b> und <b>Tarnung</b>.",
@@ -2980,7 +2982,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "52b64d3c-8692-5b3a-831b-3e8d3e57c3f6",
+      "id": "960886be-914b-5830-b5b6-b5c23cc1a8fd",
       "name": {
         "en": "Da Gobshot Thunderbuss",
         "de": "Da Gobdakka-Donnabüchse",
@@ -2994,6 +2996,7 @@
       "cost": "15",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Orks Infantry</k> model only. This model’s ranged attacks have:\r<ul><li><k>[Devastating Wounds]</k>.</li>\r<li><k>[Hazardous]</k>.</li></ul>",
         "de": "Nur für ein <k>Ork</k>-<k>Infanterie</k>-Modell. Die Fernkampfattacken dieses Modells haben:\r<ul><li><k>[Verheerende Verwundungen]</k>.</li>\r<li><k>[Riskant]</k>.</li></ul>",
@@ -3012,7 +3015,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "189f7d29-8e27-5054-9b59-e852dd673057",
+      "id": "9804d556-fbc2-574c-905e-d00e73fa6ab5",
       "name": {
         "en": "Dead Shiny Shootas (Upgrade)",
         "de": "Obafeine Wummen (Aufwertung)",
@@ -3026,6 +3029,7 @@
       "cost": "15",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Orks Infantry</k> unit only. This unit’s ranged attacks have:\r<ul><li><k>[Rapid Fire 1]</k>.</li>\r<li><u>Or:</u> If that attack already has <k>[Rapid Fire]</k>, +1 to the value of that <k>[Rapid Fire]</k> (e.g. <k>[Rapid Fire 1]</k> becomes <k>[Rapid Fire 2]</k>).</li></ul>",
         "de": "Nur für eine <k>Ork</k>-<k>Infanterie</k>-Einheit. Fernkampfattacken dieser Einheit haben:\r<ul><li><k>[Schnellfeuer 1]</k>.</li>\r<li><u>Oder:</u> Wenn jene Attacke bereits <k>[Schnellfeuer]</k> hat, +1 auf den Wert jenes <k>[Schnellfeuers]</k> (z. B. wird <k>[Schnellfeuer 1]</k> zu <k>[Schnellfeuer 2]</k>).</li></ul>",
@@ -3044,7 +3048,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "be1c2a2b-6477-5906-8571-3eabcc273321",
+      "id": "36c1143e-f9e3-5ef9-8079-38ffe2aee296",
       "name": {
         "en": "Targetin’ Gizmos (Upgrade)",
         "de": "Zieldingsdas (Aufwertung)",
@@ -3058,6 +3062,7 @@
       "cost": "15",
       "keywords": ["Wagon"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Wagon</k> unit only. While a <k>Big Mek</k> model is embarked within this unit:\r<ul><li>This unit’s ranged attacks have <k>[Ignores Cover]</k>.</li>\r<li>If the Waaagh! is active for this unit, this unit’s ranged attacks have <k>[Sustained Hits 1]</k>.</li></ul>",
         "de": "Nur für eine <k>Panza</k>-Einheit. Solange sich ein <k>Mekboss</k>-Modell an Bord dieser Einheit befindet:\n<ul><li>haben die Fernkampfattacken dieser Einheit <k>[Deckung ignorieren]</k>.</li>\n<li>haben die Fernkampfattacken dieser Einheit <k>[Trefferhagel 1]</k>, wenn der Waaagh für sie aktiv ist ist.</li></ul>",
@@ -3076,7 +3081,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c1b72e4f-c461-5b1f-9568-86b2b968355a",
+      "id": "7bc5becc-4166-5df6-b279-9b5212777536",
       "name": {
         "en": "Mork’s Kunnin’",
         "de": "Klävva wie Mork selbst",
@@ -3090,6 +3095,7 @@
       "cost": "20",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Orks</k> model only. When both players have deployed their armies, you can redeploy up to three friendly <k>Orks Infantry</k> units. When doing so, you can set those units up in <b>strategic reserves</b>, regardless of how many units are already in <b>strategic reserves</b>.",
         "de": "Nur für ein <k>Ork</k>-Modell. Wenn beide Spieler ihre Armeen aufgestellt haben, kannst du bis zu drei befreundete <k>Ork</k>-<k>Infanterie</k>-Einheiten neu aufstellen. Wenn du dies tust, kannst du jene Einheiten in die <b>strategische Reserve</b> versetzen, unabhängig davon, wie viele Einheiten sich bereits in der <b>strategischen Reserve</b> befinden.",
@@ -3108,7 +3114,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "140a5b61-bc11-538b-9cd2-5dec54dd92bc",
+      "id": "709c7308-cbb5-5def-94cf-640620c680d9",
       "name": {
         "en": "Kunnin’ Hunta",
         "de": "Klävvara Jäga",
@@ -3122,6 +3128,7 @@
       "cost": "25",
       "keywords": ["Warboss", "Infantry", "Beastboss"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>BEASTBOSS/INFANTRY WARBOSS</k> model only. (Once per turn, per unit) In your opponent’s Movement phase, when an enemy unit ends a move within 8\" of this unit, if this unit is <b>unengaged</b>, this unit can make a <b>normal move</b> of up to D3+3\".",
         "de": "Nur für ein <k>VIECHBOSS</k>-<k>WAAAGHBOSS</k>- oder <k>INFANTERIE</k>-<k>WAAAGHBOSS</k>-Modell. (Einmal pro Zug, pro Einheit) Wenn eine feindliche Einheit in der Bewegungsphase deines Gegners eine Bewegung innerhalb von 8\" um diese Einheit beendet und diese Einheit <b>nicht im Nahkampf</b> ist, kann diese Einheit eine <b>normale Bewegung</b> von bis zu W3+3\" ausführen.",
@@ -3140,7 +3147,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bfbd20de-ee8f-51b2-a8fb-e09bfe83283c",
+      "id": "6dd0f7f6-643b-541c-8b65-580b64ed9e9b",
       "name": {
         "en": "Unkillable Scourge",
         "de": "Untötbares Ungeheuer",
@@ -3154,6 +3161,7 @@
       "cost": "25",
       "keywords": ["Warboss", "Infantry", "Beastboss"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>BEASTBOSS/INFANTRY WARBOSS</k> model only. When this model is <b>destroyed</b>, if this unit has not been <b>selected to fight</b> this phase, roll one D6, with +1 to that roll if the Waaagh! is active for this unit:\n<ul><li>On a 3+, do not remove this model from the battlefield. When this unit has fought, or at the end of the phase (whichever comes first), this model is removed from the battlefield.</li></ul>",
         "de": "Nur für ein <k>VIECHBOSS</k>-<k>WAAAGHBOSS</k>- oder <k>INFANTERIE</k>-<k>WAAAGHBOSS</k>-Modell. Wenn dieses Modell <b>zerstört</b> wird und diese Einheit in dieser Phase noch nicht <b>zum Kämpfen gewählt wurde</b>, wirf einen W6 und addiere +1, wenn der Waaagh für diese Einheit aktiv ist:\r<ul><li>Bei 3+ entferne dieses Modell nicht vom Schlachtfeld. Wenn diese Einheit gekämpft hat oder am Ende der Phase (je nachdem, was zuerst eintritt), wird dieses Modell vom Schlachtfeld entfernt.</li></ul>",
@@ -3172,13 +3180,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b1dff2e8-981b-5e96-996a-f9283fcbc48a",
+      "id": "20d5b129-fb53-5888-864a-c92f4adcbd95",
       "name": {
         "en": "Follow Me Ladz"
       },
       "cost": "25",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS** model only. While the bearer is leading a unit, add 2\" to the Move characteristic of models in that unit."
       },
@@ -3190,13 +3199,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "77cee509-35ac-5ef7-a91b-5cf16abd0a57",
+      "id": "97acaa56-bf56-55d5-ac2a-ea3ba143e8d3",
       "name": {
         "en": "Headwoppa’s Killchoppa"
       },
       "cost": "20",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS** model only. Melee weapons equipped by the bearer (excluding Extra Attacks weapons) have the **[DEVASTATING WOUNDS]** ability."
       },
@@ -3208,13 +3218,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5dd256af-85d2-5036-b709-4fad6166faa5",
+      "id": "fbb36fb7-7c7a-54c9-9fcf-2e7fc914f2bd",
       "name": {
         "en": "Kunnin’ but Brutal"
       },
       "cost": "15",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS** model only. While the bearer is leading a unit, that unit is eligible to shoot and declare a charge in a turn in which it Fell Back."
       },
@@ -3226,13 +3237,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f13e040e-7121-58a3-a1a7-b532febd4ffd",
+      "id": "0598bff2-2343-5fdb-abd5-71b60f1074e0",
       "name": {
         "en": "Supa-Cybork Body"
       },
       "cost": "15",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS** model only. The bearer has the Feel No Pain 4+ ability."
       },
@@ -3244,13 +3256,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4c37071f-c693-5efb-a215-1bc7648e04a2",
+      "id": "4ceaaa98-c2d8-5b17-baa7-267450ea8fdf",
       "name": {
         "en": "Glory Hog"
       },
       "cost": "30",
       "keywords": ["Beastboss on Squigosaur"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BEASTBOSS ON SQUIGOSAUR** model only. Models in the bearer’s unit have the Scouts 9\" ability."
       },
@@ -3262,13 +3275,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cbd957ad-712c-59d3-bbde-4ecd6bf94bc0",
+      "id": "5358f2d9-91bb-5637-92f5-9dd400eb4e64",
       "name": {
         "en": "Skrag Every Stash!"
       },
       "cost": "25",
       "keywords": ["Beast Snagga"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BEAST SNAGGA** model only. At the end of your Command phase, if the bearer is within range of an objective marker you control, that objective marker remains under your control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn."
       },
@@ -3280,13 +3294,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4e501d88-8a90-5825-ac3a-0d8d94ee7aa0",
+      "id": "b0b40a47-4ef1-5fb6-ab50-5af9651ca7a1",
       "name": {
         "en": "Proper Killy"
       },
       "cost": "15",
       "keywords": ["Beast Snagga"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BEAST SNAGGA** model only. Add 1 to the Damage characteristic of melee weapons equipped by the bearer."
       },
@@ -3298,13 +3313,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f4002ad4-ff7e-5982-ac7d-0190fef0295a",
+      "id": "a0822aec-627c-57e6-89c2-19b6b95ae91d",
       "name": {
         "en": "Surly As A Squiggoth"
       },
       "cost": "20",
       "keywords": ["Beastboss on Squigosaur"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BEASTBOSS ON SQUIGOSAUR** model only. While the bearer is leading a unit, each time an attack targets that unit, if the Strength characteristic of that attack is greater than the Toughness characteristic of that unit, subtract 1 from the Wound roll."
       },
@@ -3316,13 +3332,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cca301d6-7791-562e-9172-a36a3051bafb",
+      "id": "d0eeeb46-39f7-522b-9965-81e8334c67bf",
       "name": {
         "en": "Wazblasta"
       },
       "cost": "10",
       "keywords": ["Deffkilla Wartrike"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEFFKILLA WARTRIKE** model only. In your Shooting phase, after the bearer’s unit has shot, if it is not within Engagement Range of one or more enemy units, it can make a Normal move of up to 6\". If it does, until the end of the turn, it is not eligible to declare a charge."
       },
@@ -3334,13 +3351,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "615dbb49-1211-5bc2-83e4-f8a30440c872",
+      "id": "fd6479e2-3328-5d29-9971-221ca86b2dea",
       "name": {
         "en": "Fasta Than Yooz"
       },
       "cost": "35",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS INFANTRY** model only. Each time the bearer’s unit disembarks from a **TRANSPORT** after that **TRANSPORT** has made a Normal move, the bearer’s unit is still eligible to declare a charge this turn."
       },
@@ -3352,13 +3370,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "88394912-1d74-5086-8803-d1459bdd398f",
+      "id": "cdb5133a-6e4f-541c-a653-3afee688631f",
       "name": {
         "en": "Squig-hide Tyres"
       },
       "cost": "15",
       "keywords": ["Deffkilla Wartrike"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEFFKILLA WARTRIKE** model only. Each time a model in the bearer’s unit makes a Consolidation move, it can move up to 6\" instead of up to 3\"."
       },
@@ -3370,13 +3389,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e477df3c-dc56-5202-b784-dfab86c50736",
+      "id": "bcc220c3-3acc-537c-bd94-e8546493dc49",
       "name": {
         "en": "Speed Makes Right"
       },
       "cost": "25",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS** model only. In your Command phase, if the bearer (or a **TRANSPORT** the bearer is embarked within) is within 9\" of one or more enemy units, roll one D6: on a 3+, you gain 1CP."
       },
@@ -3388,13 +3408,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1fbb59ed-87a1-571c-a5f8-7e99e4ff2b03",
+      "id": "16b3b569-4a31-5e9d-a06e-c17e5ee60843",
       "name": {
         "en": "Smoky Gubbinz"
       },
       "cost": "15",
       "keywords": ["Mek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEK** model only. Models in the bearer’s unit have the Stealth ability."
       },
@@ -3406,13 +3427,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d65cf378-ab49-51d4-afcb-5ba71e5d86b1",
+      "id": "2be9979c-07e6-5df0-a14c-d0f8e9ee9980",
       "name": {
         "en": "Supa-glowy Fing"
       },
       "cost": "20",
       "keywords": ["Mek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEK** model only. In your Command phase, select one enemy unit within 18\" of and visible to the bearer, then roll one D6: on a 1‑2, that enemy unit must take a Battle‑shock test; on a 3‑4, that enemy unit suffers D3 mortal wounds; on a 5‑6, until the start of your next Command phase, each time a model in that enemy unit makes an attack, subtract 1 from the Hit roll."
       },
@@ -3424,13 +3446,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "04a94fd0-edd9-55c8-b512-5e67f149bed9",
+      "id": "c0a17df3-6638-5944-8828-c08c9c1781c5",
       "name": {
         "en": "Press It Fasta!"
       },
       "cost": "35",
       "keywords": ["Mek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEK** model only. Each time the bearer’s unit is selected to shoot, when rolling to determine which ability that unit’s weapons gain from the Try Dat Button! Detachment rule, roll one additional D6: until the end of the phase, ranged weapons equipped by models in that unit gain both Button Effects generated by those rolls. If a duplicate Button Effect is rolled, it has no additional effect."
       },
@@ -3442,13 +3465,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "64bb884b-743a-50d0-b021-1252e6db152f",
+      "id": "44d9536c-a9b4-5d5c-8f79-9197e260c862",
       "name": {
         "en": "Gitfinder Gogglez"
       },
       "cost": "10",
       "keywords": ["Mek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEK** model only. Ranged weapons equipped by models in the bearer’s unit have the **[IGNORES COVER]** ability."
       },
@@ -3460,13 +3484,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a2af83f9-581c-530f-bb91-decaf1bdef0a",
+      "id": "b1bfeae3-4c28-5560-85d3-08ba111c4499",
       "name": {
         "en": "Ferocious Show Off"
       },
       "cost": "10",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS INFANTRY** model only. Each time the bearer fights, while resolving those attacks, add 1 to the Strength characteristic of the bearer’s melee weapons. If the bearer’s unit contains 10 or more models, while resolving those attacks, add 3 to the Strength characteristic instead."
       },
@@ -3478,13 +3503,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4f02b2d6-abe5-5d7c-b48b-071811c2ccd4",
+      "id": "dedc7aed-84c0-5faa-ac7e-f3c72696c08d",
       "name": {
         "en": "Brutal But Kunnin’"
       },
       "cost": "25",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS INFANTRY** model only. In your Command phase, if the bearer is on the battlefield (or is embarked within a **TRANSPORT** that is on the battlefield), roll one D6, adding 2 to the result if the bearer’s unit contains 10 or more models: on a 5+, you gain 1CP."
       },
@@ -3496,13 +3522,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c14bcbec-fcd0-50d5-bd24-5a7f7e719a86",
+      "id": "3ac34519-abf0-5673-b28a-795216093fe5",
       "name": {
         "en": "Bloodthirsty Belligerence"
       },
       "cost": "15",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS INFANTRY** model only. While the bearer is leading a unit, you can re‑roll Advance rolls made for that unit. While that unit contains 10 or more models, you can re‑roll Charge rolls made for that unit as well."
       },
@@ -3514,13 +3541,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "337bf07f-eadc-53e1-8437-3ef3f9a2bd3c",
+      "id": "7c0cb848-6240-553e-a709-4aa226a332e2",
       "name": {
         "en": "Raucous Warcaller"
       },
       "cost": "20",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS INFANTRY** model only. While the bearer is leading a unit, that unit always counts as containing 10 or more models for the purposes of your Detachment rule and any Stratagems you use."
       },
@@ -3532,13 +3560,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7705aa17-edb3-508a-be7e-bdcc60425dff",
+      "id": "86451fde-f78b-5d52-bb84-24ab812b48c3",
       "name": {
         "en": "Tellyporta"
       },
       "cost": "25",
       "keywords": ["Warboss in Mega Armour"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WARBOSS IN MEGA ARMOUR** model only. Models in the bearer’s unit have the Deep Strike ability."
       },
@@ -3550,13 +3579,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2e728759-0b08-59a6-9f57-aa2c1e513262",
+      "id": "86380d61-33b4-5f6a-a78a-217a89d2a05a",
       "name": {
         "en": "Big Gob"
       },
       "cost": "20",
       "keywords": ["Warboss", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY WARBOSS** model only. At the start of the Fight phase, select one enemy unit within Engagement range of the bearer. That unit must take a Battle‑shock test, and when doing so, subtract 1 from the result."
       },
@@ -3568,13 +3598,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3b39df9c-3267-5482-8d06-9ab7fc5a078f",
+      "id": "cab9558d-87e8-5807-8e1a-76f530da322c",
       "name": {
         "en": "Da Biggest Boss"
       },
       "cost": "15",
       "keywords": ["Warboss", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY WARBOSS** model only. Add 2 to the bearer’s Wounds characteristic."
       },
@@ -3586,13 +3617,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ae96d045-8e1f-5e09-abd9-e475672d6ccd",
+      "id": "60dc0709-c040-509d-88a5-cd30a1f347e8",
       "name": {
         "en": "’Eadstompa"
       },
       "cost": "10",
       "keywords": ["Warboss", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY WARBOSS** model only. Each time the bearer makes an attack that targets a unit that is below its Starting Strength, re‑roll a Wound roll of 1. If that unit is Below Half‑strength, you can re‑roll the Wound roll instead."
       },
@@ -3604,13 +3636,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2821c29d-8b5f-5b01-8ce9-0cb002409f62",
+      "id": "24dbcc8a-6cad-5276-8d08-e57edc9f407d",
       "name": {
         "en": "Da Kaptin"
       },
       "cost": "10",
       "keywords": ["Warboss"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WARBOSS** model only. Once per battle round, at the start of any phase, you can select one friendly **ORKS** unit that is Battle‑shocked and within 12\" of the bearer. That unit suffers D3 mortal wounds and it is no longer Battle‑shocked."
       },
@@ -3622,13 +3655,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c40d7255-95c5-56df-92e6-a4233147c9e4",
+      "id": "9df40da8-3f08-5221-ad5f-b739ba594647",
       "name": {
         "en": "Git-Spotter Squig"
       },
       "cost": "20",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS** model only. Ranged weapons equipped by models in the bearer’s unit have the **[IGNORES COVER]** ability."
       },
@@ -3640,13 +3674,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5df9f664-a385-5577-8495-3405d037a5d1",
+      "id": "48dccedb-68ca-5369-b472-a6da933caa2d",
       "name": {
         "en": "Bionik Workshop"
       },
       "cost": "15",
       "keywords": ["Big Mek", "Painboy"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BIG MEK** or **PAINBOY** model only. At the start of the battle, roll one D3 and compare the result to the list below. Until the end of the battle, models in the bearer’s unit have that bioniks ability.\n\n**1.  Bionik Legs:** Add 2\" to the Move characteristic of this model.\n**2.  Bionik Arms:** Add 1 to the Strength characteristic of melee weapons equipped by this model.\n**3.  Bionik Bonce:** Improve the Weapon Skill characteristic of melee weapons equipped by this model by 1."
       },
@@ -3658,13 +3693,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d8c2d39e-4895-5d24-80f2-dec0bb0585e6",
+      "id": "0c2b8f60-b4ad-57de-9a80-b6ac77169c31",
       "name": {
         "en": "Razgit’s Magik Map"
       },
       "cost": "25",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS** model only. After both players have deployed their armies, select up to three **ORKS INFANTRY** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -3676,13 +3712,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "904f3bf3-20a0-51da-846a-d28faf242ca3",
+      "id": "fcc4c88e-05ed-5044-a8d9-2c87de4df3ae",
       "name": {
         "en": "Kustom Shokk Box"
       },
       "cost": "10",
       "keywords": ["Deffkilla Wartrike"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEFFKILLA WARTRIKE** model only. Each time the bearer uses its turbo, its unit can move horizontally through terrain features."
       },
@@ -3694,13 +3731,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ddeb13ae-5d90-5800-870a-f803f8d2839d",
+      "id": "643924dd-ce48-5616-8211-560372e5a635",
       "name": {
         "en": "Dakkamek"
       },
       "cost": "25",
       "keywords": ["Mek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEK** model only. Each time the bearer uses its Mekaniak ability, until the start of your next Command phase, ranged weapons equipped by the selected Vehicle model have the **[RAPID FIRE 1]** ability."
       },
@@ -3712,13 +3750,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e0ae7bae-7f9b-5c73-9e32-10024c4d1803",
+      "id": "23717f00-0270-5f88-bb56-484f7c288e24",
       "name": {
         "en": "Supa-Burny Fuel"
       },
       "cost": "15",
       "keywords": ["Deffkilla Wartrike"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**DEFFKILLA WARTRIKE** model only. Change the Attacks characteristic of the bearer’s killa jet – burna weapon to 3D6, and change the Attacks characteristic of the bearer’s killa jet – cutta weapon to 3."
       },
@@ -3730,13 +3769,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "eeec64f0-df31-5571-aa23-b562e170633c",
+      "id": "28ff408d-c3cb-5695-bdfd-1b30d6e50781",
       "name": {
         "en": "Master Meknologist"
       },
       "cost": "20",
       "keywords": ["Big Mek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BIG MEK** model only. Improve the Ballistic Skill characteristic of the bearer’s ranged weapons by 1."
       },
@@ -3748,13 +3788,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "20a7fc90-21c1-59bb-b2c2-f25b39c7e4ce",
+      "id": "176d4ce5-dc34-559c-994b-1de6b5852341",
       "name": {
         "en": "Runnin’ Boots"
       },
       "cost": "10",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS INFANTRY CHARACTER** model only. Each time you make a Charge roll for the bearer’s unit, if that unit disembarked from a **TRANSPORT** this turn, add 1 to the result."
       },
@@ -3766,13 +3807,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "95ef4141-9419-52c2-90f5-c7748f09bef2",
+      "id": "1945fb25-2258-5e7e-ba2f-3c21364f5b45",
       "name": {
         "en": "Blitzkaptin"
       },
       "cost": "25",
       "keywords": ["Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS CHARACTER** model only. After both players have deployed their armies, if the bearer’s unit (or any **TRANSPORT** it is embarked within) is on the battlefield, select up to three **ORKS VEHICLE** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -3784,13 +3826,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "521d3faa-30d4-52ea-aba7-d937a954f96e",
+      "id": "5c57eba3-f937-5734-bdea-3abb80bacc5e",
       "name": {
         "en": "Supercharged Squig Oil"
       },
       "cost": "10",
       "keywords": ["Mek"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEK** model only. Each time the bearer uses its Mekaniak ability, until the end of the turn, you can re‑roll Charge rolls for the selected **VEHICLE** model’s unit."
       },
@@ -3802,13 +3845,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "48fe8dad-0574-55e1-86bc-7add13404efb",
+      "id": "76dfd7d6-4347-5fc2-9b03-88e4fcc7f680",
       "name": {
         "en": "Tuff Git"
       },
       "cost": "5",
       "keywords": ["Infantry", "Orks"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ORKS INFANTRY CHARACTER** model only. At the end of a phase in which the bearer’s unit disembarked from a **TRANSPORT**, if that unit is Battle‑shocked, it is no longer Battle‑shocked."
       },
@@ -3974,6 +4018,43 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Burna Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Flash Gitz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Lootas",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Tankbustas",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -4831,7 +4912,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BEAST SNAGGA BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Beast Snagga Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b2154bb5-34f0-5c55-adda-b29d978fab29",
@@ -5057,7 +5145,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SQUIGHOG BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Squighog Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6868b71c-9c3a-5064-a377-e11a4d158e5a",
@@ -5285,7 +5380,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BOYZ** ■ **BREAKA BOYZ** ■ **LOOTAS** ■ **MEK GUNZ** ■ **NOBZ** ■ **TANKBUSTAS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lootas",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Mek Gunz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tankbustas",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "06c3635f-f230-5169-ac9a-7a8e178bc831",
@@ -5762,7 +5889,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **MEGANOBZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Meganobz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "36485c40-7cb8-5bf4-ba24-1f287dd37a13",
@@ -5956,7 +6090,39 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BOYZ** ■ **BREAKA BOYZ** ■ **LOOTAS** ■ **MEK GUNZ** ■ **NOBZ** ■ **TANKBUSTAS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lootas",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Mek Gunz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tankbustas",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "60ac82b0-fd1d-599d-8484-c5e926301cfe",
@@ -6312,7 +6478,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BOYZ** ■ **BREAKA BOYZ** ■ **NOBZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0ec6442e-cdf6-5669-b5ab-57cccdf4a27f",
@@ -6877,7 +7060,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **KOMMANDOS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Kommandos",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "126f5eb6-5c28-57fb-a570-21a60a3d85f0",
@@ -8765,7 +8955,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **NOBZ ON WARBIKES** ■ **SKORCHAS** ■ **WARBIKERS** ■ **WARBUGGIES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Warbikers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "99d257a5-ca17-5cdf-96a1-7473031a1259",
@@ -9639,7 +9836,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BOYZ** ■ **BREAKA BOYZ** ■ **MEGANOBZ** ■ **NOBZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Meganobz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "4ffe5482-08d8-5c01-bf59-a4bb152fd94e",
@@ -12401,7 +12620,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BOYZ** ■ **LOOTAS** ■ **MEK GUNZ** ■ **NOBZ** ■ **TANKBUSTAS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Lootas",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Mek Gunz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tankbustas",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "71a0da31-35c6-57d1-89b9-ca161b90bb1b",
@@ -13120,7 +13366,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SQUIGHOG BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Squighog Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "40af5f86-133a-5802-9ee9-4f0a8b483b56",
@@ -13603,7 +13856,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BEAST SNAGGA BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Beast Snagga Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "233c4eaf-0ffd-51c8-816d-3a05bb14b6bf",
@@ -13792,6 +14052,38 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Burna Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Lootas",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Tankbustas",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -16031,7 +16323,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BOYZ** ■ **BREAKA BOYZ** ■ **NOBZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Nobz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "043501a6-a92e-5b75-b153-7d70ceb9ffcc",
@@ -16201,7 +16510,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **MEGANOBZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Meganobz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "fe2107c4-4c5a-5ac0-a237-9a393b7ef2df",
@@ -17091,7 +17407,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BOYZ** ■ **BREAKA BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Boyz",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Breaka Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3dc1b72a-b8f7-58b4-8bab-fa54e7523b2a",
@@ -17269,7 +17597,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BEAST SNAGGA BOYZ**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Beast Snagga Boyz",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5c0a00c4-5adf-501e-856d-ab55f4bf892a",
@@ -17438,7 +17773,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **GRETCHIN**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Gretchin",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/space_marines.json
+++ b/11th/gdc/space_marines.json
@@ -7,7 +7,7 @@
     "header": "#4b6262"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:49.853Z",
+  "updated": "2026-07-28T17:03:01.955Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -5001,7 +5001,7 @@
   ],
   "enhancements": [
     {
-      "id": "1096477e-1536-5780-92ce-6abca1747c69",
+      "id": "e5ba5535-44ea-5304-9d09-afd3ec1a6a05",
       "name": {
         "en": "Bellicose Weapon Spirits (Upgrade)",
         "de": "Kriegerische Waffengeister (Aufwertung)",
@@ -5015,6 +5015,7 @@
       "cost": "15",
       "keywords": ["Speeder"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Speeder</k> unit only. This unit can re-roll:\r<ul><li><b>Damage rolls</b>.</li>\r<li>Rolls to determine the <b>A</b> of a weapon.</li></ul>",
         "de": "Nur für eine <k>Speeder</k>-Einheit. Für diese Einheit können: \n<ul><li><b>Schadenswürfe</b> wiederholt werden.</li>\n<li>Würfe zum Bestimmen der <b>A</b> einer Waffe wiederholt werden.</li></ul>",
@@ -5033,7 +5034,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b60cc9a9-6f73-54a1-ad38-176ffc25ad1c",
+      "id": "6233ba2f-7b39-58fb-9fb6-b3e5e9afd8fe",
       "name": {
         "en": "Raptorial Cogitator Core (Upgrade)",
         "de": "Raubvogelcogitatorkern (Aufwertung)",
@@ -5047,6 +5048,7 @@
       "cost": "15",
       "keywords": ["Speeder"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Speeder</k> unit only. This unit’s ranged attacks have <k>[Ignores Cover]</k>.",
         "de": "Nur für eine <k>Speeder</k>-Einheit. Fernkampfattacken dieser Einheit haben <k>[Deckung ignorieren]</k>.",
@@ -5065,7 +5067,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "208e7d7f-a283-57b1-97f7-4c09d32700a2",
+      "id": "6e4a4dd3-9c72-5165-84ec-9cefdf925da6",
       "name": {
         "en": "Death in the Dark (Upgrade)",
         "de": "Tod in der Dunkelheit (Aufwertung)",
@@ -5079,6 +5081,7 @@
       "cost": "15",
       "keywords": ["Infantry", "Phobos"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Infantry Phobos</k> unit only. This unit’s attacks that target a <b>hidden</b> unit have +1 to <b>hit rolls</b>.",
         "de": "Nur für eine <k>Phobos</k>-<k>Infanterie</k>-Einheit. Attacken dieser Einheit gegen eine <b>versteckte</b> Einheit haben +1 auf <b>Trefferwürfe</b>.",
@@ -5097,7 +5100,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4d10c656-db11-5354-ab59-f93ed2ddf64c",
+      "id": "009cc4ed-8328-5d6b-a3b1-01aa8e8840fe",
       "name": {
         "en": "Orksbane",
         "de": "Orkbrecher",
@@ -5111,6 +5114,7 @@
       "cost": "20",
       "keywords": ["Fly", "Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>ADEPTUS ASTARTES FLY INFANTRY</k> model only. This model has the following weapon:",
         "de": "Nur für ein <k>FLIEGENDES ADEPTUS</k>-<k>ASTARTES</k>-<k>INFANTERIE</k>-Modell. Dieses Modell hat folgende Waffe:",
@@ -5129,7 +5133,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6e30e264-8d33-51b3-b505-4c5f4ae16acc",
+      "id": "1779e923-a4e6-5366-a77b-b302fec710e6",
       "name": {
         "en": "Avenging Angel",
         "de": "Racheengel",
@@ -5143,6 +5147,7 @@
       "cost": "20",
       "keywords": ["Fly", "Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>ADEPTUS ASTARTES FLY INFANTRY</k> model only. When this unit ends an <b>ingress move</b>, select up to one enemy unit within 9\" of this unit. That enemy unit makes a <b>battle-shock roll</b>, with -1 to that <b>battle-shock roll</b>.",
         "de": "Nur für ein <k>FLIEGENDES ADEPTUS</k>-<k>ASTARTES</k>-<k>INFANTERIE</k>-Modell. Wenn diese Einheit eine <b>Einsatzbewegung</b> beendet, wähle bis zu eine feindliche Einheit innerhalb von 9\" um diese Einheit. Jene feindliche Einheit führt einen <b>Erschütterungswurf</b> mit -1 aus.",
@@ -5161,7 +5166,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e57fb613-614d-5b49-8cec-e65f3baa5787",
+      "id": "c5eb4843-eb05-5245-8943-d2e6faa55711",
       "name": {
         "en": "Prescience",
         "de": "Voraussicht",
@@ -5175,6 +5180,7 @@
       "cost": "20",
       "keywords": ["Psyker", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Psyker</k> model only (excluding <k>Terminator</k> models). (Once per turn per unit) In your opponent’s Movement phase, when an enemy unit ends a move within 8\" of this unit, if this unit is <b>unengaged</b>, this unit can make a <b>normal move</b> of:\r<ul><li>Up to D6\".</li>\r<li><u>Or:</u> If this unit has the <b>Divination Discipline</b> ability, up to 6\".</li></ul>",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Psioniker</k>-Modell (ausgenommen <k>Terminator</k>-Modelle). (Einmal pro Zug, pro Einheit) In der Bewegungsphase deines Gegners kann diese Einheit, wenn eine feindliche Einheit eine Bewegung innerhalb von 8\" um sie beendet und sie <b>nicht im Nahkampf</b> ist, eine <b>normale Bewegung</b>:\r<ul><li>von bis zu W6\" ausführen.</li>\r<li><u>oder:</u> von bis zu 6\", wenn deine Einheit die Fähigkeit <b>Prophetie-­Disziplin</b> hat.</li></ul>",
@@ -5193,7 +5199,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2794d55b-2da7-5605-9a0e-50b14dc9f79b",
+      "id": "dfb6257d-e6ff-54a4-b4a9-c4a9979e649c",
       "name": {
         "en": "Shroud Field",
         "de": "Schleierfeld",
@@ -5207,6 +5213,7 @@
       "cost": "20",
       "keywords": ["Phobos"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Phobos</k> model only. This model has:\r<ul><li><b>Lone Operative</b>.</li>\r<li><b>Stealth</b>.</li></ul>",
         "de": "Nur für ein <k>Phobos</k>-Modell. Dieses Modell hat:\r<ul><li><b>Einsamer Wolf</b>.</li>\r<li><b>Tarnung</b>.</li></ul>",
@@ -5225,7 +5232,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "662e5040-e739-5d7d-bc90-811d9a15698e",
+      "id": "1f4dc518-f163-5c94-921d-70d64dd157d0",
       "name": {
         "en": "Obfuscation",
         "de": "Verschleierung",
@@ -5239,6 +5246,7 @@
       "cost": "25",
       "keywords": ["Psyker", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Psyker</k> model only.\r<ul><li>Enemy units cannot target this unit with <b>snap shooting</b> attacks.</li>\r<li>If this unit has the <b>Telepathy Discipline</b> ability, this unit has ‑3\" <b>detection range</b>.</li></ul>",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Psioniker</k>-Modell.\r<ul><li>Feindliche Einheiten können gegen diese Einheit keine <b>Eiliger-Beschuss</b>-Attacken ausführen.</li>\r<li>Wenn diese Einheit die Fähigkeit <b>Telepathie-Disziplin</b> hat, hat sie ‑3\" <b>Entdeckungsreichweite</b>.</li></ul>",
@@ -5257,7 +5265,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6b902ddd-bd1f-52c0-aaf8-b981e870112f",
+      "id": "f6fbb2d6-59e9-5298-9fe1-3b0441818c44",
       "name": {
         "en": "Temporal Corridor",
         "de": "Temporaler Korridor",
@@ -5271,6 +5279,7 @@
       "cost": "25",
       "keywords": ["Psyker", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES PSYKER** model only.\n▪ If this unit has the **Telekinesis Discipline** ability, this unit has **Deep Strike**.\n▪ At the end of your opponent’s Fight phase, if this unit is **unengaged**, you can use this ability. If you do:\n▪ Place this unit in **strategic reserves**.\n▪ This unit can make an **ingress move** in your next Movement phase (including in your first turn).",
         "de": "Nur für ein <k>Adeptus-Astartes-Psioniker</k>-Modell.\n<ul><li>Wenn diese Einheit die Fähigkeit <b>Telekinese-Disziplin</b> hat, hat sie <b>Schocktruppen</b>.</li>\n<li>Wenn diese Einheit am Ende der Nahkampfphase deines Gegners <b>nicht im Nahkampf</b> ist, kannst du diese Fähigkeit einsetzen. Wenn du dies tust:</li>\n<ul><li>Versetze diese Einheit in die <b>strategische Reserve</b>.</li>\n<li>Diese Einheit kann in deiner nächsten Bewegungsphase eine <b>Einsatzbewegung</b> ausführen (auch in deinem ersten Zug).</li></ul></ul>",
@@ -5289,7 +5298,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6936d90b-fcfe-5b33-8e05-e80163e68754",
+      "id": "32523c3f-6f24-5b3b-8983-ec0fb840e224",
       "name": {
         "en": "Fusillade",
         "de": "Salve",
@@ -5303,6 +5312,7 @@
       "cost": "25",
       "keywords": ["Psyker", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES PSYKER** model only. This unit’s ranged attacks have:\n▪ **[LETHAL HITS]**.\n▪ If this unit has the **Pyromancy Discipline** ability, **[SUSTAINED HITS 1]**.",
         "de": "Nur für ein <k>Adeptus-Astartes-Psioniker</k>-Modell. Die Fernkampfattacken dieser Einheit haben:\n<ul><li><k>[TÖDLICHE TREFFER]</k>. </li>\n<li><k>[Trefferhagel 1]</k>, wenn diese Einheit die Fähigkeit <b>Pyromantie-Disziplin</b> hat.</li></ul>",
@@ -5321,7 +5331,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "772f9d44-3068-5486-8f12-5ce93773387a",
+      "id": "2e7f8a38-b53b-51bd-8765-732e7c42da88",
       "name": {
         "en": "Celerity",
         "de": "Schnelligkeit",
@@ -5335,6 +5345,7 @@
       "cost": "35",
       "keywords": ["Psyker", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Psyker</k> model only.\r<ul><li>When this unit is selected to make an <b>advance move</b>, that move does not prevent this unit from being <b>eligible to declare a charge</b>.</li>\r<li>When this unit is selected to make a <b>fall‑back move</b>, if this unit has the <b>Biomancy Discipline</b> ability, that move does not prevent this unit from being <b>eligible to declare a charge</b>.</li></ul>",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Psioniker</k>-Modell.\rWenn diese Einheit gewählt wird, eine <b>Vorrückenbewegung</b> auszuführen, verhindert jene Bewegung nicht, dass diese Einheit <b>infrage kommt, einen Angriff anzusagen</b>.\rWenn diese Einheit gewählt wird, eine <b>Rückzugsbewegung</b> auszuführen, und die Fähigkeit <b>Biomantie-Disziplin</b> hat, verhindert jene Bewegung nicht, dass diese Einheit <b>infrage kommt, einen Angriff anzusagen</b>.",
@@ -5353,13 +5364,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4663cb9d-2415-51ec-b496-5b7f7c5b20c2",
+      "id": "4d709e6f-5df2-5dad-9336-f1c45dc51538",
       "name": {
         "en": "Artificer Armour"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. The bearer has a Save characteristic of 2+ and the Feel No Pain 5+ ability."
       },
@@ -5371,13 +5383,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cd688005-b342-58dd-8d95-a49d5e8418a3",
+      "id": "cd078b19-4649-5561-8565-127a665abacc",
       "name": {
         "en": "The Blade Driven Deep"
       },
       "cost": "25",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES INFANTRY** model only. While the bearer is leading a unit, models in that unit have the Infiltrators ability."
       },
@@ -5389,13 +5402,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e0ae6573-3d3d-5962-9f88-c14d545ddfee",
+      "id": "412f0a13-1519-5630-9ab5-dd3b1a1fe185",
       "name": {
         "en": "The Honour Vehement"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks and Strength characteristics of the bearer’s melee weapons. While the bearer is under the effects of the Assault Doctrine, add 2 to the Attacks and Strength characteristics of the bearer’s melee weapons instead."
       },
@@ -5407,13 +5421,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "45261f9d-4c9c-53e9-98f1-73a0fcf07f05",
+      "id": "8f6ecaa3-6f62-5a52-8f95-4564b26c61a6",
       "name": {
         "en": "Ghostweave Cloak"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. The bearer has the Stealth and Lone Operative abilities."
       },
@@ -5425,13 +5440,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b3a95af2-511f-5a36-998b-bf9b812597a6",
+      "id": "9cb3de18-43d4-5460-bdc2-6ae1e0ddf250",
       "name": {
         "en": "Adept of the Codex"
       },
       "cost": "20",
       "keywords": ["Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CAPTAIN** model only. At the start of your Command phase, if the bearer is on the battlefield, instead of selecting a Combat Doctrine to be active for your army, you can select the Tactical Doctrine. If you do, until the start of your next Command phase, that Combat Doctrine is active for the bearer’s unit only, even if you have already selected that Combat Doctrine to be active for your army this battle."
       },
@@ -5443,13 +5459,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9c4f605c-990b-5eee-a0cf-f01e1e9c963c",
+      "id": "57226bf2-e350-508d-9639-1f26dfed5fbc",
       "name": {
         "en": "Execute and Redeploy"
       },
       "cost": "20",
       "keywords": ["Phobos"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**PHOBOS** model only. In your Shooting phase, after the bearer’s unit has shot, if that unit is not within Engagement Range of one or more enemy units, it can make a Normal move of up to 6\". If it does, until the end of the turn, that unit is not eligible to declare a charge. This cannot allow the bearer’s unit to move more than once in your Shooting phase."
       },
@@ -5461,13 +5478,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c4b474a4-1952-5cc0-9f13-5e6706a87a68",
+      "id": "434a7131-db08-5164-b3ca-36574558ab6d",
       "name": {
         "en": "Fire Discipline"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, ranged weapons equipped by models in that unit have the **[SUSTAINED HITS 1]** ability. In addition, while the bearer’s unit is under the effects of the Devastator Doctrine, you can re-roll Advance rolls made for that unit."
       },
@@ -5479,13 +5497,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dbdf932f-b347-5e13-b20d-68b4bdb32b54",
+      "id": "12b9a3fd-ff01-5b25-af44-6cfca1d66735",
       "name": {
         "en": "Shadow War Veteran"
       },
       "cost": "30",
       "keywords": ["Phobos"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**PHOBOS** model only. The bearer has the following ability:\n\n**Lord of Deceit (Aura):** Once per turn, when your opponent targets a unit from their army within 12” of this model with a **stratagem**, you can use this ability. If you do increase the CP cost of that use of that **stratagem** by 1CP."
       },
@@ -5497,13 +5516,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "37b299f3-d479-5c65-b6e7-ad4043165c2d",
+      "id": "cc5079b7-8c91-56db-b2f1-7eff40e657ba",
       "name": {
         "en": "Indomitable Fury"
       },
       "cost": "20",
       "keywords": ["Gravis"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GRAVIS** model only. The first time the bearer is destroyed, roll one D6 at the end of the phase. On a 2+, set the bearer back up on the battlefield, as close as possible to where it was destroyed and not within Engagement Range of any enemy units, with its full wounds remaining."
       },
@@ -5515,13 +5535,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "06589659-5e77-5215-9f8a-bede61794d84",
+      "id": "0a77a36a-7b74-5d56-90a1-1e16202bff56",
       "name": {
         "en": "Fleet Commander"
       },
       "cost": "15",
       "keywords": ["Captain"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**CAPTAIN** model only. Once per battle, at the start of your Shooting phase, you can select one point on the battlefield and place a marker on that point. At the start of your next Shooting phase, place another marker on the battlefield within 12\" of the centre of the first marker, then draw a straight line between the centre of each of these markers. Roll one D6 for each unit that line passes over or through: on a 3+, that unit suffers D3 mortal wounds. Both markers are then removed."
       },
@@ -5533,13 +5554,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fe1eaf0d-4020-55c1-89c4-51d2d7b447d7",
+      "id": "9967b592-08ff-508f-a921-8d9460cb1090",
       "name": {
         "en": "Stoic Defender"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, models in that unit have the Feel No Pain 6+ ability while they are within range of an objective marker you control and, while that unit is Battle-shocked, halve the Objective Control characteristic of models in that unit instead of changing it to 0."
       },
@@ -5551,13 +5573,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "262043f5-23ea-5072-8260-8a119d61e61b",
+      "id": "a0ba7ea7-a824-5f02-8c53-8297c52fb63a",
       "name": {
         "en": "Architect of War"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, ranged weapons equipped by models in that unit have the **[IGNORES COVER]** ability."
       },
@@ -5569,13 +5592,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c7050a58-ae62-5456-8b7a-4ffa1fd6304a",
+      "id": "921cf245-5483-501c-9265-e0c4a6fb7d5f",
       "name": {
         "en": "Target Augury Web"
       },
       "cost": "30",
       "keywords": ["Techmarine"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECHMARINE** model only. In your Command phase, select one **ADEPTUS ASTARTES VEHICLE** model within 6\" of the bearer. Until the start of your next Command phase, weapons equipped by that **VEHICLE** model have the **[LETHAL HITS]** ability."
       },
@@ -5587,13 +5611,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b7732c63-cc1e-518c-be57-8488ff202faa",
+      "id": "9eb00f98-c37a-5c5f-bcb0-ac333e9e2ce3",
       "name": {
         "en": "The Flesh Is Weak"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. The bearer has the Feel No Pain 4+ ability."
       },
@@ -5605,13 +5630,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5dcfadc6-3709-547c-a6ae-40ba4019c36d",
+      "id": "ba6fc9de-1c80-5004-a3f7-e84299fa84bf",
       "name": {
         "en": "Adept of the Omnissiah"
       },
       "cost": "35",
       "keywords": ["Techmarine"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TECHMARINE** model only. Once per battle round, when a saving throw is failed for a friendly **ADEPTUS ASTARTES VEHICLE** model within 6\" of the bearer, you can change the Damage characteristic of that attack to 0."
       },
@@ -5623,13 +5649,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e249e519-50b4-52f3-b238-589392c3d200",
+      "id": "6118f2bb-ba8d-5f62-8a53-46afdca11793",
       "name": {
         "en": "Master of Machine War"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. In your Command phase, select one **ADEPTUS ASTARTES VEHICLE** model within 6\" of the bearer. Until the start of your next Command phase, that **VEHICLE** is eligible to shoot even if it Fell Back or Advanced this turn."
       },
@@ -5641,13 +5668,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f468da08-14ee-5504-8e0a-f6226b652def",
+      "id": "07c9c6f0-11c8-5186-8e53-f243ae8e2955",
       "name": {
         "en": "Champion of Humanity"
       },
       "cost": "10",
       "keywords": ["Tacticus"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TACTICUS** model only. While the bearer is leading a unit, models in that unit can ignore any or all modifiers to their characteristics and/or to any roll or test made for them (excluding modifiers to saving throws)."
       },
@@ -5659,13 +5687,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b1b6d092-fd36-5555-9df5-6f03442c48f4",
+      "id": "bbee7fe8-95d2-54aa-9717-819f41c43458",
       "name": {
         "en": "War-tempered Artifice"
       },
       "cost": "25",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES INFANTRY** model only. Add 3 to the Strength characteristic of the bearer’s melee weapons."
       },
@@ -5677,13 +5706,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "974acc99-4e63-5070-8be8-b14cdcc37bb4",
+      "id": "3b19c653-ba11-5a54-b79e-6aa10202716d",
       "name": {
         "en": "Forged in Battle"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, once per turn, after making a Hit roll or a saving throw for a model in that unit, you can change the result of that roll to an unmodified 6."
       },
@@ -5695,13 +5725,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0d4f3365-79e1-5c8b-ad38-05f3c3c27fe3",
+      "id": "575ab892-ee42-5a77-ac03-3ba2d15ddbc4",
       "name": {
         "en": "Adamantine Mantle"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time an attack is allocated to the bearer, subtract 1 from the Damage characteristic of that attack. If that attack was made with a Melta or Torrent weapon, change the Damage characteristic of that attack to 1 instead."
       },
@@ -5713,13 +5744,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e086511b-9630-5e14-aba2-13f769318061",
+      "id": "b9e6aee3-4723-503c-8e8d-bd1d7834e3b1",
       "name": {
         "en": "Fury of the Storm"
       },
       "cost": "25",
       "keywords": ["Mounted", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES MOUNTED** model only. Improve the Strength and Armour Penetration characteristics of the bearer’s melee weapons by 1. Each time the bearer ends a Charge move, until the end of the turn, improve the Strength and Armour Penetration characteristics of the bearer’s melee weapons by 2 instead."
       },
@@ -5731,13 +5763,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5512281d-c3f6-52c2-a842-d3e6ea81dfdf",
+      "id": "0cbbb2c4-de01-504d-bea2-f17ed25b1ce6",
       "name": {
         "en": "Portents of Wisdom"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, you can re-roll Advance rolls made for that unit."
       },
@@ -5749,13 +5782,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2d0423f7-79ee-5fad-9660-81e5b582f328",
+      "id": "aa6b25eb-1650-5648-82a9-2b3da536d9b5",
       "name": {
         "en": "Feinting Withdrawal"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, that unit is eligible to shoot in a turn in which it Fell Back."
       },
@@ -5767,13 +5801,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0bdbc832-0556-53e7-90aa-2f864a03506e",
+      "id": "bb6045d2-1d27-5c9e-985a-c2f55739b442",
       "name": {
         "en": "Hunter’s Instincts"
       },
       "cost": "25",
       "keywords": ["Mounted", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES MOUNTED** model only. If the bearer’s unit is in Strategic Reserves, for the purposes of setting up that unit on the battlefield, treat the current battle round number as being one higher than it actually is."
       },
@@ -5785,13 +5820,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d6fefd1c-ba9d-526f-83ac-df2cc4ab3f92",
+      "id": "4a2c7146-f28c-5aca-a474-5f31c926e122",
       "name": {
         "en": "The Imperium’s Sword"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks characteristic of the bearer’s melee weapons. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, until the end of the phase, add 1 to the Attacks characteristic of melee weapons equipped by all other models in the bearer’s unit as well."
       },
@@ -5803,13 +5839,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f5dbc311-df00-5d6c-b232-42ad2c578c7f",
+      "id": "24f60613-38dd-5eb5-8ed5-9693025be41b",
       "name": {
         "en": "Fear Made Manifest (Aura)"
       },
       "cost": "30",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While an enemy unit (excluding **MONSTERS** and **VEHICLES**) is within 6\" of the bearer, each time that unit fails a Battle-shock test, one model in that unit is destroyed (chosen by its controlling player). Once per battle, when such an enemy unit fails a Battle-shock test, you can choose for D3 models in that unit to be destroyed in this way instead."
       },
@@ -5821,13 +5858,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "45dd4861-b93d-5652-b418-4550996ec0ee",
+      "id": "f2ec9b9f-42a5-59df-9cd1-f7038fbe00e6",
       "name": {
         "en": "Rites of War"
       },
       "cost": "10",
       "keywords": ["Terminator", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR** model only. Improve the Objective Control characteristic of the bearer by 1. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, until the end of the phase, add 1 to the Objective Control characteristic of all other models in the bearer’s unit as well."
       },
@@ -5839,13 +5877,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "87acf6af-65d3-52ec-a54b-47ebcc20234e",
+      "id": "a8af0e4c-4b79-59fc-a477-a08050a3d532",
       "name": {
         "en": "Iron Resolve"
       },
       "cost": "15",
       "keywords": ["Terminator", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR** model only. The bearer has the Feel No Pain 5+ ability. Once per battle, after the bearer’s unit is selected as the target of one or more attacks, the bearer can use this Enhancement. If it does, until the end of the phase, models in the bearer’s unit have the Feel No Pain 5+ ability."
       },
@@ -5857,13 +5896,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "679ec816-197c-50e7-844f-afd0d62a76ca",
+      "id": "cdf74831-303c-51cb-a98c-859b187bffd0",
       "name": {
         "en": "Immolator"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks characteristics of Torrent weapons equipped by models in the bearer’s unit."
       },
@@ -5875,13 +5915,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b1b6d092-fd36-5555-9df5-6f03442c48f4",
+      "id": "86129493-925b-5c0e-99e0-c468d7d029a7",
       "name": {
         "en": "War-tempered Artifice"
       },
       "cost": "25",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES INFANTRY** model only. Add 3 to the Strength characteristic of the bearer’s melee weapons."
       },
@@ -5893,13 +5934,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "974acc99-4e63-5070-8be8-b14cdcc37bb4",
+      "id": "069bdbeb-5e1a-50a1-8808-8583645cda71",
       "name": {
         "en": "Forged in Battle"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, once per turn, after making a Hit roll or a saving throw for a model in that unit, you can change the result of that roll to an unmodified 6."
       },
@@ -5911,13 +5953,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0d4f3365-79e1-5c8b-ad38-05f3c3c27fe3",
+      "id": "25c2af59-3e02-5d8e-9dd1-c34da8741c22",
       "name": {
         "en": "Adamantine Mantle"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time an attack is allocated to the bearer, subtract 1 from the Damage characteristic of that attack. If that attack was made with a Melta or Torrent weapon, change the Damage characteristic of that attack to 1 instead."
       },
@@ -5929,13 +5972,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4cd57b70-07ee-59f8-96a9-b60a63a88d02",
+      "id": "a78b5a2d-779f-5bd7-a965-8a23ec5d4eb3",
       "name": {
         "en": "Champion of the Feast"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks characteristic of the bearer’s melee weapons. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, until the end of the phase, add 1 to the Attacks characteristic of melee weapons equipped by other models in the bearer’s unit as well."
       },
@@ -5947,13 +5991,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "383cd9f3-2fe4-5462-a980-af9ce37069b0",
+      "id": "c96e02b4-a7d7-503c-b63c-6662ed09625f",
       "name": {
         "en": "Disciple of Rhetoricus"
       },
       "cost": "10",
       "keywords": ["Terminator", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR** model only. Improve the Objective Control characteristic of the bearer by 1. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, until the end of the phase, add 1 to the Objective Control characteristic of other models in the bearer’s unit as well."
       },
@@ -5965,13 +6010,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8ec87c75-9909-5c55-b4c0-addfe21704ed",
+      "id": "68bf0960-d087-5a99-907f-910ec103f38d",
       "name": {
         "en": "Indomitable Champion"
       },
       "cost": "20",
       "keywords": ["Terminator", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR** model only. The first time the bearer is destroyed, roll one D6 at the end of the phase. On a 2+, set the bearer back up on the battlefield, as close as possible to where it was destroyed and not within Engagement Range of any enemy units, with 3 wounds remaining."
       },
@@ -5983,13 +6029,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4af23427-eff1-5de2-8043-e144b042ed12",
+      "id": "d3a493f9-3ed9-588a-b915-7c59b791ad1d",
       "name": {
         "en": "Malodraxian Standard"
       },
       "cost": "20",
       "keywords": ["Ancient", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES ANCIENT** model only. Each time an attack targets the bearer’s unit, if the Strength characteristic of that attack is greater than the Toughness characteristic of the bearer’s unit, subtract 1 from the Wound roll."
       },
@@ -6001,13 +6048,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1724784f-d6d7-5899-a690-846d947d6275",
+      "id": "fd833d52-9d95-5912-849f-00cb0a39fe73",
       "name": {
         "en": "Blackwing Shroud"
       },
       "cost": "25",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES INFANTRY** model only. While the bearer is leading a unit, models in that unit have the Infiltrators ability."
       },
@@ -6019,13 +6067,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "84399519-8d73-5752-b879-63ef3d37c969",
+      "id": "bb8b484f-60f3-5a4f-a814-108ce01bd936",
       "name": {
         "en": "Coronal Susurrant"
       },
       "cost": "30",
       "keywords": ["Phobos"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**PHOBOS** model only. The bearer has the following ability:\n\n**Lord of Deceit (Aura):** Once per turn, when your opponent targets a unit from their army within 12” of this model with a **stratagem**, you can use this ability. If you do increase the CP cost of that use of that **stratagem** by 1CP."
       },
@@ -6037,13 +6086,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8c8dcae3-ff4a-5705-9eaf-f8567c04307c",
+      "id": "7da172d7-c9f5-50fd-a1a7-71f85bfaa487",
       "name": {
         "en": "Umbral Raptor"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. The bearer has the Stealth and Lone Operative abilities."
       },
@@ -6055,13 +6105,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0bdbc832-0556-53e7-90aa-2f864a03506e",
+      "id": "b991e983-215f-5650-ad55-bba50f9db57c",
       "name": {
         "en": "Hunter’s Instincts"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. In your Movement phase, if the bearer’s unit is in Strategic Reserves, for the purposes of setting up that unit on the battlefield, treat the current battle round number as being one higher than it actually is."
       },
@@ -6073,13 +6124,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4c2a6f9c-e7c1-59df-b63f-b3fb1fb8b555",
+      "id": "37811534-6a96-5e80-918b-75882f1d45f8",
       "name": {
         "en": "Spiritus Ferrum"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks characteristic of the bearer’s melee weapons. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, until the end of the phase, add 1 to the Attacks characteristic of melee weapons equipped by all other models in the bearer’s unit as well."
       },
@@ -6091,13 +6143,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3235a673-5c3c-5de0-8a43-2df0e1454975",
+      "id": "d2391938-fd58-58ad-b2df-665833b07633",
       "name": {
         "en": "Medusan Roar (Aura)"
       },
       "cost": "30",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While an enemy unit (excluding **MONSTERS** and **VEHICLES**) is within 6\" of the bearer, each time that unit fails a Battle‐shock test, one model in that unit is destroyed (chosen by its controlling player). Once per battle, when such an enemy unit fails a Battle‐shock test, you can choose for D3 models in that unit to be destroyed in this way instead."
       },
@@ -6109,13 +6162,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "daa0b458-086d-55a5-babb-b1ae736d9d6b",
+      "id": "e319eb2d-480e-5a5f-bad1-17e647623bb8",
       "name": {
         "en": "Iron Laurel"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Improve the Objective Control characteristic of the bearer by 1. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, until the end of the phase, add 1 to the Objective Control characteristic of all other models in the bearer’s unit as well."
       },
@@ -6127,13 +6181,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "aecf1d0a-e0ef-55ff-92d5-089334499602",
+      "id": "fb551a4f-6e04-519e-8f86-eded5f68fb4b",
       "name": {
         "en": "Steel Font"
       },
       "cost": "15",
       "keywords": ["Terminator", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR** model only. While the bearer is leading a unit, in your Command phase, you can return 1 destroyed Bodyguard model to that unit."
       },
@@ -6145,13 +6200,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "38ef81b0-06c1-5c25-a342-25aefab5a629",
+      "id": "ed1ca0fd-79a4-5e96-8cab-734a4f74de48",
       "name": {
         "en": "Spearpoint Paragon"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Improve the Strength and Armour Penetration characteristics of the bearer’s melee weapons by 1. Each time the bearer ends a Charge move, until the end of the turn, improve the Strength and Armour Penetration characteristics of the bearer’s melee weapons by 2 instead."
       },
@@ -6163,13 +6219,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "230a40e8-c827-5b8a-8dc6-44808e832886",
+      "id": "d8853214-0e0c-5c5c-84dd-41a760daa233",
       "name": {
         "en": "Stormseers' Wisdom"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, you can re‐roll Advance rolls made for that unit."
       },
@@ -6181,13 +6238,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4a2247d8-eb7e-5eb0-8f08-cadf0fd1a700",
+      "id": "074fa6f1-5208-5e81-befb-81e97287c2ac",
       "name": {
         "en": "Hunter’s Eye"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Ranged weapons equipped by models in the bearer’s unit have the **[SUSTAINED HITS 1]** and **[IGNORES COVER]** abilities."
       },
@@ -6199,13 +6257,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1e6101bb-5ba9-5d60-b556-5235c068f44b",
+      "id": "ca53e5c0-365f-51a1-91ce-a15af5d2308e",
       "name": {
         "en": "Chogorian Huntmaster"
       },
       "cost": "25",
       "keywords": ["Mounted", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES MOUNTED** model only. If the bearer’s unit is in Strategic Reserves, for the purposes of setting up that unit on the battlefield, treat the current battle round number as being one higher than it actually is."
       },
@@ -6217,13 +6276,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "37187226-0433-53aa-a591-41ff6bdc1721",
+      "id": "e8e9f3b5-271a-521a-86b1-caed74450e46",
       "name": {
         "en": "Armour of Antoninus"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. The bearer has a Save characteristic of 2+ and the Feel No Pain 5+ ability."
       },
@@ -6235,13 +6295,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6b1a0ed5-0884-5700-8727-e9a048d3abf7",
+      "id": "6da32fde-f782-5a28-99c7-5c0419a6d374",
       "name": {
         "en": "Oath of Macragge"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks and Strength characteristics of the bearer’s melee weapons. While the bearer is under the effects of the Assault Doctrine, add 2 to the Attacks and Strength characteristics of the bearer’s melee weapons instead."
       },
@@ -6253,13 +6314,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f0b7f044-154e-5ff5-af64-e0d7a4b8c66c",
+      "id": "243b6f9e-ab4a-512f-b805-92e0e05f82fb",
       "name": {
         "en": "Student of the Codex"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. At the start of your Command phase, if the bearer is on the battlefield, it can use this Enhancement. If it does, until the start of your next Command phase, the Tactical Doctrine is active for this unit (instead of any other Combat Doctrine you select to be active for your army, and even if there is no Combat Doctrine active for your army)."
       },
@@ -6271,13 +6333,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "01173b3b-9678-5b60-a556-0c7baf3cff28",
+      "id": "2df5449f-5b79-5b31-ba8c-a8434104aa9c",
       "name": {
         "en": "Veteran of Behemoth"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, ranged weapons equipped by models in that unit have the **[SUSTAINED HITS 1]** ability. In addition, while the bearer’s unit is under the effects of the Devastator Doctrine, you can re-roll Advance rolls made for that unit."
       },
@@ -6289,13 +6352,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "677ffb82-3189-5311-ba36-58fde100d007",
+      "id": "8fdbc970-f436-564b-9b11-7827f944c77c",
       "name": {
         "en": "Laurels of Thunder"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. You can re‑roll Charge rolls made for the bearer’s unit in a turn in which it was set up on the battlefield."
       },
@@ -6307,13 +6371,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "98933a30-244e-5b2d-9251-d2661b97b7f1",
+      "id": "4d8329ec-7b4b-5abc-a647-a2c9ceb3cbe3",
       "name": {
         "en": "Veteran of the Vanguard"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Models in the bearer’s unit have the Scouts 6\" ability."
       },
@@ -6325,13 +6390,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ccf8d82a-0bc7-5b9e-bd11-a3e2d6a347c5",
+      "id": "da419432-a155-59f2-89c2-14f1e1151a35",
       "name": {
         "en": "Orbital Uplink Reliquary"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. After both players have deployed their armies, select up to three **ADEPTUS ASTARTES** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -6343,13 +6409,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b5dbee46-2e7b-50f9-8548-f10325709c96",
+      "id": "0d6b8702-1a01-59b7-a870-b62bc6044b94",
       "name": {
         "en": "Dedicated Gunship"
       },
       "cost": "15",
       "keywords": ["Terminator", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR** model only. Once per battle, at the end of your opponent’s Fight phase, if the bearer’s unit is not within Engagement Range of one or more enemy units, the bearer can use this Enhancement. If it does, remove the bearer’s unit from the battlefield and place it into Strategic Reserves."
       },
@@ -6361,13 +6428,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "aa8175a1-00cf-59ff-a9b6-b57a41a7ef55",
+      "id": "64a0d503-17bd-5736-aa95-99290ebc9402",
       "name": {
         "en": "Eye of the Primarch"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Ranged weapons equipped by the bearer and **BATTLELINE** models in the bearer’s unit have the **[PRECISION]** ability."
       },
@@ -6379,13 +6447,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b759d983-4c44-57cd-926d-34d7421a25e2",
+      "id": "a80ca031-a992-5eb9-bf32-5147a0eb5a3d",
       "name": {
         "en": "Hero of the Chapter"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. While the bearer is leading a unit, the bearer has the **BATTLELINE** keyword."
       },
@@ -6397,13 +6466,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8ed7f325-89c2-5ae5-a7ea-6a1439feba1a",
+      "id": "b44835e9-3b16-512a-a48f-72fcbabcd780",
       "name": {
         "en": "Blades of Valour"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Improve the Armour Penetration characteristic of melee weapons equipped by the bearer and **BATTLELINE** models in the bearer’s unit by 1."
       },
@@ -6415,13 +6485,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "849b9714-b5a2-5603-a3a3-e304941e3772",
+      "id": "e861301f-5b21-507f-aad4-36cc43e84f59",
       "name": {
         "en": "Bombast Omnivox"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time you select the bearer’s unit as the target of a Stratagem, roll one D6, adding 1 if the bearer’s unit has the **BATTLELINE** keyword: on a 4+, you gain 1CP."
       },
@@ -6433,13 +6504,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "34d1b8dd-6ece-545a-a579-9786bd3d644d",
+      "id": "1a78f5ad-2023-52f9-b7d7-a6a2ef04cb3b",
       "name": {
         "en": "Seals of Reconquest"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Models in the bearer’s unit have a 5+ invulnerable save."
       },
@@ -6451,13 +6523,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a9f9e60e-373c-5ce5-9031-e670f629cebc",
+      "id": "7ae7f30b-2321-50e5-a5fd-9ad7bf9b8fa9",
       "name": {
         "en": "Avenging Avatar (Aura)"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. In the Battle‑shock step of your opponent’s Command phase, if an enemy unit that is below its Starting Strength is within 9\" of the bearer, that enemy unit must take a Battle‑shock test."
       },
@@ -6469,13 +6542,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b5cb5e5d-04d4-552d-a101-f5f0056a1976",
+      "id": "1f2d286e-5ab8-58d1-8592-e03692a44bb3",
       "name": {
         "en": "Scroll of Proclamation"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "When this unit **declares a charge**, if an enemy unit within range of an **objective** is within 12\" of this unit, you can use this **enhancement**. If you do:\n\n• This unit can re-roll that **charge roll**.\n• This unit <u>must</u> end that **charge move engaged** with one or more of those enemy units."
       },
@@ -6487,13 +6561,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "21d39ff5-bb5c-53ed-b04f-7e94608b6f39",
+      "id": "3e32ca72-9f5b-565d-b502-7abfcb169d69",
       "name": {
         "en": "Liberatum"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time the bearer makes an attack that targets an enemy unit, if the target is within range of an objective marker, you can re‑roll the Hit roll and you can re‑roll the Wound roll."
       },
@@ -6505,13 +6580,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b33af856-cf49-51d7-bbe9-8b3e7b4a4b1b",
+      "id": "44935542-b9b4-586d-8188-428bad45cb6c",
       "name": {
         "en": "Honour Indefatigable"
       },
       "cost": "25",
       "keywords": ["Gravis"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**GRAVIS** model only. The first time the bearer is destroyed, roll one D6 at the end of the phase. On a 2+, set the bearer back up on the battlefield, as close as possible to where it was destroyed and not within Engagement Range of any enemy units, with its full wounds remaining."
       },
@@ -6523,13 +6599,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8897f08a-bf60-53ed-b0c6-cc377a5fb084",
+      "id": "2f2a68f8-b4c5-5dd4-86a9-620a7f3f951e",
       "name": {
         "en": "Castellum Omnivox"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time the bearer’s unit makes a Fall Back move, select one of the following to apply to that unit until the end of the turn:\n\n■ That unit is eligible to perform an Action in a turn in which it Fell Back.\n■ That unit is eligible to shoot and declare a charge in a turn in which it Fell Back."
       },
@@ -6541,13 +6618,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f2da1b33-a156-5645-94f4-ea4ff8c4d48b",
+      "id": "fa625743-945a-594f-a7dd-fb401399b8ea",
       "name": {
         "en": "Spy-skull Data Link"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Ranged weapons equipped by models in the bearer’s unit have the **[IGNORES COVER]** ability."
       },
@@ -6559,13 +6637,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2dbcc974-c621-5f08-bd39-0c50106756bc",
+      "id": "94b15e03-a909-53f0-bfc0-6b6fa9213ca5",
       "name": {
         "en": "Defensive Mastery"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. After both players have deployed their armies, select up to three **ADEPTUS ASTARTES** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -6577,13 +6656,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d125164a-5462-5de1-ab32-6ce4b77d8ec3",
+      "id": "a0f1b3b8-0c6e-5f3f-9e87-5606a5686cc8",
       "name": {
         "en": "Liberator"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. If you control an objective marker at the end of your Command phase, and the bearer’s unit (or any **HEAVY TRANSPORT** it is embarked within) is within range of that objective marker, that objective marker remains under your control until your opponent’s Level of Control over that objective marker is greater than yours at the end of a phase."
       },
@@ -6595,13 +6675,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8e425230-f26f-5e20-a786-6c512b875e87",
+      "id": "72470662-801b-530b-89c0-fccb2789803d",
       "name": {
         "en": "Tip of the Spear"
       },
       "cost": "40",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. If the bearer starts the battle embarked within a **TRANSPORT**, that **TRANSPORT** has the Scouts 6\" ability."
       },
@@ -6613,13 +6694,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fcd47158-9dcc-5422-b948-4d186a4dffe5",
+      "id": "b8b892d2-4310-55f8-8666-d22a19cd139f",
       "name": {
         "en": "Shock Deployment"
       },
       "cost": "20",
       "keywords": ["Gravis", "Adeptus Astartes", "Terminator"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR** or **GRAVIS** model only. In your Shooting phase, each time the bearer’s unit is selected to shoot, if it disembarked from a **TRANSPORT** this turn, until the end of the phase, ranged weapons equipped by models in that unit have the **[SUSTAINED HITS 1]** ability."
       },
@@ -6631,13 +6713,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e326559a-f7b4-577f-9e39-2ad1b5a3c1ca",
+      "id": "d21d9dc5-82f3-5999-8f5e-4d34eddf7d4d",
       "name": {
         "en": "Armoured Commander"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Once per turn, in your Movement phase, the bearer can use this Enhancement. If it does, select one friendly **ADEPTUS ASTARTES TRANSPORT** that is in Strategic Reserves. Until the end of the phase, for the purposes of setting up that **TRANSPORT** on the battlefield, treat the current battle round number as being one higher than it actually is."
       },
@@ -6649,13 +6732,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "675072cb-32dd-5d4e-b022-6e27e7dd2093",
+      "id": "06e10b1c-5802-5136-94d8-e3230c0bbad4",
       "name": {
         "en": "Redoubtable Machine Spirit"
       },
       "cost": "25",
       "keywords": ["Vehicle", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES VEHICLE** model only. The bearer has a 5+ invulnerable save and, at the end of your Command phase, the bearer regains 1 lost wound."
       },
@@ -6667,13 +6751,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e9af30e6-0778-5e1e-86be-0468c80dc68e",
+      "id": "ed6d6451-7590-5cb4-ab3b-43b7cff79301",
       "name": {
         "en": "Gunnery Honours"
       },
       "cost": "20",
       "keywords": ["Vehicle", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES VEHICLE** model only. Once per phase, you can re‑roll one Hit roll, one Wound roll and one Damage roll for the bearer."
       },
@@ -6685,13 +6770,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0e3e1fde-9849-58ed-bfee-c6cfc8547a0b",
+      "id": "70fccdda-0584-5876-b27d-23ce0b670411",
       "name": {
         "en": "Firestorm Coordinators"
       },
       "cost": "20",
       "keywords": ["Vehicle", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES VEHICLE** model only. Ranged weapons equipped by the bearer have the **[SUSTAINED HITS 1]** ability."
       },
@@ -6703,13 +6789,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "547e9064-0816-50ca-ad4b-1e22c3677581",
+      "id": "6d89ae63-b7c2-572d-92e6-2639d07db5fc",
       "name": {
         "en": "Astartes Tank Ace (Aura)"
       },
       "cost": "40",
       "keywords": ["Vehicle", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES VEHICLE** model only. In your Shooting phase, while a friendly **ADEPTUS ASTARTES VEHICLE** unit is within 6\" of the bearer, ranged weapons equipped by models in that unit have the **[ASSAULT]** ability"
       },
@@ -6896,7 +6983,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **INFERNUS SQUAD** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "adaaf09e-4121-59f8-bc1a-9dd869a965ad",
@@ -7572,6 +7696,78 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Desolation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Devastator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "support",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -7910,6 +8106,33 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Deathwatch Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Deathwing Knights",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Deathwing Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Terminator Squad",
+          "targetType": "keyword"
+        }
       ]
     },
     {
@@ -8116,6 +8339,78 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Desolation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Devastator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "support",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -8299,6 +8594,28 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Aggressor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Eradicator Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "support",
+          "target": "Heavy Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Indomitor Kill Team",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -9713,6 +10030,13 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -10443,7 +10767,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RELIC TERMINATOR SQUAD** ■ **TERMINATOR ASSAULT SQUAD** ■ **TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "1abbc533-9ffb-5095-8cb4-b8f948061854",
@@ -10805,7 +11141,84 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **CRUSADER SQUAD** ■ **DEATHWATCH VETERANS** ■ **DECIMUS KILL TEAM** ■ **FORTIS KILL TEAM** ■ **HELLBLASTER SQUAD** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **SWORD BRETHREN** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **VICTRIX HONOUR GUARD** ■ **WOLF GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Victrix Honour Guard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "be09a646-d690-5507-a239-3b21e4ac3e20",
@@ -11095,7 +11508,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AGGRESSOR SQUAD** ■ **ERADICATOR SQUAD** ■ **HEAVY INTERCESSOR SQUAD** ■ **INDOMITOR KILL TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aggressor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Eradicator Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Heavy Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Indomitor Kill Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "056b030e-f4d7-50d1-9528-b1547d5fffe4",
@@ -11300,7 +11735,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ELIMINATOR SQUAD** ■ **HOUNDS OF MORKAI** ■ **INCURSOR SQUAD** ■ **INFILTRATOR SQUAD** ■ **REIVER SQUAD** ■ **SCOUT SQUAD** ■ **SPECTRUS KILL TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Eliminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Incursor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infiltrator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Reiver Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Scout Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Spectrus Kill Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "cc8bb72d-0f4f-5e68-97c7-20d7385395b0",
@@ -11540,7 +12007,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATHWATCH TERMINATOR SQUAD** ■ **DEATHWING COMMAND SQUAD** ■ **DEATHWING KNIGHTS** ■ **DEATHWING TERMINATOR SQUAD** ■ **RELIC TERMINATOR SQUAD** ■ **TERMINATOR ASSAULT SQUAD** ■ **TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Deathwatch Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwing Knights",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwing Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Squad",
+          "targetType": "keyword"
+        }
+      ]
     },
     {
       "id": "b1e6cdfd-dd71-51ff-b312-dfb44a9ffe8b",
@@ -11756,7 +12250,54 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **HELLBLASTER SQUAD** ■ **INFERNUS SQUAD** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **VICTRIX HONOUR GUARD** ■ **WARDENS OF ULTRAMAR**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Victrix Honour Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Wardens of Ultramar",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9820b84f-1b0a-5bba-942b-bc18a2f221a9",
@@ -12127,7 +12668,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSORS WITH JUMP PACKS** ■ **ASSAULT SQUAD WITH JUMP PACKS** ■ **SANGUINARY GUARD** ■ **SKYCLAWS** ■ **TALONSTRIKE KILL TEAM** ■ **VANGUARD VETERAN SQUAD WITH JUMP PACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessors with Jump Packs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sanguinary Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Talonstrike Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vanguard Veteran Squad with Jump Packs",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9225304f-8069-5cbc-bba6-bd42f41c852d",
@@ -12343,6 +12906,13 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Victrix Honour Guard",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -13105,7 +13675,84 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **CRUSADER SQUAD** ■ **DEATH COMPANY MARINES** ■ **DEATH COMPANY MARINES WITH BOLT RIFLES** ■ **DEATH COMPANY MARINES WITH BOLTGUNS** ■ **DEATHWATCH VETERANS** ■ **DECIMUS KILL TEAM** ■ **FORTIS KILL TEAM** ■ **HELLBLASTER SQUAD** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **SWORD BRETHREN** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **WOLF GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Company Marines with Bolt Rifles",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Company Marines",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6dcf2c16-999d-5127-b23e-c4912ce9cc43",
@@ -13303,7 +13950,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATHWATCH TERMINATOR SQUAD** ■ **DEATHWING COMMAND SQUAD** ■ **DEATHWING KNIGHTS** ■ **DEATHWING TERMINATOR SQUAD** ■ **RELIC TERMINATOR SQUAD** ■ **TERMINATOR ASSAULT SQUAD** ■ **TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Deathwatch Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwing Knights",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwing Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Squad",
+          "targetType": "keyword"
+        }
+      ]
     },
     {
       "id": "427470a5-0515-50c3-afd7-58042c36aaa1",
@@ -13495,7 +14169,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BIKE SQUAD** ■ **COMPANY VETERANS ON BIKES** ■ **OUTRIDER SQUAD** ■ **RAVENWING BLACK KNIGHTS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Outrider Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ravenwing Black Knights",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "cea9dfce-bbfa-5ac3-81cb-a79d5fabec96",
@@ -13900,7 +14586,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSORS WITH JUMP PACKS** ■ **ASSAULT SQUAD WITH JUMP PACKS** ■ **DEATH COMPANY MARINES WITH BOLTGUNS AND JUMP PACKS** ■ **DEATH COMPANY MARINES WITH JUMP PACKS** ■ **SKYCLAWS** ■ **TALONSTRIKE KILL TEAM** ■ **VANGUARD VETERAN SQUAD WITH JUMP PACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessors with Jump Packs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Death Company Marines with Jump Packs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Talonstrike Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vanguard Veteran Squad with Jump Packs",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "aad0f52c-e204-5ddd-a9db-84b0a4707b2e",
@@ -14111,7 +14819,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **DESOLATION SQUAD** ■ **DEVASTATOR SQUAD** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Desolation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Devastator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "128e8838-b062-57d4-8bcb-8aa9b012526d",
@@ -14554,7 +15299,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RELIC TERMINATOR SQUAD** ■ **TERMINATOR ASSAULT SQUAD** ■ **TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "89a5bc47-72bc-50c4-a6c0-7952a6d8fb41",
@@ -20658,7 +21415,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AGGRESSOR SQUAD** ■ **ERADICATOR SQUAD** ■ **HEAVY INTERCESSOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aggressor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Eradicator Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Heavy Intercessor Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "975b42e0-7b09-5ece-9dfe-a5da3838b3cf",
@@ -20831,7 +21605,69 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **CRUSADER SQUAD** ■ **DEATHWATCH VETERANS** ■ **DECIMUS KILL TEAM** ■ **FORTIS KILL TEAM** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **SWORD BRETHREN** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **WOLF GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "54abfd41-d81e-5238-be09-db481da796ac",
@@ -21036,7 +21872,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSORS WITH JUMP PACKS** ■ **ASSAULT SQUAD WITH JUMP PACKS** ■ **VANGUARD VETERAN SQUAD WITH JUMP PACKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessors with Jump Packs",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Vanguard Veteran Squad with Jump Packs",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "990cf04d-3c9b-5891-8513-cc95e7a5ac0f",
@@ -21220,7 +22068,39 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d63b5215-7378-55b6-b363-5d768a81474d",
@@ -22515,7 +23395,69 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **DEATHWATCH VETERANS** ■ **DECIMUS KILL TEAM** ■ **DESOLATION SQUAD** ■ **DEVASTATOR SQUAD** ■ **FORTIS KILL TEAM** ■ **HELLBLASTER SQUAD** ■ **INFERNUS SQUAD** ■ **INNER CIRCLE COMPANIONS** ■ **INTERCESSOR SQUAD** ■ **LONG FANGS** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **WOLF GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Desolation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Devastator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "eea8ef2c-0dc2-53d9-99e2-77a4d6ecb3e3",
@@ -22728,7 +23670,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ELIMINATOR SQUAD** ■ **HOUNDS OF MORKAI** ■ **INCURSOR SQUAD** ■ **INFILTRATOR SQUAD** ■ **REIVER SQUAD** ■ **SPECTRUS KILL TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Eliminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Incursor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infiltrator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Reiver Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Spectrus Kill Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "76427e7e-ec93-537e-94d3-a614d30246f0",
@@ -22974,7 +23943,34 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **DEATHWATCH TERMINATOR SQUAD** ■ **DEATHWING COMMAND SQUAD** ■ **DEATHWING KNIGHTS** ■ **DEATHWING TERMINATOR SQUAD** ■ **RELIC TERMINATOR SQUAD** ■ **TERMINATOR ASSAULT SQUAD** ■ **TERMINATOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Deathwatch Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwing Knights",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Deathwing Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "206eeab4-32a1-57f3-99bf-d1d8e96cef39",
@@ -23373,6 +24369,78 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Deathwatch Veterans",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Hellblaster Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Inner Circle Companions",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "support",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -23594,6 +24662,28 @@
             }
           ]
         }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Incursor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Infiltrator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Reiver Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Spectrus Kill Team",
+          "targetType": "datasheet"
+        }
       ]
     },
     {
@@ -23788,6 +24878,13 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Reiver Squad",
+          "targetType": "datasheet"
         }
       ]
     },
@@ -24163,7 +25260,74 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AGGRESSOR SQUAD** ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **ERADICATOR SQUAD** ■ **HEAVY INTERCESSOR SQUAD** ■ **INFERNUS SQUAD** ■ **INTERCESSOR SQUAD** ■ **RELIC TERMINATOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD** ■ **TERMINATOR ASSAULT SQUAD** ■ **TERMINATOR SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **VICTRIX HONOUR GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aggressor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Eradicator Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Heavy Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Assault Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Terminator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Victrix Honour Guard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "7a701c86-8b99-5ef2-94a7-15e3cb64e34a",
@@ -24708,7 +25872,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLADEGUARD VETERAN SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "ae8823f4-1e44-58db-a791-de6260571359",
@@ -29826,7 +31012,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BIKE SQUAD** ■ **COMPANY VETERANS ON BIKES** ■ **OUTRIDER SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Outrider Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "3a1b4813-01ca-5a6b-83c2-dd4d1b327fa3",
@@ -31012,7 +32205,54 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **CRUSADER SQUAD** ■ **DECIMUS KILL TEAM** ■ **DESOLATION SQUAD** ■ **DEVASTATOR SQUAD** ■ **FORTIS KILL TEAM** ■ **INTERCESSOR SQUAD** ■ **LONG FANGS** ■ **SWORD BRETHREN** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **WOLF GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crusader Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Decimus Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Desolation Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Devastator Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Fortis Kill Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sword Brethren Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f995c048-454a-5054-82bf-d3eca07582d6",
@@ -32061,7 +33301,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **AGGRESSOR SQUAD** ■ **ERADICATOR SQUAD** ■ **HEAVY INTERCESSOR SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Aggressor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Eradicator Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Heavy Intercessor Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "896d350b-6346-59b7-941d-7164cdb4cf36",
@@ -32262,7 +33519,44 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **BLADEGUARD VETERAN SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **INTERCESSOR SQUAD** ■ **STERNGUARD VETERAN SQUAD** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD** ■ **VICTRIX HONOUR GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Victrix Honour Guard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "7a79c892-5f99-5475-96c7-d4b3ba808c93",
@@ -33393,7 +34687,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **ASSAULT INTERCESSOR SQUAD** ■ **ASSAULT SQUAD** ■ **COMMAND SQUAD** ■ **COMPANY HEROES** ■ **INFERNUS SQUAD** ■ **TACTICAL SQUAD** ■ **VANGUARD VETERAN SQUAD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Company Heroes",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Infernus Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tactical Squad",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "46257f58-c3cc-5ba3-b979-0026be7c4e56",
@@ -33815,6 +35131,28 @@
               "cost": "0"
             }
           ]
+        }
+      ],
+      "attachesTo": [
+        {
+          "type": "support",
+          "target": "Assault Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Bladeguard Veteran Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Intercessor Squad",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "support",
+          "target": "Sternguard Veteran Squad",
+          "targetType": "keyword"
         }
       ]
     },

--- a/11th/gdc/spacewolves.json
+++ b/11th/gdc/spacewolves.json
@@ -7,7 +7,7 @@
     "header": "#435d63"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.320Z",
+  "updated": "2026-07-28T17:03:02.726Z",
   "parent_id": "01623188-9470-4441-96b0-e06eb2572bb5",
   "parent_name": "Adeptus Astartes",
   "rules": {
@@ -1728,7 +1728,7 @@
   ],
   "enhancements": [
     {
-      "id": "2c572a93-1474-5831-93e9-3b76cff71776",
+      "id": "8cf893a8-e227-53a9-9332-07c7ac264b37",
       "name": {
         "en": "Thirst for Glory (Upgrade)",
         "de": "Streben nach Ruhm (Aufwertung)",
@@ -1742,6 +1742,7 @@
       "cost": "15",
       "keywords": ["Terminator", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>ADEPTUS ASTARTES TERMINATOR</k> model only. This unit has +1 <b>OC</b>.",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Terminator</k>-Modell. Diese Einheit hat +1 <b>MK</b>.",
@@ -1760,7 +1761,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "921d73d7-11a4-53c8-b90c-d1a59aacf600",
+      "id": "58e56e07-1f13-58a5-8bc5-ce9582470465",
       "name": {
         "en": "Weaver of Sagas",
         "de": "Meister der Sagen",
@@ -1774,6 +1775,7 @@
       "cost": "15",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Wolf Priest</k> model only. (Once per battle-round, per army) In your Movement phase, at the start or end of this unit's move, you can:\r<ul><li>Select one friendly <k>Adeptus Astartes</k> unit within 6\" of this unit. That unit is no longer <b>battle-shocked</b>.</li>\r<li><u>Or:</u> Select one friendly <k>Grey Hunters</k> unit within 18\" of this unit. That unit is no longer <b>battle-shocked</b>.</li></ul>",
         "de": "Nur für ein <k>Wolfspriester</k>-Modell. (Einmal pro Schlachtrunde, pro Armee). In deiner Bewegungsphase kannst du zu Beginn oder am Ende der Bewegung dieser Einheit:\r<ul><li>eine befreundete <k>Adeptus</k>-<k>Astartes</k>-Einheit innerhalb von 6\" um diese Einheit wählen. Jene Einheit ist nicht mehr <b>erschüttert</b>.</li>\r<li><u>oder:</u> eine befreundete <k>Graumähnen</k>-Einheit innerhalb von 18\" um diese Einheit wählen. Jene Einheit ist nicht mehr <b>erschüttert</b>.</li></ul>",
@@ -1792,7 +1794,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "938e279f-ae72-556b-b47e-0ab9eab62165",
+      "id": "59f035e7-0ad7-5c89-a9e8-0db2ac5348d6",
       "name": {
         "en": "A Giant Amongst Giants",
         "de": "Ein Riese unter den Riesen",
@@ -1806,6 +1808,7 @@
       "cost": "15",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Infantry</k> model only.\r<ul><li>This model has +2 <b>W</b>.</li>\r<li>This model’s melee attacks have +1 <b>S</b>.</li></ul>",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Infanterie</k>-Modell.\r<ul><li>Dieses Modell hat +2 <b>LP</b>.</li>\r<li>Die Nahkampfattacken dieses Modells haben +1 <b>S</b>.</li></ul>",
@@ -1824,7 +1827,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ab6f5c2a-c50d-50bc-87b6-64272bc123d1",
+      "id": "c4353b0c-b09a-5f44-bd6e-8c500f23d0d1",
       "name": {
         "en": "Preyslayer",
         "de": "Beuteschlag",
@@ -1838,6 +1841,7 @@
       "cost": "15",
       "keywords": ["Infantry", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Adeptus Astartes Infantry</k> model only. This unit can re‑roll <b>advance rolls</b> and <b>countercharge rolls</b>.",
         "de": "Nur für ein <k>Adeptus</k>-<k>Astartes</k>-<k>Infanterie</k>-Modell. Diese Einheit kann <b>Vorrückenwürfe</b> und <b>Gegenangriffwürfe</b> wiederholen.",
@@ -1856,7 +1860,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "360d9abc-c9ec-5ec9-ba69-51b71404c02e",
+      "id": "8135889f-4a07-507b-9c57-b27a4ae1c138",
       "name": {
         "en": "Eye of the Hunter",
         "de": "Auge des Jägers",
@@ -1870,6 +1874,7 @@
       "cost": "20",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Wolf Guard Battle Leader</k> model only. This unit's ranged attacks have:\r<ul><li><k>[Assault]</k>.</li>\r<li><k>[Ignores Cover]</k>.</li>\r<li>+1 <b>AP</b>.</li></ul>",
         "de": "Nur für ein <k>Wolfsgarde</k>-<k>Held</k>-Modell. Fernkampfattacken dieser Einheit haben:\r<ul><li><k>[Sturm]</k>.</li>\r<li><k>[Deckung ignorieren]</k>. </li>\r<li>+1 <b>DS</b>.</li></ul>",
@@ -1888,7 +1893,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6f5fb444-17dc-545e-9352-96b692b613b7",
+      "id": "fe05fe54-5ebf-5222-b102-95474ee79bf0",
       "name": {
         "en": "Fierce Example (Upgrade)",
         "de": "Grimmes Vorbild (Aufwertung)",
@@ -1902,6 +1907,7 @@
       "cost": "25",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>WOLF GUARD TERMINATORS</k> unit only. This unit has +1 <b>T</b>.",
         "de": "Nur für eine <k>Wolfsgarde-Terminatoren</k>-Einheit. Diese Einheit hat +1 <b>W</b>.",
@@ -1920,13 +1926,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b0f459c5-988d-5ca7-b3e7-f77d041da9a1",
+      "id": "2a8f2600-240a-5389-93df-97bb0e449c06",
       "name": {
         "en": "Swift Hunter"
       },
       "cost": "20",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPACE WOLVES** model only. Models in the bearer’s unit have the Scouts 7\" ability."
       },
@@ -1938,13 +1945,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0af97fb6-73e2-50db-9a28-48b25107448c",
+      "id": "0a363bee-00ac-5f8f-8b76-655f089b2c2d",
       "name": {
         "en": "Fenrisian Grit"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. The bearer has the Feel No Pain 4+ ability."
       },
@@ -1956,13 +1964,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6963348f-8f6f-5bd4-85d8-5de80516f018",
+      "id": "78f047a8-70df-5397-8fb4-1f74c320c6ae",
       "name": {
         "en": "Wolf Master"
       },
       "cost": "5",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPACE WOLVES** model only. In your Command phase, select one friendly **SPACE WOLVES** unit within 9\" of the bearer. Until the start of your next Command phase, teeth and claws and Tyrnak and Fenrir weapons equipped by models in that unit have the **[LETHAL HITS]** ability."
       },
@@ -1974,13 +1983,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b1de1b58-a743-5796-9db7-2e0ed20ac7ed",
+      "id": "6eb7ecde-7023-5e1b-97a6-2240aa160819",
       "name": {
         "en": "Feral Rage"
       },
       "cost": "10",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Add 1 to the Attacks characteristic of melee weapons equipped by the bearer. Each time the bearer ends a Charge move, until the end of the turn, add an additional 1 to the Attacks characteristic of those weapons."
       },
@@ -1992,13 +2002,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "777b9d8d-6337-53c8-8fac-0799f7168b6e",
+      "id": "5bb98cca-b8eb-5de1-9cd7-ec1a948bcfb6",
       "name": {
         "en": "Braggart’s Steel"
       },
       "cost": "20",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPACE WOLVES** model only. Add 2 to the Strength characteristic of melee weapons equipped by the bearer. If the bearer’s unit has achieved one or more Boasts, add 1 to the Damage characteristic of those weapons as well."
       },
@@ -2010,13 +2021,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dd7f3a10-cc79-5f32-a363-346b364c7b21",
+      "id": "6cfd361d-b4c7-517d-8ee8-678f5b2998b6",
       "name": {
         "en": "Skjald"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time a **SPACE WOLVES CHARACTER** unit from your army achieves a Boast, if the bearer is on the battlefield, you gain 1CP."
       },
@@ -2028,13 +2040,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fef95683-f97c-5b60-8fae-8e73b8fa0f4f",
+      "id": "dc17a4b5-d8dc-5a0e-85bb-4872d0228d5f",
       "name": {
         "en": "Hordeslayer"
       },
       "cost": "15",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPACE WOLVES** model only. At the start of the Fight phase, if there are more enemy models than friendly models wholly within 6\" of the bearer, until the end of the phase, add 2 to the Attacks characteristic of melee weapons equipped by the bearer. If the bearer’s unit has achieved one or more Boasts, add 3 to the Attacks characteristic instead."
       },
@@ -2046,13 +2059,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4b2d0156-66cb-595a-b45f-cb96e5f41677",
+      "id": "718cec95-6160-5cf2-9b94-8a323c28a2fd",
       "name": {
         "en": "Thunderwolf’s Fortitude"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. (Once per battle, per army) When this model is **destroyed**, at the end of the phase, roll one D6:\n▪ On a 2+, set up this model on the battlefield, **unengaged** and as close as possible to where it was **destroyed**. This model is not part of an **attached** unit and its unit has a **starting strength** of 1. This model has 3 wounds remaining."
       },
@@ -2064,13 +2078,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0ca7a27f-a043-5a1a-a0b0-464867e3106a",
+      "id": "3698c567-8d40-5203-a1ad-bcdcd786438b",
       "name": {
         "en": "Wolf-touched"
       },
       "cost": "15",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPACE WOLVES** model only. Add 2\" to the Move characteristic of the bearer."
       },
@@ -2082,13 +2097,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8214a5c5-1551-5cea-8eee-d5fd9176802c",
+      "id": "acadea09-7567-5769-a4cd-4e4cb544a3ad",
       "name": {
         "en": "Hunter’s Guile"
       },
       "cost": "20",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. After both players have deployed their armies, select up to three **THUNDERWOLF CAVALRY**, **WULFEN** and/or **BLOOD CLAWS** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -2100,13 +2116,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "13c532da-1604-5173-9f38-f9eb6e57dd39",
+      "id": "c5daab6d-58a0-5a88-9187-87e32cd95ee0",
       "name": {
         "en": "Elder’s Guidance"
       },
       "cost": "20",
       "keywords": ["Space Wolves"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SPACE WOLVES** model only. Once per battle, at the start of the Fight phase, if the bearer is leading a **BLOOD CLAWS** unit, the bearer can use this Enhancement. If it does, until the end of the phase, improve the Armour Penetration characteristic of melee weapons equipped by models in that unit by 1."
       },
@@ -2118,13 +2135,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "88f86f91-6857-5ce6-9fd9-ed4646e56a2e",
+      "id": "a5fed538-28dd-5959-ae0f-b9acb86d58f8",
       "name": {
         "en": "Helm of the Beastslayer"
       },
       "cost": "15",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. Each time an attack made by a **CHARACTER**, **MONSTER** or **VEHICLE** model targets the bearer’s unit, reduce the Armour Penetration characteristic of that attack by 1."
       },
@@ -2136,13 +2154,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ce7295f8-a57f-5af7-8273-e04df6d8f7e1",
+      "id": "2a886787-b57d-5ea3-81d5-86fdd0f9fed4",
       "name": {
         "en": "Grimnar’s Mark"
       },
       "cost": "20",
       "keywords": ["Terminator", "Captain", "Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES TERMINATOR CAPTAIN** model only. Once per battle round, you can target this unit with the **Rapid Ingress**/**Heroic Intervention stratagem**, regardless of any other uses of that **stratagem** this phase. If you do:\n\n▪ That use is -1 CP.\n▪ That use does not prevent any uses of that **stratagem** on other units this phase."
       },
@@ -2154,13 +2173,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8cc2b378-c763-5caf-a79c-c09670a3c07c",
+      "id": "55f9295b-a75d-5b54-9804-ef444f2079ec",
       "name": {
         "en": "Howlmaw"
       },
       "cost": "15",
       "keywords": ["Wolf Priest"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WOLF PRIEST** model only. At the start of the Fight phase, you can select one enemy unit within 6\" of the bearer. That unit must take a Battle-shock, subtracting 1 from the result."
       },
@@ -2172,13 +2192,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c6e6fe5c-c3a8-5d9c-84e0-81e252ee5ea0",
+      "id": "2d7ed4de-71f6-532c-ba19-396a55cd0f77",
       "name": {
         "en": "Chariots of the Storm"
       },
       "cost": "25",
       "keywords": ["Adeptus Astartes"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**ADEPTUS ASTARTES** model only. After both players have deployed their armies, select up to three **ADEPTUS ASTARTES** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -2190,13 +2211,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a6b5d9c1-10bc-5b85-a962-c80cc8a83672",
+      "id": "f3a9e5b2-c6bc-5e91-bbf9-8a13018325ce",
       "name": {
         "en": "Skjald’s Foretelling"
       },
       "cost": "25",
       "keywords": ["Battle Leader", "Wolf Guard"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WOLF GUARD BATTLE LEADER** model only. While the bearer is leading a unit, weapons equipped by models in that unit have the **[LANCE]** ability."
       },
@@ -2379,7 +2401,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WOLF GUARD TERMINATORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Wolf Guard Terminators",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "edd355c2-4e85-5611-823c-cb639b3b193e",
@@ -3515,7 +3544,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOOD CLAWS** ■ **GREY HUNTERS** ■ **WOLF GUARD HEADTAKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blood Claws",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Grey Hunters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Wolf Guard Headtakers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "75374f5c-5b30-5b87-b2e4-1f8c176b21e6",
@@ -3741,7 +3787,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **WOLF GUARD TERMINATORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Wolf Guard Terminators",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "cbc3fcf5-ecb4-5134-a733-a67e904e4698",
@@ -4168,7 +4221,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOOD CLAWS** ■ **GREY HUNTERS** ■ **WOLF GUARD HEADTAKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blood Claws",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Grey Hunters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Wolf Guard Headtakers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "f7c221df-be2f-5050-9b4d-1af14f9d6716",
@@ -4347,7 +4417,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOOD CLAWS** ■ **WOLF GUARD HEADTAKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blood Claws",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Wolf Guard Headtakers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5d78ad6a-0eaa-5cb9-877f-76b039ebac0a",
@@ -4861,7 +4943,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOOD CLAWS** ■ **GREY HUNTERS** ■ **WOLF GUARD HEADTAKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blood Claws",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Grey Hunters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Wolf Guard Headtakers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "928a43b7-7178-5826-92ff-0a03ee4bf111",
@@ -5491,7 +5590,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOOD CLAWS** ■ **GREY HUNTERS** ■ **WOLF GUARD HEADTAKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blood Claws",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Grey Hunters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Wolf Guard Headtakers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "8d93ba37-ccb2-573b-ac1a-19ae62eb92e8",
@@ -6266,7 +6382,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BLOOD CLAWS** ■ **GREY HUNTERS** ■ **WOLF GUARD HEADTAKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Blood Claws",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Grey Hunters",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Wolf Guard Headtakers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "c086546e-a615-5212-be4a-d91d1f6a1b70",

--- a/11th/gdc/tau.json
+++ b/11th/gdc/tau.json
@@ -7,7 +7,7 @@
     "header": "#2e5a6a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.685Z",
+  "updated": "2026-07-28T17:03:09.533Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -1631,7 +1631,7 @@
   ],
   "enhancements": [
     {
-      "id": "e5a05462-4728-59cb-bc61-a8dcd15a3e66",
+      "id": "43c723a8-44ad-54fc-8c10-77f413b85070",
       "name": {
         "en": "Negation Emitters (Upgrade)",
         "de": "Negierungsemitter (Aufwertung)",
@@ -1645,6 +1645,7 @@
       "cost": "15",
       "keywords": ["T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Stealth Battlesuits</k> unit only. This unit has -3\" <b>detection range</b>.",
         "de": "Nur für eine <k>Geist-Kampfanzug</k>-Einheit. Diese Einheit hat -3\" <b>Entdeckungsreichweite</b>.",
@@ -1663,7 +1664,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "549c49d5-4521-5a13-878b-1684c6f1be0a",
+      "id": "684e2efa-cf7e-517c-9080-a1a340f0531e",
       "name": {
         "en": "Unmasking Suite (Upgrade)",
         "de": "Demaskierungssysteme (Aufwertung)",
@@ -1677,6 +1678,7 @@
       "cost": "15",
       "keywords": ["Pathfinder Team", "Ghostkeel"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Ghostkeel Battlesuit</k>/<k>Pathfinder Team</k>/<k>Stealth Battlesuits</k> unit only. When this unit is <b>selected to shoot</b>, you can select one enemy unit within 24\" of this unit. That enemy unit has +9\" <b>detection range</b> until this unit has shot.",
         "de": "Nur für eine <k>Phantom-Kampfanzug</k>-/<k>Späherteam</k>-/<k>Geist-Kampfanzug</k>-Einheit. Wenn diese Einheit <b>zum Schießen gewählt wird</b>, kannst du eine feindliche Einheit innerhalb von 24\" um diese Einheit wählen. Jene feindliche Einheit hat +9\" <b>Entdeckungsreichweite</b>, bis diese Einheit geschossen hat.",
@@ -1695,7 +1697,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9fc7149c-28aa-5c44-ae5f-0fe94248e773",
+      "id": "018f33eb-508d-581f-a37c-eb1caf4f5a16",
       "name": {
         "en": "Thermoneutronic Projector",
         "de": "Thermoneutronischer Projektor",
@@ -1709,6 +1711,7 @@
       "cost": "15",
       "keywords": ["Battlesuit"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Battlesuit</k> model only. In the Declare Battle Formations step, select one of this model’s T’au Flamer weapons. That weapon’s attacks have:\r<ul><li>+2 <b>S</b></li>\r<li>+1 <b>AP</b> and <b>D</b>.</li></ul>",
         "de": "Nur für ein <k>Kampfanzug</k>-Modell. Wähle im Schritt „Schlachtformation festlegen“ eine Flammenwerfer-Waffe dieses Modells. Die Attacken jener Waffe haben:\r<ul><li>+2 <b>S</b></li>\r<li>+1 <b>DS</b> und <b>SW</b>.</li></ul>",
@@ -1727,7 +1730,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "bd1851c2-6bf2-5ccb-9d72-cb06a3aa5dfd",
+      "id": "21ac89ed-99ab-5546-9a18-ea026bb45336",
       "name": {
         "en": "Supernova Launcher",
         "de": "Supernova-Werfer",
@@ -1741,6 +1744,7 @@
       "cost": "15",
       "keywords": ["Battlesuit"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Battlesuit</k> model only. In the Declare Battle Formations step, select one of this model’s Airbursting Fragmentation Projector weapons. That weapon’s attacks have:\r<ul><li>+3 <b>S</b></li>\r<li>+1 <b>AP</b> and <b>D</b>.</li></ul>",
         "de": "Nur für ein <k>Kampfanzug</k>-Modell. Wähle im Schritt „Schlachtformation festlegen“ eine der Streugranatwerfer-Waffen dieses Modells. Attacken jener Waffe haben:\r<ul><li>+3 <b>S</b>.</li>\r<li>+1 <b>DS</b> und <b>SW</b>.</li></ul>",
@@ -1759,7 +1763,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "07cd6b57-ebec-5449-b949-4a31a3370aa4",
+      "id": "03698bfd-6d3c-5ebb-8fb7-12dcef811d7d",
       "name": {
         "en": "Student of Kauyon",
         "de": "Gelehrter des Kauyon",
@@ -1773,6 +1777,7 @@
       "cost": "20",
       "keywords": ["Shaper", "Kroot"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Kroot Shaper</k> model only. In the Declare Battle Formations step, you can select up to three friendly <k>Kroot Carnivores/Farstalkers</k> units. Those units have <b>Deep Strike</b>.",
         "de": "Nur für ein <k>Kroot-Former</k>-Modell. Im Schritt „Schlachtformation festlegen“ kannst du bis zu drei befreundete <k>Kroot-Jagdtrupp</k>-<k>/Fern­pirscher</k>-Einheiten wählen. Jene Einheiten haben <b>Schocktruppen</b>.",
@@ -1791,7 +1796,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c721bd3b-323e-5952-a989-77aa16cee3f8",
+      "id": "45b3735b-d683-52e1-93ed-299855354423",
       "name": {
         "en": "Admired Leader",
         "de": "Geschätzter Anführer",
@@ -1805,6 +1810,7 @@
       "cost": "20",
       "keywords": ["T’au Empire"],
       "excludes": ["Kroot"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>T’au Empire</k> model only (excluding <k>Kroot</k> models). In your Command phase, you can select one <k>Kroot/Vespid Stingwings</k> unit within 12\" of this model. If you do, that unit has +1 <b>Ld</b> and <b>OC</b> until the start of your next Command phase.",
         "de": "Nur für ein <k>Sternenreich</k>-<k>der</k>-<k>T’au</k>-Modell (ausgenommen <k>Kroot</k>-Modelle). In deiner Befehlsphase kannst du eine <k>Kroot</k>-<k>/Vespid-Stachelflügel</k>-Einheit innerhalb von 12\" um dieses Modell wählen. Wenn du dies tust, hat jene Einheit bis zum Beginn deiner nächsten Befehls­phase +1 <b>MW</b> und <b>MK</b>.",
@@ -1823,7 +1829,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2e285f1f-409b-54b4-a420-d24ee2f48f41",
+      "id": "1d05b80c-1e2b-53d0-931a-3b4cdd59cf9a",
       "name": {
         "en": "Plasma Accelerator Rifle",
         "de": "Plasmabeschleunigergewehr",
@@ -1837,6 +1843,7 @@
       "cost": "20",
       "keywords": ["Battlesuit"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Battlesuit</k> model only. In the Declare Battle Formations step, select one of this model’s Plasma Rifle weapons. That weapon’s attacks have:\r<ul><li>+2 <b>S</b></li>\r<li>+1 <b>A</b>, <b>AP</b> and <b>D</b>.</li></ul>",
         "de": "Nur für ein <k>Kampfanzug</k>-Modell. Wähle im Schritt „Schlachtformation festlegen“ eine der Plasmagewehr-Waffen dieses Modells. Attacken jener Waffe haben:\n<ul><li>+2 <b>S</b></li>\n<li>+1 <b>A</b>, <b>DS</b> und <b>SW</b>.</li></ul>",
@@ -1855,13 +1862,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "20d5d26e-cda1-50e2-8218-32b8365fb387",
+      "id": "8c120023-0f8b-55d7-85cd-6765a44f959e",
       "name": {
         "en": "Exemplar of the Kauyon"
       },
       "cost": "20",
       "keywords": ["T’au Empire"],
       "excludes": ["Shaper"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only (excluding **KROOT SHAPER** models). While the bearer is leading a unit, the Patient Hunter Detachment rule applies to that unit from the second battle round onwards instead of from the third."
       },
@@ -1873,13 +1881,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "29c3bf37-3290-528c-93fd-76a1124c9590",
+      "id": "29296910-5b8c-540b-ab72-c9b1ea5c2fea",
       "name": {
         "en": "Precision of the Patient Hunter"
       },
       "cost": "15",
       "keywords": ["T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only. Each time the bearer makes a ranged attack, add 1 to the Hit roll. From the third battle round onwards, add 1 to the Wound roll as well."
       },
@@ -1891,13 +1900,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3987f242-fb5e-5555-8891-c9b78bf944f2",
+      "id": "33ecd95e-b225-5df8-95a8-5868b525e957",
       "name": {
         "en": "Solid-image Projection Unit"
       },
       "cost": "20",
       "keywords": ["T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only. After both players have deployed their armies, select up to three **T’AU EMPIRE** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -1909,13 +1919,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "43bb671a-4438-5387-8cf0-448261f72904",
+      "id": "01adb5f1-71b3-5f21-9e7f-74cbcdc16337",
       "name": {
         "en": "Through Unity, Devastation"
       },
       "cost": "30",
       "keywords": ["T’au Empire"],
       "excludes": ["Shaper"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only (excluding **KROOT SHAPER** models). While the bearer is leading a unit, each time that unit is an Observer unit, until the end of the phase, ranged weapons equipped by models in a Guided unit have the **[LETHAL HITS]** ability while targeting their Spotted unit."
       },
@@ -1927,13 +1938,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "58ec8c96-448f-547c-864b-fc87f5152874",
+      "id": "fbc88955-2fbc-5236-aea0-0ec4a425ff98",
       "name": {
         "en": "Exemplar of the Mont’ka"
       },
       "cost": "10",
       "keywords": ["T’au Empire"],
       "excludes": ["Shaper"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only (excluding **KROOT SHAPER** models). While the bearer is leading a unit, the Killing Blow Detachment rule applies to that unit during the fourth battle round as well."
       },
@@ -1945,13 +1957,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a616aabe-3222-581b-b576-8958225eefa2",
+      "id": "72d589d7-722c-5334-955a-32c5fd615fb8",
       "name": {
         "en": "Strike Swiftly"
       },
       "cost": "35",
       "keywords": ["T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only. In the Resolve Pre-battle Abilities step, you can select up to two friendly **T'AU EMPIRE** units within 6\" of this model that do not have the Scouts ability. Until the end of the battle, all models in the selected units have the **Scouts 6\"** ability."
       },
@@ -1963,13 +1976,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e2b65797-2731-5fc3-8c73-73c911954bab",
+      "id": "3f177ab3-2406-5f35-85e7-d5774b796c6c",
       "name": {
         "en": "Strategic Conqueror"
       },
       "cost": "15",
       "keywords": ["T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only. At the start of the first battle round, before the first turn begins, select one objective marker on the battlefield. While a friendly **T’AU EMPIRE** model is within range of that objective marker and the bearer is on the battlefield, add 1 to that friendly model’s Objective Control characteristic."
       },
@@ -1981,13 +1995,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f3b67a49-b662-5196-a942-e64dd2a371b7",
+      "id": "20524ae6-2307-571b-9577-a9d7f87c9793",
       "name": {
         "en": "Coordinated Exploitation"
       },
       "cost": "30",
       "keywords": ["T’au Empire"],
       "excludes": ["Shaper"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE** model only (excluding **KROOT SHAPER** models). While the bearer is leading a unit, each time that unit is an Observer unit, until the end of the phase, ranged weapons equipped by models in a Guided unit have the **[SUSTAINED HITS 1]** ability while targeting their Spotted unit."
       },
@@ -1999,13 +2014,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4687682c-84ca-50e4-bcc8-8c5ccedd85f2",
+      "id": "6ddf03da-bea2-574b-a9e0-9d7bab291bfd",
       "name": {
         "en": "Puretide Engram Neurochip"
       },
       "cost": "15",
       "keywords": ["Battlesuit", "T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE BATTLESUIT** model only. Each time you target the bearer’s unit with a Stratagem, roll one D6: on a 4+, you gain 1CP."
       },
@@ -2017,13 +2033,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "28e7bc02-636f-510a-ba46-d2cb491d1a66",
+      "id": "50829442-b8f8-5239-b6ff-cd0c76363cbd",
       "name": {
         "en": "Starflare Ignition System"
       },
       "cost": "20",
       "keywords": ["Battlesuit", "T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’au EMPIRE BATTLESUIT** model only. At the end of your opponent’s turn, if the bearer’s unit is not within Engagement Range of one or more enemy units, you can remove that unit from the battlefield and place it into Strategic Reserves."
       },
@@ -2035,13 +2052,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3003886c-e0cc-5155-affe-f1ba0d44a93c",
+      "id": "3a97deaf-f8fd-565c-a814-1ad2ef8043c0",
       "name": {
         "en": "Internal Grenade Racks"
       },
       "cost": "20",
       "keywords": ["Battlesuit", "T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE BATTLESUIT** model only. The bearer has the **GRENADES** keyword, and each time the bearer ends a Normal move, you can select one enemy unit that it moved over during that move. If you do, roll six D6: for each 4+, that enemy unit suffers 1 mortal wound."
       },
@@ -2053,13 +2071,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cee3489a-6c94-574d-b3dc-3157e603d498",
+      "id": "0b1943f2-5578-50ec-a573-bcd8a232a7fc",
       "name": {
         "en": "Prototype Weapon System"
       },
       "cost": "15",
       "keywords": ["Battlesuit", "T’au Empire"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**T’AU EMPIRE BATTLESUIT** model only. Each time the bearer is selected to shoot, select either the **[LETHAL HITS]** or **[SUSTAINED HITS 1]** ability. Until those attacks are resolved, ranged weapons equipped by the bearer have the selected ability."
       },
@@ -2071,13 +2090,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "eb4257b9-3b55-56dc-8963-9126c3ade82a",
+      "id": "17da6ed3-c85a-511c-ad45-7e0be55ff920",
       "name": {
         "en": "Kroothawk Flock"
       },
       "cost": "10",
       "keywords": ["Kroot"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KROOT** model only. Ranged weapons equipped by models in the bearer’s unit have the **[IGNORES COVER]** ability, and enemy units that are set up on the battlefield as Reinforcements cannot be set up within 12\" horizontally of the bearer."
       },
@@ -2089,13 +2109,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d7cf45c9-3c45-5ce0-92c9-4a199702626c",
+      "id": "09da85e4-09bd-56c8-bd4b-2ccc0f601cc9",
       "name": {
         "en": "Nomadic Hunter"
       },
       "cost": "20",
       "keywords": ["Trail Shaper"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KROOT TRAIL SHAPER** model only. While the bearer is leading a unit, add 3\" to the Move characteristic of models in that unit and ranged weapons equipped by models in that unit have the **[ASSAULT]** ability."
       },
@@ -2107,13 +2128,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cadf43ca-31d0-500b-bfd8-8a1c3dd41d29",
+      "id": "7f52d920-8122-5c00-bf6b-fa7367bc6ea3",
       "name": {
         "en": "Root-carved Weapons"
       },
       "cost": "10",
       "keywords": ["War Shaper"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KROOT WAR SHAPER** model only. All weapons equipped by the bearer have the **[PRECISION]** and **[DEVASTATING WOUNDS]** abilities."
       },
@@ -2125,13 +2147,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c6278e1c-8420-5713-b3ae-5c27f388a499",
+      "id": "088bdb63-3026-54b3-b4a1-7dd2eda2754d",
       "name": {
         "en": "Borthrod Gland"
       },
       "cost": "15",
       "keywords": ["Flesh Shaper"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KROOT FLESH SHAPER** only. While the bearer is leading a unit, each time a model in that unit makes a melee attack, an unmodified Hit roll of 5+ scores a Critical Hit."
       },
@@ -3382,7 +3405,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BREACHER TEAM** ■ **STRIKE TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Breacher Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Strike Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5ed6cc39-b7b5-57b6-a635-7aaaf08610be",
@@ -3585,7 +3620,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CRISIS BATTLESUITS** ■ **CRISIS FIREKNIFE BATTLESUITS** ■ **CRISIS STARSCYTHE BATTLESUITS** ■ **CRISIS SUNFORGE BATTLESUITS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Crisis Fireknife Battlesuits",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crisis Starscythe Battlesuits",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crisis Sunforge Battlesuits",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "599e050f-97b6-55fa-9b83-a6a575a34f25",
@@ -4091,7 +4143,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CRISIS BATTLESUITS** ■ **CRISIS FIREKNIFE BATTLESUITS** ■ **CRISIS STARSCYTHE BATTLESUITS** ■ **CRISIS SUNFORGE BATTLESUITS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Crisis Fireknife Battlesuits",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crisis Starscythe Battlesuits",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crisis Sunforge Battlesuits",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "efd60099-c354-57d5-8033-85a74ccf7ca0",
@@ -4569,7 +4638,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CRISIS BATTLESUITS** ■ **CRISIS FIREKNIFE BATTLESUITS** ■ **CRISIS STARSCYTHE BATTLESUITS** ■ **CRISIS SUNFORGE BATTLESUITS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Crisis Fireknife Battlesuits",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crisis Starscythe Battlesuits",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Crisis Sunforge Battlesuits",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "ada4d0e5-17fc-5789-bb6c-ae0457815a4a",
@@ -5989,7 +6075,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **PATHFINDER TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Pathfinder Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "703c9ce7-b3d1-533c-8bb6-3183b1e44a52",
@@ -6447,7 +6540,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BREACHER TEAM** ■ **STRIKE TEAM**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Breacher Team",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Strike Team",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "7764dea0-8567-5a1b-9cb1-4c940cb496e0",
@@ -8080,7 +8185,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **KROOT CARNIVORES** ■ **KROOT FARSTALKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Kroot Carnivores",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kroot Farstalkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9d360357-8430-5411-b508-36c165cb8867",
@@ -8624,7 +8741,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **KROOT CARNIVORES** ■ **KROOT FARSTALKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Kroot Carnivores",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kroot Farstalkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "e90fbb27-1fd0-58ef-94a3-e4aa25a8ed94",
@@ -8850,7 +8979,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **KROOT CARNIVORES** ■ **KROOT FARSTALKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Kroot Carnivores",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Kroot Farstalkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "2a7f103b-4e45-5925-9943-3f6df77b3555",

--- a/11th/gdc/thousandsons.json
+++ b/11th/gdc/thousandsons.json
@@ -7,7 +7,7 @@
     "header": "#185862"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.584Z",
+  "updated": "2026-07-28T17:03:03.239Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2192,7 +2192,7 @@
   ],
   "enhancements": [
     {
-      "id": "cff56fd5-52d6-58ea-b619-44ed0a646ceb",
+      "id": "195b73bb-5c79-548a-9dcb-d85d541fb461",
       "name": {
         "en": "Thicket of Bladed Bone (Upgrade)",
         "de": "Zahllose Knochenklingen (Aufwertung)",
@@ -2206,6 +2206,7 @@
       "cost": "10",
       "keywords": ["Chaos Spawn"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Spawn</k> unit only. This unit’s melee attacks have:\r<ul><li>+1 <b>AP</b>.</li>\r<li><k>[Cleave 1]</k>.</li></ul>",
         "de": "Nur für eine <k>Brut</k>-Einheit. Nahkampfattacken dieser Einheit haben:\n<ul><li>+1 <b>DS</b>.</li>\n<li><k>[Spalten 1]</k>.</li></ul>",
@@ -2224,7 +2225,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "626207be-e969-5dda-820f-4b26a8927bef",
+      "id": "c8c94bd2-3cce-5c10-9ac2-19b175bf2756",
       "name": {
         "en": "Unravelled Fates",
         "de": "Zerfaserte Schicksale",
@@ -2238,6 +2239,7 @@
       "cost": "15",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Tzaangor Shaman</k> model only. In your Movement phase, at the start or end of this unit's move, you can select one friendly <b>battle-shocked</b> <k>Mutant</k> unit within 6\" of this model. That unit is no longer <b>battle-shocked</b>.",
         "de": "Nur für ein <k>Tzaangor-Schamane</k>-Modell. In deiner Bewegungsphase kannst du zu Beginn oder am Ende der Bewegung dieser Einheit eine <b>erschütterte</b> befreundete <k>Mutant</k>-Einheit innerhalb von 6\" um dieses Modell wählen. Jene Einheit ist nicht länger <b>erschüttert</b>.",
@@ -2256,7 +2258,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "78d72568-5371-5d83-9b7e-23889c772e0b",
+      "id": "f7d27e8a-d0f1-5a34-9797-8505412a3802",
       "name": {
         "en": "Curse of Life",
         "de": "Fluch der Lebendigkeit",
@@ -2270,6 +2272,7 @@
       "cost": "20",
       "keywords": ["Infantry", "Psyker", "Thousand Sons", "Mounted"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Infantry/Mounted Thousand Sons Psyker</k> model only. When this model <b>heals</b> as a result of the <b>Sorcerous Invigoration detachment rule</b>, you can add 3 to the number of wounds <b>healed</b>.",
         "de": "Nur für ein <k>beritten</k>-<k>/Infanterie</k>-<k>Thousand</k>-<k>Sons</k>-<k>Psioniker</k>-Modell. Wenn dieses Modell durch die <b>Kontingentsregel Magische Kräftigung geheilt</b> wird, kannst du 3 zur Anzahl der <b>geheilten</b> Lebenspunkte addieren.",
@@ -2288,7 +2291,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f9cd83e6-3387-549c-9660-230702846b41",
+      "id": "596ff9b3-edb1-5bc9-bb44-5186c527fb61",
       "name": {
         "en": "Occulus Infernum",
         "de": "Occulus Infernum",
@@ -2302,6 +2305,7 @@
       "cost": "20",
       "keywords": ["Sorcerer", "Exalted Sorcerer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Sorcerer/Exalted Sorcerer</k> model only. In your Movement phase, at the start or end of this unit’s move, you can select one friendly <k>SEKHETAR ROBOTS</k> unit within 6\" of this unit. That unit’s ranged attacks have +1 <b>BS</b> until the start of your next turn.",
         "de": "Nur für ein <k>Hexer</k>-<k>/Erhabener</k>-<k>Hexer</k>-Modell. In deiner Bewegungsphase kannst du zu Beginn oder am Ende der Bewegung dieser Einheit eine befreundete <k>Sekhetar-Roboter</k>-Einheit innerhalb von 6\" wählen. Bis zum Beginn deines nächsten Zugs haben Fernkampfattacken jener Einheit +1 <b>BF</b>.",
@@ -2320,7 +2324,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e302fa76-89a6-56bb-bd06-f8fac331713f",
+      "id": "90aa1eb3-a8b4-50f8-8517-18b381a6688e",
       "name": {
         "en": "Walking Rampart",
         "de": "Wandelnde Schilde",
@@ -2334,6 +2338,7 @@
       "cost": "30",
       "keywords": ["Exalted Sorcerer", "Sorcerer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Sorcerer</k>/<k>Exalted Sorcerer</k> model only. This model has the following abilities:\r<ul><li><b>Soul Bound:</b> In your Movement phase, at the start or end of this unit’s move, you can select one friendly <k>SEKHETAR ROBOTS</k> unit within 3\" of this model. That <k>SEKHETAR ROBOTS</k> unit <b>heals</b> D3+1 wounds.</li>\r<li><b>Kine‑shielded Guardians:</b> While this model is within 3\" of a friendly <k>SEKHETAR ROBOTS</k> unit, this model has <b>Lone Operative</b>.</li></ul>",
         "de": "Nur für ein <k>Hexer</k>-/<k>Erhabener</k>-<k>Hexer</k>-Modell. Dieses Modell hat die folgenden Fähigkeiten:\r<ul><li><b>Seelengebunden:</b> In deiner Bewegungsphase kannst du zu Beginn oder am Ende der Bewegung dieser Einheit eine befreundete <k>Sekhetar-Roboter</k>-Einheit innerhalb von 3\" um dieses Modell wählen. Jene <k>Sekhetar-Roboter</k>-Einheit wird um W3+1 Lebenspunkte <b>geheilt</b>.</li>\r<li><b>Niedere Wächter:</b> Solange sich dieses Modell innerhalb von 3\" um eine befreundete <k>Sekhetar-Roboter</k>-Einheit befindet, hat es <b>Einsamer Wolf</b>.</li></ul>",
@@ -2352,7 +2357,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5149a7ac-a1c4-526d-8a32-aa194fa4e61a",
+      "id": "64801ec0-3ec7-536e-8920-9c86c23e0c10",
       "name": {
         "en": "Eruption of Vitality",
         "de": "Eruption der Lebendigkeit",
@@ -2366,6 +2371,7 @@
       "cost": "35",
       "keywords": ["Mounted", "Psyker", "Thousand Sons", "Infantry"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**INFANTRY/MOUNTED THOUSAND SONS PSYKER** model only. (Once per battle, per army) When this model is **destroyed**, at the end of the phase, roll one D6:\n▫ On a 2+, set up this model on the battlefield, **unengaged** and as close as possible to where it was **destroyed**. This model is not part of an **attached** unit and its unit has a **starting strength** of 1. This model has 3 wounds remaining.",
         "de": "Nur für ein <k>BERITTENES/INFANTERIE-THOUSAND-SONS-PSIONIKER</k>-Modell. (Einmal pro Schlacht, pro Armee) Wenn dieses Modell <b>zerstört</b> wird, wirf am Ende der Phase einen W6: \n<ul><li>Bei 2+ stelle dieses Modell auf dem Schlachtfeld auf, <b>nicht im Nahkampf</b> und so nahe wie möglich an der Stelle, an der es <b>zerstört</b> wurde. Dieses Modell ist nicht Teil einer <b>angeschlossenen</b> Einheit und seine Einheit hat <b>Sollstärke</b> 1. Dieses Modell hat 3 verbleibende Lebenspunkte.</li></ul>",
@@ -2384,13 +2390,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b7c701ed-32e6-54f2-9cb1-96de862eae15",
+      "id": "9bdce669-325d-5002-a561-289437722f18",
       "name": {
         "en": "Lord of Forbidden Lore"
       },
       "cost": "20",
       "keywords": ["Psyker", "Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. Each time the bearer manifests a Ritual, while resolving that Ritual, add 6\" to its range."
       },
@@ -2402,13 +2409,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "876096da-bbaf-5dc7-9f50-abb80ed8d7dd",
+      "id": "52e3fa98-f9ea-500c-a650-40c76a95824f",
       "name": {
         "en": "Incandaeum"
       },
       "cost": "15",
       "keywords": ["Exalted Sorcerer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**EXALTED SORCERER** model only. Once per battle, when selecting a Ritual for the bearer to attempt, you can select Doombolt, even if a model from your army has already attempted to manifest that Ritual this phase."
       },
@@ -2420,13 +2428,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f8224d58-36a5-55f4-a475-4b4f38c61495",
+      "id": "b8f17c13-62d0-5d0c-a743-c179bfd7ba6f",
       "name": {
         "en": "Umbralefic Crystal"
       },
       "cost": "20",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. (Once per battle, per army) In your Command phase, if this unit is **unengaged**, you can use this ability. If you do:\n▪ Place this unit in **strategic reserves**.\n▪ This unit has **Deep Strike** until the start of your next Shooting phase.\n▪ This unit must make an **ingress move** in your next Movement phase (including in your first turn)."
       },
@@ -2438,13 +2447,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8178a678-3fdb-5df7-8bc8-1cfe8b8b9018",
+      "id": "d102ca63-6479-5ec7-930b-3034de730c0e",
       "name": {
         "en": "Eldritch Vortex of E’Taph"
       },
       "cost": "35",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. Add 1 to the Strength and Damage characteristics of Psychic weapons equipped by the bearer."
       },
@@ -2456,13 +2466,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4aa02c68-5ad7-5447-96e3-ec472e76f5dc",
+      "id": "3bd3d674-e6f3-5990-a0d3-c4e37242d868",
       "name": {
         "en": "Arcane Might"
       },
       "cost": "20",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. Add 1 to the Strength characteristic of Psychic weapons equipped by models in the bearer’s unit. While the bearer’s unit is wholly within your army’s Flow of Magic, add 2 to the Strength characteristic of Psychic weapons equipped by models in that unit instead."
       },
@@ -2474,13 +2485,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a1f4c88e-58a5-5422-b135-26a95467f13e",
+      "id": "e22dda8e-3316-59d2-8ce6-2fd495f48501",
       "name": {
         "en": "Empowered Manifestation"
       },
       "cost": "20",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. While the bearer’s unit is wholly within your army’s Flow of Magic, you can add 6\" to the range of Psychic abilities the bearer has that specify a range (including Rituals) and each time a model in the bearer’s unit takes a Hazardous test for a Psychic weapon, you can re‑roll the result."
       },
@@ -2492,13 +2504,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "485db1b0-f74c-5ec3-a526-ba74d778d372",
+      "id": "187d0742-f8dc-5fcc-a926-5675c77fba1d",
       "name": {
         "en": "Empyric Onslaught"
       },
       "cost": "25",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. While the bearer’s unit is wholly within your army’s Flow of Magic, add 3 to the Attacks characteristic of ranged Psychic weapons equipped by the bearer."
       },
@@ -2510,13 +2523,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a344e349-5fce-5743-8314-cb3ccae23fdb",
+      "id": "3b273309-1518-5b48-91eb-317e0776c007",
       "name": {
         "en": "Noctilith Mantle"
       },
       "cost": "15",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. While the bearer’s unit is on the battlefield, it is wholly within your army’s Flow of Magic. Models in that unit cannot be selected to use any Rituals."
       },
@@ -2528,13 +2542,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4839df02-cc1e-510e-8cf4-47aa6f576437",
+      "id": "7e12b11a-82e2-5285-a1d2-fd36b31afbc2",
       "name": {
         "en": "Nethershriek Mind-Eater"
       },
       "cost": "10",
       "keywords": ["Thousand Sons", "Lord of Change"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** or **LORD OF CHANGE** model only. At the start of your Shooting phase, select one enemy unit within 12\" of and visible to the bearer. That unit must take a Battle-shock test; if that test is failed, that unit suffers 3 mortal wounds."
       },
@@ -2546,13 +2561,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0648e288-c025-5672-ad78-94ef997a96f4",
+      "id": "2db18309-e719-51a4-afb9-664bd6359b5c",
       "name": {
         "en": "Diabolic Savant"
       },
       "cost": "20",
       "keywords": ["Infantry", "Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS INFANTRY** model only. While the bearer is within 6\" of one or more friendly **SCINTILLATING LEGIONS** units, each time the bearer Channels the Warp, add 1 to the Psychic test result."
       },
@@ -2564,13 +2580,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "622a5fd2-67bf-5e04-86d1-aed157886d98",
+      "id": "bca52c09-10d9-51f8-afbd-d7a1aac38c14",
       "name": {
         "en": "Duplicitous Malediction"
       },
       "cost": "15",
       "keywords": ["Thousand Sons", "Lord of Change"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** or **LORD OF CHANGE** model only. After both players have deployed their armies, select up to three **THOUSAND SONS** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -2582,13 +2599,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "50926b25-976a-5048-976f-0f2a77184418",
+      "id": "da34b171-cb11-5999-8821-26249f0a0f1a",
       "name": {
         "en": "Tome of True Names"
       },
       "cost": "20",
       "keywords": ["Infantry", "Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS INFANTRY** model only. Once per battle, at the start of any phase, the bearer can use this Enhancement. If it does, until the end of the phase, the bearer has a 2+ invulnerable save."
       },
@@ -2600,13 +2618,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e3d3fe88-a20f-559e-85b1-b029f8226a43",
+      "id": "3fe3f5f5-b503-5602-a8d4-728b1767de15",
       "name": {
         "en": "Warpmeld Dagger"
       },
       "cost": "10",
       "keywords": ["Tzaangor Shaman"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TZAANGOR SHAMAN** model only. Each time the bearer attempts a Ritual, just before determining the Psychic test result, the bearer can use this Enhancement. If it does, the bearer suffers D3 mortal wounds; if it is not destroyed as a result, add 1 to that Psychic test result for each of those mortal wounds suffered."
       },
@@ -2618,13 +2637,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "382a3646-c3e3-5da8-a5e8-a26b19beea2e",
+      "id": "5844bc07-74e1-5c28-aac3-5fa5795db953",
       "name": {
         "en": "Diamond of Distortion"
       },
       "cost": "20",
       "keywords": ["Tzaangor Shaman"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TZAANGOR SHAMAN** model only. While the bearer is leading a unit, each time an attack targets that unit, subtract 1 from the Hit roll."
       },
@@ -2636,13 +2656,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "8174f967-6b5d-5bfa-a3d5-5dedaf7a0ba1",
+      "id": "173ddb00-1d5a-5804-83e0-58e1c9034ad6",
       "name": {
         "en": "Bray Lord"
       },
       "cost": "15",
       "keywords": ["Infernal Master", "Sorcerer"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SORCERER** or **INFERNAL MASTER** model only. The bearer has the **Scouts 6\"** ability."
       },
@@ -2654,13 +2675,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "854d3e20-8be4-5068-9cb5-7a4245cc30f7",
+      "id": "17665786-bc02-5865-ad61-cbc05bc3bc4e",
       "name": {
         "en": "Flowing Flesh"
       },
       "cost": "10",
       "keywords": ["Tzaangor Shaman"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TZAANGOR SHAMAN** model only. The bearer has the Feel No Pain 4+ ability and a Wounds characteristic of 5."
       },
@@ -2672,13 +2694,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "01eb5357-565e-55cd-805c-e92828ea50b6",
+      "id": "c67f6e53-0c92-592c-97cc-73b1f54d0a42",
       "name": {
         "en": "Risen Rubricae"
       },
       "cost": "30",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. At the start of the Declare Battle Formations step, select either two **RUBRICAE BATTLELINE** units from your army or one other **RUBRICAE** unit from your army; models in the selected units have the Infiltrators ability."
       },
@@ -2690,13 +2713,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "46b00514-cfa3-5a51-aa7b-4f575362ed46",
+      "id": "7484278d-a1ff-536d-9789-603abd0f0dc1",
       "name": {
         "en": "Arcane Thralls (Aura)"
       },
       "cost": "5",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. While a friendly **RUBRICAE** unit is within 9\" of the bearer, you can re-roll Battle-shock tests taken for that unit."
       },
@@ -2708,13 +2732,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "71fb43bf-e72d-5eca-8322-1930cda54a13",
+      "id": "c910e257-e713-5134-a191-8f1f03fdab57",
       "name": {
         "en": "Lord of the Rubricae"
       },
       "cost": "15",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. While the bearer is leading a unit, each time a **RUBRICAE** model in that unit makes an attack, add 1 to the Hit roll."
       },
@@ -2726,13 +2751,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a5a7c4ec-692c-51d6-8431-6f533399e856",
+      "id": "c924db18-8bb2-5e3a-a533-57868dfa7338",
       "name": {
         "en": "Stave Abominus"
       },
       "cost": "20",
       "keywords": ["Infantry", "Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS INFANTRY** model only. The bearer’s melee weapons have the **[SUSTAINED HITS D3]** and **[DEVASTATING WOUNDS]** abilities."
       },
@@ -2744,13 +2770,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f0875044-8664-5d31-9ba4-689880f33491",
+      "id": "6564a05b-d19d-5661-82b3-74cb09aceea7",
       "name": {
         "en": "Warp Syphon"
       },
       "cost": "5",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. While the bearer is within 6\" of one or more friendly **THOUSAND SONS VEHICLE** units, each time the bearer Channels the Warp, after you roll that additional D6 but before checking for doubles or triples, the bearer can use this Enhancement. If it does, select one of those **VEHICLE** units; that **VEHICLE** unit suffers 1 mortal wound and you can re-roll that additional D6."
       },
@@ -2762,13 +2789,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e176d2a6-7c5d-5433-b327-505806600f72",
+      "id": "3d2b2b27-b721-5b64-96b7-91d95c32b6c2",
       "name": {
         "en": "Perplexing Cloak"
       },
       "cost": "20",
       "keywords": ["Infantry", "Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS INFANTRY** model only. While the bearer is within 3\" of one or more friendly **THOUSAND SONS VEHICLE** units, the bearer has the Lone Operative ability"
       },
@@ -2780,13 +2808,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0a9b17bb-e1b7-5c4c-a1f8-8bdcfd3f6b5f",
+      "id": "7044b527-34d1-5d3f-9f40-1c7f74bd8167",
       "name": {
         "en": "Biomechanical Mutation"
       },
       "cost": "15",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. In your Command phase, you can select one friendly **THOUSAND SONS VEHICLE** model within 6\" of this model. That model regains up to D3 lost wounds."
       },
@@ -2798,13 +2827,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2cbf74a2-f8e9-546a-a745-d3004062073e",
+      "id": "eabd44fa-28f4-51ac-82d3-e52e7b854919",
       "name": {
         "en": "Warp-Cursed Runemaster"
       },
       "cost": "10",
       "keywords": ["Thousand Sons"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**THOUSAND SONS** model only. While the bearer is within 6\" of one or more friendly **THOUSAND SONS VEHICLE** units, each time the bearer manifests a Ritual, while resolving that Ritual, add 6\" to its range."
       },
@@ -3021,7 +3051,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RUBRIC MARINES** ■ **TZAANGOR ENLIGHTENED** ■ **TZAANGOR ENLIGHTENED WITH FATECASTER GREATBOWS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Rubric Marines",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tzaangor Enlightened with Fatecaster Greatbows",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tzaangor Enlightened",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5f021401-11a5-573d-b8e4-43e911156975",
@@ -5583,7 +5630,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RUBRIC MARINES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Rubric Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0f3885db-c32e-5afe-8158-6c5991dca0db",
@@ -5818,7 +5872,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RUBRIC MARINES** ■ **TZAANGOR ENLIGHTENED** ■ **TZAANGOR ENLIGHTENED WITH FATECASTER GREATBOWS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Rubric Marines",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tzaangor Enlightened with Fatecaster Greatbows",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tzaangor Enlightened",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d654c6b1-4542-5b8d-ae19-ce281858841d",
@@ -6862,7 +6933,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RUBRIC MARINES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Rubric Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "648b8e41-4b1c-5d75-99c5-98040213e464",
@@ -8755,7 +8833,14 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RUBRIC MARINES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Rubric Marines",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "923d6baf-c292-5797-a90d-283d17fe9786",
@@ -9002,7 +9087,14 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **SCARAB OCCULT TERMINATORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Scarab Occult Terminators",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "9262f9fe-d276-5924-8816-9e200656a466",
@@ -9569,7 +9661,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **TZAANGOR ENLIGHTENED** ■ **TZAANGOR ENLIGHTENED WITH FATECASTER GREATBOWS** ■ **TZAANGORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Tzaangor Enlightened with Fatecaster Greatbows",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tzaangor Enlightened",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tzaangors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "e6a01d5b-aafa-5195-9052-45eae4dadbbe",

--- a/11th/gdc/titan.json
+++ b/11th/gdc/titan.json
@@ -7,7 +7,7 @@
     "header": "#4b6262"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:54.728Z",
+  "updated": "2026-07-28T17:03:11.650Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {

--- a/11th/gdc/tyranids.json
+++ b/11th/gdc/tyranids.json
@@ -7,7 +7,7 @@
     "header": "#381a3a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:49.295Z",
+  "updated": "2026-07-28T17:03:00.801Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2319,7 +2319,7 @@
   ],
   "enhancements": [
     {
-      "id": "1be1cc6c-3ea6-5e25-a19b-7f0ea1b5a486",
+      "id": "80815722-5313-58fb-9751-11daeb7cd0e3",
       "name": {
         "en": "Cryptophotaic Camouflage (Upgrade)",
         "de": "Kryptophotische Tarnung (Aufwertung)",
@@ -2333,6 +2333,7 @@
       "cost": "15",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Von Ryan’s Leapers</k> unit only. This unit has ‑3\" <b>detection range</b>.",
         "de": "Nur für eine <k>Von</k>-<k>Ryan</k>-<k>Springteufel</k>-Einheit. Diese Einheit hat ‑3\" <b>Entdeckungsreichweite</b>.",
@@ -2351,7 +2352,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "161cbd01-be8b-589b-b695-7e38a8651f5e",
+      "id": "595253a7-1f7e-5be7-8b63-430af9ddda1f",
       "name": {
         "en": "Encircling Horrors (Upgrade)",
         "de": "Umzingelt von Schrecken (Aufwertung)",
@@ -2365,6 +2366,7 @@
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>NEUROLICTOR/LICTOR/VON RYAN’S LEAPERS</k> unit only. In your opponent’s Movement phase, when an enemy unit ends a move within 8\" of this unit, this unit can make a <b>normal move</b> of up to D3+3\".",
         "de": "Nur für eine <k>Neuroliktor</k>-<k>/Liktor</k>-<k>/Von</k>-<k>Ryan</k>-<k>Springteufel</k>-Einheit. Wenn eine feindliche Einheit in der Bewegungsphase deines Gegners eine Bewegung innerhalb von 8\" um diese Einheit beendet, kann diese Einheit eine <b>normale Bewegung</b> von bis zu W3+3\" ausführen.",
@@ -2383,7 +2385,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "887d3abc-f58b-55ea-b4cf-76f5ac14d5b3",
+      "id": "fb9b12fa-92be-5a55-b94c-720db47d9fd6",
       "name": {
         "en": "Destabilising Predation (Upgrade)",
         "de": "Destabilisierungsjagd (Aufwertung)",
@@ -2397,6 +2399,7 @@
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Norn Emissary</k> unit only. This unit’s ranged attacks have <k>[Anti‑Character 2+]</k>.",
         "de": "Nur für eine <k>Schwarmbote</k>-Einheit. Fernkampfattacken dieser Einheit haben <k>[Anti‑Charaktermodell 2+]</k>.",
@@ -2415,7 +2418,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e1f76fbb-187d-5c6e-b17d-8d4fe2303a3b",
+      "id": "6131766b-f569-51e2-9776-92dfd2c68bb9",
       "name": {
         "en": "Ocular Adaptation",
         "de": "Okulare Anpassung",
@@ -2429,6 +2432,7 @@
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Winged Tyranid Prime</k>/<k>Tyranid Prime with lash whip</k> model only. This unit’s melee attacks have +1 to <b>hit rolls</b>.",
         "de": "Nur für ein <k>Geflügelter-Alphakrieger-</k>/<k>Alphakrieger-mit-Tentakelpeitsche</k>-Modell. Die Nahkampfattacken dieser Einheit haben +1 auf <b>Trefferwürfe</b>.",
@@ -2447,7 +2451,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b480a2af-4192-59da-a303-0dee8bbf9c3b",
+      "id": "b998c441-2d17-5804-9dbf-c09e8cfdc7e9",
       "name": {
         "en": "Synaptoprescience (Upgrade)",
         "de": "Synaptische Voraussicht (Aufwertung)",
@@ -2461,6 +2465,7 @@
       "cost": "25",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Norn Assimilator</k> unit only. This unit has 4+ <b>InSv</b>.",
         "de": "Nur für eine <k>Schwarmassimilator</k>-Einheit. Diese Einheit hat 4+ <b>RE</b>.",
@@ -2479,7 +2484,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9aa923d9-01d5-592e-b543-893d182bf5cc",
+      "id": "45370037-f6af-5931-b457-acee803c6881",
       "name": {
         "en": "Elevated Might",
         "de": "Entwickelte Kraft",
@@ -2493,6 +2498,7 @@
       "cost": "30",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Winged Tyranid Prime</k>/<k>Tyranid Prime with lash whip</k> model only. This model’s melee attacks:\r<ul><li>Can re-roll <b>wound rolls</b>.</li>\r<li>Have +1 <b>AP</b>.</li></ul>",
         "de": "Nur für ein <k>Geflügelter-Alphakrieger-</k>/<k>Alphakrieger-mit-Tentakelpeitsche</k>-Modell. Für Nahkampfwaffen dieses Modells: \n<ul><li>können <b>Verwundungswürfe</b> wiederholt werden.</li>\n<ul><li>Nahkampfattacken dieses Modells haben +1 <b>DS</b>.</li></ul>",
@@ -2511,13 +2517,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "90977725-0f8f-5966-b8d9-0b3afb496892",
+      "id": "1c2d6547-edf2-5f1a-97bb-4a38f5feb283",
       "name": {
         "en": "Alien Cunning"
       },
       "cost": "30",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. After both players have deployed their armies, select up to three **TYRANIDS** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves if you wish, regardless of how many units are already in Strategic Reserves."
       },
@@ -2529,13 +2536,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5cb197c0-1805-5e2b-bce0-262f9099260a",
+      "id": "c333da7a-cf92-5c0d-88b5-b590482d06f4",
       "name": {
         "en": "Perfectly Adapted"
       },
       "cost": "15",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. Once per turn, you can re-roll one Hit roll, one Wound roll, one Damage roll, one Advance roll, one Charge roll or one saving throw made for the bearer."
       },
@@ -2547,13 +2555,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "54c95cc4-e4a2-5f86-b152-53907aa718bb",
+      "id": "605d0ef8-73ff-5a41-9fa3-ee5ba3f03d43",
       "name": {
         "en": "Synaptic Linchpin"
       },
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. While a friendly **TYRANIDS** unit is within 9\" of the bearer, that unit is within Synapse Range of your army."
       },
@@ -2565,13 +2574,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "eb4e01d1-2d5e-5e05-b845-6deda818cd90",
+      "id": "8e64729b-09a4-5a2c-8635-849bd1b8b17e",
       "name": {
         "en": "Adaptive Biology"
       },
       "cost": "25",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. The bearer has the Feel No Pain 5+ ability. At the start of any turn, if the bearer has fewer than its starting number of wounds remaining, until the end of the battle, it has the Feel No Pain 4+ ability instead."
       },
@@ -2583,13 +2593,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f84c9c3c-5135-5866-b4b6-74e9d409ff79",
+      "id": "a0a70a2b-9590-5320-a303-e5f3ca7352be",
       "name": {
         "en": "Ominous Presence"
       },
       "cost": "15",
       "keywords": ["Monster", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS MONSTER** model only. Add 3 to the bearer’s Objective Control characteristic."
       },
@@ -2601,13 +2612,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c54fa1cb-99b5-59f9-b7c8-a5be084e4139",
+      "id": "1db2f49f-f214-50ae-94c9-c0d7168e6ebe",
       "name": {
         "en": "Enraged Reserves"
       },
       "cost": "20",
       "keywords": ["Monster", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS MONSTER** model only. If the bearer is destroyed by a melee attack, if it has not fought this phase, roll one D6: on a 3+, do not remove it from play. It can fight after the attacking model’s unit has finished making its attacks, and is then removed from play."
       },
@@ -2619,13 +2631,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "70857bc4-5076-5ce3-b73d-da8bbe9eba77",
+      "id": "cf7321c9-07a8-5e55-af15-de033799a06c",
       "name": {
         "en": "Null Nodules"
       },
       "cost": "10",
       "keywords": ["Monster", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS MONSTER** model only. Once per battle, when a Psychic Attack is allocated to the bearer, it can use this ability. If it does, until the end of the phase, the bearer has the Feel No Pain 5+ ability against Psychic Attacks."
       },
@@ -2637,13 +2650,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "aa33376f-07ef-55a6-878d-5cd44b5bbab6",
+      "id": "a06eeb67-b498-582b-ad9b-501d2ae9e9d1",
       "name": {
         "en": "Monstrous Nemesis"
       },
       "cost": "25",
       "keywords": ["Monster", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS MONSTER** model only. Each time the bearer makes a melee attack that targets a **MONSTER** or **VEHICLE** unit, add 1 to the Wound roll."
       },
@@ -2655,13 +2669,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e1d862b4-0e49-5c31-b648-2f6f4e5c6365",
+      "id": "67b0ce66-e7fb-5f47-ba6e-e5d9267df297",
       "name": {
         "en": "Relentless Hunger"
       },
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. Add 2\" to the Move characteristic of models in the bearer’s unit."
       },
@@ -2673,13 +2688,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "82b51e40-6b5c-52b6-87cd-334cb7ed891e",
+      "id": "73931514-9568-5458-a074-1e5fac4a71cb",
       "name": {
         "en": "Naturalised Camouflage"
       },
       "cost": "30",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. At the start of the first battle round, select up to three friendly **ENDLESS MULTITUDE** units within 9\" of the bearer. Until the end of the battle round, each time a ranged attack targets one of those units, models in that unit have the Benefit of Cover against that attack."
       },
@@ -2691,13 +2707,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "99970ecf-80e5-5648-b063-c67de054e19e",
+      "id": "857edb3d-7164-5688-a006-6f258be7a46a",
       "name": {
         "en": "Piercing Talons"
       },
       "cost": "25",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. Each time a model in the bearer’s unit makes an attack, on a Critical Wound, improve the Armour Penetration characteristic of that attack by 1."
       },
@@ -2709,13 +2726,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4bd138a8-316b-57fa-a4fe-30964f123c21",
+      "id": "2dfbe62e-3426-5245-bd39-61257b5e517a",
       "name": {
         "en": "Adrenalised Onslaught"
       },
       "cost": "15",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. Each time the bearer’s unit Piles In or Consolidates, models in this unit can move an additional 3\"."
       },
@@ -2727,13 +2745,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6eac929e-d3a1-5f50-be81-dd48479cf58a",
+      "id": "511f5830-d001-541d-aae1-d7c308d515d9",
       "name": {
         "en": "Regenerating Monstrosity"
       },
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": ["Monster"],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only (excluding **MONSTERS** models). The bearer’s unit can be regenerated up to twice per phase, instead of once."
       },
@@ -2745,13 +2764,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ee89c865-9d71-5dc1-8e2e-17044a79f42c",
+      "id": "e7bc0555-04b6-5d6f-b34f-6bb64677e903",
       "name": {
         "en": "Instinctive Defence"
       },
       "cost": "15",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. While the bearer is within 6\" of one or more friendly **HARVESTER** units, when you target this unit with the Heroic Intervention stratagem, that use is -1 CP. In addition, while the bearer is within 6\" of one or more friendly **HARVESTER** units, models in the bearer’s unit have the Fights First ability."
       },
@@ -2763,13 +2783,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "cee37a4e-372f-58f9-aca2-62ef85063ee9",
+      "id": "b2784ac7-9bf6-5adb-a87a-c99b746cf8c2",
       "name": {
         "en": "Biophagic Flow (Aura)"
       },
       "cost": "10",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. While a friendly **HARVESTER** model is within 12\" of the bearer, when using the Feed the Swarm ability, that **HARVESTER** model can Regenerate one friendly **TYRANIDS** unit that is within 9\" of it, instead of one within 6\"."
       },
@@ -2781,13 +2802,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ad05866b-3591-5cdd-8038-eec3ca79a5b1",
+      "id": "77e54505-4eb4-5828-a1b7-b2e7007365bd",
       "name": {
         "en": "Parasitic Biomorphology"
       },
       "cost": "25",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. Add 1 to the Strength characteristic of melee weapons equipped by models in the bearer’s unit. The first time the bearer’s unit destroys an enemy unit in the Fight phase while the bearer is within 6\" of one or more friendly **HARVESTER** units, until the end of the battle, add 1 to the Attacks characteristic of melee weapons equipped by models in the bearer’s unit."
       },
@@ -2799,13 +2821,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d90bd592-650d-599d-b123-ae0cb7fdb508",
+      "id": "916030ab-86c8-58e1-8843-de3a532fb773",
       "name": {
         "en": "Hunting Grounds"
       },
       "cost": "30",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. While the bearer is on the battlefield, each time your opponent sets up a Reserves unit on the battlefield, roll one D6: on a 2+, that unit must take a Battle-shock test."
       },
@@ -2817,13 +2840,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d6be3abe-d782-5adb-a4f1-ca5c772dde97",
+      "id": "edd05529-a7aa-5b31-b657-77c035d96b67",
       "name": {
         "en": "Chameleonic"
       },
       "cost": "15",
       "keywords": ["Vanguard Invader"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VANGUARD INVADER** model only. This unit has **Stealth**."
       },
@@ -2835,13 +2859,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "fd140c7e-4195-5892-b169-4d2426bc64ad",
+      "id": "32fc69f8-2520-589a-99fd-497d8dccf2a9",
       "name": {
         "en": "Stalker"
       },
       "cost": "10",
       "keywords": ["Vanguard Invader"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**VANGUARD INVADER** model only. At the start of the battle, select one enemy unit. Each time the bearer makes an attack that targets that enemy unit, add 1 to the Hit roll and add 1 to the Wound roll."
       },
@@ -2853,13 +2878,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "75b4aa52-8263-51af-80a0-cd97ae7b89cf",
+      "id": "d8f4655d-ee6c-55d6-804d-3bf680b7d62e",
       "name": {
         "en": "Neuronode"
       },
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. After both players have deployed their armies, you can select up to three **VANGUARD INVADER** units from your army and redeploy all of those units. When doing so, any of those units can be placed into Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -2871,13 +2897,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "814ada38-186a-55be-8a10-22a82c42fe2c",
+      "id": "16c85b10-2b97-5854-9a9a-02c99eeeeafb",
       "name": {
         "en": "Power of the Hive Mind"
       },
       "cost": "10",
       "keywords": ["Psyker", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS PSYKER** model only. Improve the Strength and Armour Penetration characteristics of psychic weapons equipped by the bearer by 1."
       },
@@ -2889,13 +2916,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6856fd9f-0c2e-57f9-9029-28d1fcc88755",
+      "id": "76df9640-be70-5ada-86fe-dd11ec875208",
       "name": {
         "en": "Psychostatic Disruption"
       },
       "cost": "30",
       "keywords": ["Synapse", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS SYNAPSE** model only. Enemy units that arrive on the battlefield from Reserves cannot be set up within 12\" of the bearer. In addition, once per battle, during the first or second battle round, when your opponent declares that a unit will arrive on the battlefield from Strategic Reserves, the bearer can use this Enhancement. If it does, roll one D6: on a 4+, that enemy unit cannot arrive on the battlefield this turn."
       },
@@ -2907,13 +2935,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9b187ce4-bbb9-54f3-9304-3bf26bcc1a4b",
+      "id": "05d2834a-a670-5c0d-9a5a-63ad849b9d78",
       "name": {
         "en": "Synaptic Control"
       },
       "cost": "20",
       "keywords": ["Synapse", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS SYNAPSE** model only. Each time an attack is allocated to the bearer, subtract 1 from the Damage characteristic of that attack."
       },
@@ -2925,13 +2954,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d5e68f7d-5d95-5a18-bb57-ac8062ca9ee4",
+      "id": "988601db-0626-5473-b639-3607d699d2a1",
       "name": {
         "en": "The Dirgeheart of Kharis (Aura)"
       },
       "cost": "15",
       "keywords": ["Synapse", "Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS SYNAPSE** model only. While an enemy unit is within 9\" of the bearer, worsen that unit’s Leadership characteristic by 1."
       },
@@ -2943,13 +2973,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7d14c934-ceb5-5297-a8ba-538a2223dd8c",
+      "id": "e9f7d443-2c40-5696-a53c-b8e7f5056f32",
       "name": {
         "en": "Synaptic Strategy"
       },
       "cost": "15",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. Once per battle, you can target the bearer’s unit with the Rapid Ingress stratagem for 0CP, and can do so even if you have already targeted a different unit with that Stratagem this phase."
       },
@@ -2961,13 +2992,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "603c7ea3-fc95-5cb0-bd80-c4de2320c2c3",
+      "id": "103793f7-d6c8-5971-bbe0-033654b4769a",
       "name": {
         "en": "Tremor Senses"
       },
       "cost": "20",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model only. After both players have deployed their armies, select up to three friendly **TYRANIDS** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -2979,13 +3011,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1617de6e-6736-5d2a-a664-4bb7acc15696",
+      "id": "12b1f913-eafe-5432-a41e-bd5f72bf8050",
       "name": {
         "en": "Vanguard Intellect"
       },
       "cost": "15",
       "keywords": ["Tyranids"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TYRANIDS** model with the Deep Strike ability only. The bearer’s unit can be set up using the Deep Strike ability in the Reinforcements step of your first, second or third Movement phase, regardless of any mission rules."
       },
@@ -2997,13 +3030,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "3ceee34a-6547-56e4-9241-dd21dd4eb54a",
+      "id": "9cb2a26c-e6eb-539d-a3a4-d0bdb5f3605d",
       "name": {
         "en": "Trygon Prime"
       },
       "cost": "20",
       "keywords": ["Trygon"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**TRYGON** model only. The bearer gains the **SYNAPSE** keyword. Improve the Strength and Weapon Skill characteristics of melee weapons equipped by the bearer by 1."
       },
@@ -3480,7 +3514,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **GENESTEALERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Genestealers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "28b62847-0a45-5cf7-a498-0ed2ab794f82",
@@ -5956,7 +5997,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **TYRANT GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Tyrant Guard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "b6d511cb-c07b-5e74-9aaf-0d2e07b841b3",
@@ -6323,7 +6371,14 @@
       },
       "leader": {
         "en": "This model can be attached to the following units:  ■ **RAVENERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Raveners",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0d3bc100-533c-5a07-93e5-b6e944c037fb",
@@ -7417,7 +7472,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **NEUROGAUNTS** ■ **TYRANT GUARD** ■ **ZOANTHROPES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Neurogaunts",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tyrant Guard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Zoanthropes",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "5fb3c75c-f1a2-5a08-b36c-d1cd3df3961c",
@@ -8003,7 +8075,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CARNIFEXES**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Carnifexes",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a5be0b4a-f8f1-5f2e-940d-575b5255b9a4",
@@ -10118,7 +10197,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **TYRANT GUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Tyrant Guard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "d71c0768-ad7f-5d9e-9cb8-e849dbc083f2",
@@ -10615,7 +10701,29 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **HORMAGAUNTS** ■ **TERMAGANTS** ■ **TYRANID WARRIORS WITH MELEE BIO-WEAPONS** ■ **TYRANID WARRIORS WITH RANGED BIO-WEAPONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Hormagaunts",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Termagants",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tyranid Warriors with Melee Bio-weapons",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tyranid Warriors with Ranged Bio-weapons",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "661e51bb-c49f-5d0e-8c9d-cf5255ee3267",
@@ -12359,7 +12467,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **GARGOYLES** ■ **TYRANID WARRIORS WITH MELEE BIO-WEAPONS** ■ **TYRANID WARRIORS WITH RANGED BIO-WEAPONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Gargoyles",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tyranid Warriors with Melee Bio-weapons",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Tyranid Warriors with Ranged Bio-weapons",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "63bb6521-6679-5ee4-83b0-09f3131380f5",

--- a/11th/gdc/votann.json
+++ b/11th/gdc/votann.json
@@ -7,7 +7,7 @@
     "header": "#3c4b3f"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:53.450Z",
+  "updated": "2026-07-28T17:03:08.947Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2301,7 +2301,7 @@
   ],
   "enhancements": [
     {
-      "id": "e8ba6eca-6445-5ba5-887e-7bdd7ddd3ecd",
+      "id": "2b9908b3-1caa-5097-b0d6-5c94c476aab3",
       "name": {
         "en": "Pan-spectral Lockons (Upgrade)",
         "de": "Panspektrale Visiere (Aufwertung)",
@@ -2315,6 +2315,7 @@
       "cost": "10",
       "keywords": ["Pioneers"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>PIONEERS</k> unit only. In your Shooting phase, you can select one <b>visible</b> enemy unit within 12\" of this unit. That enemy unit is <b>spotted</b>:\r<ul><li>While a unit is <b>spotted</b>, that unit has +3\" <b>detection range</b>.</li></ul>",
         "de": "Nur für eine <k>Pionier</k>-Einheit. In deiner Fernkampfphase kannst du eine für dies Einheit <b>sichtbare</b> feindliche Einheit innerhalb von 12\" wählen. Jene Einheit ist <b>gesichtet</b>:\r<ul><li>Solange eine Einheit <b>gesichtet</b> ist, hat sie +3\" <b>Entdeckungs­reichweite</b>.</li></ul>",
@@ -2333,7 +2334,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "90538e66-95bc-5307-80ac-68615dd458de",
+      "id": "093580cc-a816-515d-91d2-316b4cbbff6e",
       "name": {
         "en": "Ironskein",
         "de": "Eisenstrang",
@@ -2347,6 +2348,7 @@
       "cost": "10",
       "keywords": ["Kâhl"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Kâhl</k> model only. This model has +2 <b>W</b>.",
         "de": "Nur für ein <k>Kâhl</k>-Modell. Dieses Modell hat +2 <b>LP</b>.",
@@ -2365,7 +2367,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "20b334f1-7780-5499-b8df-2386eaa618a3",
+      "id": "1362283d-3e19-5c9d-9813-5bdfa3d9a82c",
       "name": {
         "en": "Shroudwërke Talismans (Upgrade)",
         "de": "Tarnfeldtalismane (Aufwertung)",
@@ -2379,6 +2381,7 @@
       "cost": "15",
       "keywords": ["Yaegirs"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Yaegirs</k> unit only. This unit has ‑3\" <b>detection range</b>.",
         "de": "Nur für eine <k>Yaeger</k>-Einheit. Diese Einheit hat -3\" <b>Entdeckungs­reichweite</b>.",
@@ -2397,7 +2400,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "38b2ff22-b1d3-500e-85a5-171a45d21550",
+      "id": "0dc7b19f-3f94-559c-a5ed-3f70fb4545a4",
       "name": {
         "en": "Saturation Rounds (Upgrade)",
         "de": "Durchdringende Geschosse (Aufwertung)",
@@ -2411,6 +2414,7 @@
       "cost": "15",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Sagitaur</k> unit only. This unit’s ranged attacks have <k>[Ignores Cover]</k>.",
         "de": "Nur für eine <k>Sagitauros</k>-Einheit. Fernkampfattacken dieser Einheit haben <k>[Deckung ignorieren]</k>.",
@@ -2429,7 +2433,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "dd33a365-bb0a-55d1-af31-6324889b2ea1",
+      "id": "951f6fa9-6fcb-5a20-a5b9-7ecc30ee2d1d",
       "name": {
         "en": "Optimised Attack Lines (Upgrade)",
         "de": "Optimierte Angriffslinien (Aufwertung)",
@@ -2443,6 +2447,7 @@
       "cost": "15",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Sagitaur</k> unit only. This unit has <k>Mobile</k>.",
         "de": "Nur für eine <k>Sagitauros</k>-Einheit. Diese Einheit hat <k>Mobil</k>.",
@@ -2461,7 +2466,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "463bcb58-c699-5f27-9703-08d27cea34c4",
+      "id": "fd98a2f0-a24b-58d0-8402-4f5f3f75b2bc",
       "name": {
         "en": "High Kâhl",
         "de": "Großkâhl",
@@ -2475,6 +2480,7 @@
       "cost": "30",
       "keywords": ["Kâhl"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>Kâhl</k> model only. In the Fight phase, when a model in this unit is <b>destroyed</b>, if this unit has not been <b>selected to fight</b> this phase, roll one D6: on a 4+, do not remove that model from the battlefield; after this unit has fought, or at the end of the phase (whichever comes first), that model is removed from the battlefield.",
         "de": "Nur für ein <k>Kâhl</k>-Modell. Wenn in der Nahkampfphase ein Modell dieser Einheit <b>zerstört</b> wird und diese Einheit in dieser Phase noch nicht <b>zum Kämpfen gewählt wurde</b>, wirf einen W6: Bei 4+ entferne jenes Modell nicht vom Schlachtfeld; nachdem diese Einheit gekämpft hat oder am Ende der Phase (was immer zuerst eintritt) wird jenes Modell vom Schlachtfeld entfernt.",
@@ -2493,13 +2499,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "56967ce8-09e9-5286-83ed-430a20181bf3",
+      "id": "1f4fd983-4f36-5c05-83f3-5e76115ad482",
       "name": {
         "en": "Oathbound Speculator"
       },
       "cost": "30",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Each time a model in the bearer’s unit makes an attack, re‑roll a Wound roll of 1. Each time the bearer’s unit is selected to shoot or fight, you can spend 3YP. If you do, until the end of the phase, each time a model in the bearer’s unit makes an attack, add 1 to the Wound roll."
       },
@@ -2511,13 +2518,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1588536f-50b9-5a40-916f-4390d1ee6ce7",
+      "id": "320dda5f-2cda-56f3-98c4-3280475e2c3c",
       "name": {
         "en": "Dead Reckoning"
       },
       "cost": "10",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. At the end of the turn, if the bearer is on the battlefield and you spent no YP in that turn, you can gain 1YP."
       },
@@ -2529,13 +2537,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1a2d6626-3ea5-5d08-964f-3c2bbbd4d32e",
+      "id": "84f9f0f1-3c9d-51fa-8cc0-3deece55a060",
       "name": {
         "en": "Iron Ambassador"
       },
       "cost": "5",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model equipped with an Autoch‑pattern combi‑bolter only. Once per battle, when the bearer’s unit is selected to shoot, the bearer can use this Enhancement. If it does, spend up to 3YP and, until the end of the phase, add the number of YP you just spent to the Damage characteristic of the bearer’s ranged weapons"
       },
@@ -2547,13 +2556,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0273260a-2b9b-50fd-9390-0f91995e3951",
+      "id": "77bdbf0a-354e-5ae7-9cb1-2087b292e42b",
       "name": {
         "en": "Ancestral Crest"
       },
       "cost": "15",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Once per turn, when you target the bearer’s unit with the Command Re‑roll Stratagem, the bearer can use this Enhancement. If it does, spend 1YP and reduce the CP cost of that use of that Stratagem by 1CP."
       },
@@ -2565,13 +2575,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b9b3e0ec-1be1-52ea-954b-67644412302f",
+      "id": "23084a50-172b-5bfa-8661-bc525451a3d6",
       "name": {
         "en": "Bastion Shield"
       },
       "cost": "25",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Each time a ranged attack targets the bearer’s unit, if the attacking model is within 12\" of the bearer’s unit, worsen the Armour Penetration characteristic of that attack by 1. If you spend 1YP, until the end of the phase, if the attacking model is within 18\" of the bearer’s unit, worsen the Armour Penetration characteristic of that attack by 1 instead."
       },
@@ -2583,13 +2594,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "7396264d-c65f-557d-8797-18adc34bc730",
+      "id": "3f38ee73-9040-57bb-baf9-ce5e4ab38518",
       "name": {
         "en": "Quake Multigenerator"
       },
       "cost": "15",
       "keywords": ["Kâhl", "Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KÂHL** model only. In your Shooting phase, after the bearer has shot, select one enemy unit (excluding **TITANIC** units) hit by one or more of those attacks. Until the start of your next turn, that enemy unit is suppressed. While a unit is suppressed, each time a model in that unit makes an attack, subtract 1 from the Hit roll."
       },
@@ -2601,13 +2613,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "90538e66-95bc-5307-80ac-68615dd458de",
+      "id": "a20fc92a-8bb2-51ea-bfb2-795fbc7ca32d",
       "name": {
         "en": "Ironskein"
       },
       "cost": "10",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Add 2 to the bearer’s Wounds characteristic."
       },
@@ -2619,13 +2632,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "463bcb58-c699-5f27-9703-08d27cea34c4",
+      "id": "d2d93b50-34f1-5355-94f3-56715af08882",
       "name": {
         "en": "High Kâhl"
       },
       "cost": "30",
       "keywords": ["Kâhl", "Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KÂHL** model only. Each time a model in the bearer’s unit is destroyed by a melee attack, if it has not fought this phase, roll one D6: on a 4+, do not remove it from play. The destroyed model can fight after the attacking unit has finished making its attacks, and is then removed from play."
       },
@@ -2637,13 +2651,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "114d0864-533a-5a93-b50e-caa303011dd2",
+      "id": "7ee81a55-8d1c-526a-a8c2-e345ca06236e",
       "name": {
         "en": "Eye for Weakness"
       },
       "cost": "25",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Each time a model in the bearer’s unit makes an attack that targets an assailed unit, add 1 to the Wound roll."
       },
@@ -2655,13 +2670,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2ce68fb5-0556-5c44-aebf-67390f35ec79",
+      "id": "6294cfd9-b1f6-5398-8f4f-67a3fb0a0ff2",
       "name": {
         "en": "Writ of Acquisition"
       },
       "cost": "10",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. In your Shooting phase, after the bearer’s unit has shot, you gain 1YP for each assailed enemy unit hit by one or more of those attacks (to a maximum of 3YP)."
       },
@@ -2673,13 +2689,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "b0e586ae-818c-57f1-89f3-8a738c7ba045",
+      "id": "c9e4a927-bd8b-5874-90c3-0ad38d931975",
       "name": {
         "en": "Surgical Saboteur"
       },
       "cost": "10",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. In your Shooting phase, after the bearer’s unit has shot, select one **MONSTER** or **VEHICLE** unit hit by one or more of those attacks; until the start of your next Shooting phase, that unit is pinned."
       },
@@ -2691,13 +2708,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "838ef5a2-2287-565c-96e9-301dcafa724c",
+      "id": "ca9696b8-231c-587e-b66f-cc4939c4f7c1",
       "name": {
         "en": "Nomad Strategist"
       },
       "cost": "20",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Once per battle, at the end of your opponent’s Fight phase, if the bearer is on the battlefield, it can use this Enhancement. If it does, you can spend up to 4YP. Select one **HERNKYN** unit from your army, and, for every 2YP you just spent, select up to one additional **HERNKYN** unit from your army. You can remove those units from the battlefield and place them into Strategic Reserves. You cannot select a unit that is within Engagement Range of one or more enemy units (excluding assailed units)."
       },
@@ -2709,13 +2727,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "d8c6fd25-9c85-50f8-8344-d3a546f924d4",
+      "id": "6d0341c2-74dc-5afb-ae39-ca6faebd89e8",
       "name": {
         "en": "Dêlvewerke Navigator"
       },
       "cost": "25",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. In the Reinforcements step of your Movement phase, the bearer can use this Enhancement. If it does, select one friendly **CTHONIAN BESERKS** unit visible to the bearer and then spend any number of YP. Return one destroyed model (excluding **CHARACTER** models) to that unit and then, for every 2YP you just spent, return up to one additional destroyed model (excluding **CHARACTER** models) to that unit."
       },
@@ -2727,13 +2746,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e0b63611-a706-512c-b898-fd4a2f67945f",
+      "id": "12dc847d-41b6-534c-8660-f183ebf403b5",
       "name": {
         "en": "Multiwave System Jammer"
       },
       "cost": "10",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Once per battle, in your Movement phase, if the bearer is on the battlefield, it can use this Enhancement. If it does, select one friendly **CTHONIAN** unit that is in Reserves. Until the end of the phase, for the purposes of setting up that unit on the battlefield, treat the current battle round number as being one higher than it actually is."
       },
@@ -2745,13 +2765,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "44c2b487-e4da-57b9-8aba-12c21f2a7be9",
+      "id": "17ed857c-e91d-5521-acda-0d47bf02e7ee",
       "name": {
         "en": "Quake Supervisor"
       },
       "cost": "20",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. While the bearer is within 3\" of one or more friendly **LEAGUES OF VOTANN ARTILLERY** units, the bearer has the Lone Operative ability, and each time one of those **ARTILLERY** units makes a ranged attack that targets an enemy unit visible to the bearer, add 1 to the Hit roll."
       },
@@ -2763,13 +2784,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "59b914ad-0f30-574f-af04-d21ad2a5e330",
+      "id": "e2a6bc2b-8708-5bc5-8768-de783ce2b659",
       "name": {
         "en": "Piledriver"
       },
       "cost": "15",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Each time the bearer’s unit is selected to fight, the bearer can use this Enhancement. If it does, spend up to 2YP and, until the end of the phase, add the number of YP you just spent to the Damage characteristic of the bearer’s melee weapons."
       },
@@ -2781,13 +2803,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5c703fc5-8179-5eaf-82d1-2356520d0bcd",
+      "id": "c0d86460-3b33-58c0-b460-3341149dd596",
       "name": {
         "en": "Tactical Alchemy"
       },
       "cost": "10",
       "keywords": ["Kâhl"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KÂHL** model only. In your Command phase, if the bearer’s unit is within range of one or more objective markers you control that are not within your deployment zone, you can spend 1YP. If you do, roll one D6: on a 4+, you gain 1CP."
       },
@@ -2799,13 +2822,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "2afea515-67fe-5dfb-ac07-4c1cf259873c",
+      "id": "c6f12eb0-90ab-581e-a3bd-827e17b5615a",
       "name": {
         "en": "Trivärg Cyber Implant"
       },
       "cost": "40",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. In your Shooting phase, each time the bearer’s unit is selected to shoot, if it disembarked from a **TRANSPORT** this turn, or if you spend 2YP, until the end of the phase, ranged weapons equipped by models in that unit have the **[SUSTAINED HITS 2]** ability."
       },
@@ -2817,13 +2841,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0cde09cf-e611-5d37-9f0a-69eb20449da1",
+      "id": "bd3d1b7f-4950-552c-bef3-9a7220f1c579",
       "name": {
         "en": "Precursive Judgement"
       },
       "cost": "15",
       "keywords": ["Kâhl"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KÂHL** model only. While the bearer’s unit is wholly within 6\" of one or more friendly **LEAGUES OF VOTANN TRANSPORT** units, you can target the bearer’s unit with the Fire Overwatch Stratagem for 0CP and hits are scored on unmodified Hit rolls of 5+ while resolving that Stratagem."
       },
@@ -2835,13 +2860,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5be49b35-7655-598e-b3d6-dbca18598d2c",
+      "id": "ee57261e-b6df-5d20-98ae-b83f16735675",
       "name": {
         "en": "Signature Restoration"
       },
       "cost": "5",
       "keywords": ["Brôkhyr"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IRON‑MASTER** model only. Each time a friendly **LEAGUES OF VOTANN** model is repaired using the bearer’s Forgewrought Expertise ability, that model regains 1 additional lost wound."
       },
@@ -2853,13 +2879,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "6effa718-e2d3-5f86-b356-a428532ec2ba",
+      "id": "7684e4c7-384f-50f9-bc3d-dc099cadaf7b",
       "name": {
         "en": "Fârstrydr Node"
       },
       "cost": "20",
       "keywords": ["Memnyr Strategist", "Brôkhyr"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IRON‑MASTER** or **MEMNYR STRATEGIST** model only. Models in the bearer’s unit have the Deep Strike ability."
       },
@@ -2871,13 +2898,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e1ef7a13-6799-5c22-a04b-fa065b7d1263",
+      "id": "d3070477-6902-55a0-a3c7-72511e7a482a",
       "name": {
         "en": "Calculated Tenacity"
       },
       "cost": "15",
       "keywords": ["Brôkhyr", "Memnyr Strategist"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IRON‑MASTER** or **MEMNYR STRATEGIST** model only. While the bearer is leading a unit, add 1 to the Objective Control characteristic of models in that unit."
       },
@@ -2889,13 +2917,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "949115eb-5d48-5bb5-a287-e9de01ae2e8c",
+      "id": "db17f290-6dca-5f70-9174-1fa8633e6f0a",
       "name": {
         "en": "Mantle of Elders"
       },
       "cost": "10",
       "keywords": ["Memnyr Strategist"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEMNYR STRATEGIST** model only. Each time the bearer’s unit is selected to shoot, if you spend YP using the Optimal Application Detachment rule when doing so, you can roll one D6: on a 2+, you gain 1YP."
       },
@@ -2907,13 +2936,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5e4cd65a-d6a9-58c6-acf9-475ed679865f",
+      "id": "16e39fe6-2165-5842-9c65-34c80e853187",
       "name": {
         "en": "Graviton Vault"
       },
       "cost": "5",
       "keywords": ["Brôkhyr"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**IRON‑MASTER** model only. In your Shooting phase, after the bearer has shot, and in the Fight phase, after the bearer has fought, select one enemy **MONSTER** or **VEHICLE** unit hit by one or more of those attacks. Until the start of your next turn, that enemy unit is suppressed. While a unit is suppressed, each time a model in that unit makes an attack, subtract 1 from the Hit roll."
       },
@@ -2925,13 +2955,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1079f891-cb16-5f8a-88d7-ef730ccfa7b2",
+      "id": "2a1e524b-0474-5c77-a0b0-6fd74a50d2be",
       "name": {
         "en": "Mercenary Prospector"
       },
       "cost": "20",
       "keywords": ["Kâhl"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**KÂHL** model only. Each time an enemy unit is destroyed by the bearer’s unit, gain 2YP."
       },
@@ -2943,13 +2974,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4b654ed2-8bad-5b50-8034-42a1ec4321fc",
+      "id": "79679ca0-566c-541c-8ee4-245b24c4fae0",
       "name": {
         "en": "Metaphysical Brokerage"
       },
       "cost": "20",
       "keywords": ["Memnyr Strategist"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**MEMNYR STRATEGIST** model only. At the end of your turn, if the bearer is on the battlefield and you gained fewer than 3YP this turn, you gain an amount of YP equal to the difference."
       },
@@ -2961,13 +2993,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f52dbf61-df4a-54fe-be0f-fd12fbbf5431",
+      "id": "ea6af81d-99d5-50d0-8e0f-b210724fa0a7",
       "name": {
         "en": "Etacarn SB9 Targeting Implant"
       },
       "cost": "15",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. Each time a model in the bearer’s unit makes an attack, re‑roll a Hit roll of 1. Each time the bearer’s unit is selected to shoot or fight, you can spend 3YP. If you do, until the end of the phase, each time a model in the bearer’s unit makes an attack, that attack has the **[SUSTAINED HITS 1]** ability."
       },
@@ -2979,13 +3012,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "e1c2c102-05cc-52d6-9994-003054ba0a0c",
+      "id": "3a73a88b-defa-5f28-9249-b37c33ac889d",
       "name": {
         "en": "Asset Manipulator"
       },
       "cost": "25",
       "keywords": ["Leagues of Votann"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LEAGUES OF VOTANN** model only. At the start of the Command phase, you can spend 3YP. If you do, until the end of the turn, while an enemy unit is within 3\" of the bearer, subtract 1 from the Objective Control characteristic of models in that enemy unit."
       },
@@ -3374,7 +3408,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **CTHONIAN BESERKS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Cthonian Beserks",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "8d066aa5-47e9-5d02-861b-bcd5abfe8b04",
@@ -3724,7 +3765,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **BRÔKHYR THUNDERKYN** ■ **HEARTHKYN WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Brôkhyr Thunderkyn",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hearthkyn Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6c6112d4-601f-5bc8-b253-5d211b7900e3",
@@ -4784,7 +4837,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EINHYR HEARTHGUARD**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Einhyr Hearthguard",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "cfd5032a-2dc7-507a-a400-a0fc45d1e82a",
@@ -5390,7 +5450,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **HEARTHKYN WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Hearthkyn Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "0fd9319f-37fc-5325-8bbe-3bc58f5834f2",
@@ -7579,7 +7646,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EINHYR HEARTHGUARD** ■ **HEARTHKYN WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Einhyr Hearthguard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hearthkyn Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "a0a637e3-2f11-5769-bc5f-66a9de8ba824",
@@ -8194,7 +8273,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **IRONKIN STEELJACKS WITH HEAVY VOLKANITE DISINTEGRATORS** ■ **IRONKIN STEELJACKS WITH MELEE WEAPONS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Ironkin Steeljacks with Heavy Volkanite Disintegrators",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Ironkin Steeljacks with Melee Weapons",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "6d880dd3-d9e1-5a41-a2fd-5354f8c988c4",
@@ -8643,7 +8734,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EINHYR HEARTHGUARD** ■ **HEARTHKYN WARRIORS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Einhyr Hearthguard",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Hearthkyn Warriors",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }

--- a/11th/gdc/worldeaters.json
+++ b/11th/gdc/worldeaters.json
@@ -7,7 +7,7 @@
     "header": "#4d161a"
   },
   "compatibleDataVersion": 913,
-  "updated": "2026-07-28T15:14:50.751Z",
+  "updated": "2026-07-28T17:03:03.572Z",
   "parent_id": null,
   "parent_name": null,
   "rules": {
@@ -2017,7 +2017,7 @@
   ],
   "enhancements": [
     {
-      "id": "1f2b1727-e09f-53f6-aace-8c0595c2e1c7",
+      "id": "bf6df154-160a-5ee2-90d4-9c8ecd596766",
       "name": {
         "en": "Gateways to Glory",
         "de": "Pforten des Ruhms",
@@ -2031,6 +2031,7 @@
       "cost": "10",
       "keywords": ["Daemon Prince", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>World Eaters Daemon Prince</k> model only. This model has:\r<ul><li><k>Mobile</k>.</li>\r<li> +1 to <b>charge rolls</b>.</li></ul>",
         "de": "Nur für ein <k>World</k>-<k>Eaters</k>-<k>Dämonenprinz</k>-Modell. Dieses Modell hat:\r<ul><li><k>Mobil</k>.</li>\r<li>+1 auf <b>Angriffswürfe</b>.</li></ul>",
@@ -2049,7 +2050,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "94910f83-ae7d-58a0-8912-7def76b0d234",
+      "id": "db374e6f-2a10-5dca-9bfe-6abab04abc16",
       "name": {
         "en": "Sanctified in Slaughter (Upgrade)",
         "de": "Blutige Weihe (Aufwertung)",
@@ -2063,6 +2064,7 @@
       "cost": "15",
       "keywords": ["Terminator Squad"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Terminator Squad</k> unit only. This unit has +1 <b>OC</b>.",
         "de": "Nur für eine <k>Terminatortrupp</k>-Einheit. Diese Einheit hat +1 <b>MK</b>.",
@@ -2081,7 +2083,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f6acccf3-9c37-5ceb-bcbb-bd77b332bffe",
+      "id": "fc56e8ad-bcf3-547a-8cd8-71b457dd646b",
       "name": {
         "en": "Murder-forged Entity (Upgrade)",
         "de": "Mordlüsterne Schmiedewesenheit (Aufwertung)",
@@ -2095,6 +2097,7 @@
       "cost": "15",
       "keywords": ["Vehicle", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>World Eaters Vehicle</k> unit only. This unit has <k>Daemon</k>.",
         "de": "Nur für eine <k>World</k>-<k>Eaters</k>-<k>Fahrzeug</k>-Einheit. Diese Einheit hat <k>Dämon</k>.",
@@ -2113,7 +2116,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "5c5f840c-4b70-5cca-bfa0-387228221a62",
+      "id": "79340226-f7d4-5d1e-8c3a-300683d573f6",
       "name": {
         "en": "Gore-stained Veterans (Upgrade)",
         "de": "Blutbespritzte Veteranen (Aufwertung)",
@@ -2127,6 +2130,7 @@
       "cost": "20",
       "keywords": ["Terminator Squad"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Terminator Squad</k> unit only. This unit’s melee attacks have +1 <b>WS</b>.",
         "de": "Nur für eine <k>Terminatortrupp</k>-Einheit. Die Nahkampfattacken dieser Einheit haben +1 <b>KG</b>.",
@@ -2145,7 +2149,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0514f599-9802-55f6-957e-c6ebc97b1a8a",
+      "id": "794c4218-8cb4-56dd-a092-bc349691327f",
       "name": {
         "en": "Talons of Butchery (Upgrade)",
         "de": "Blutgeschwärzte Krallen (Aufwertung)",
@@ -2159,6 +2163,7 @@
       "cost": "20",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": true,
       "description": {
         "en": "<k>Maulerfiend</k> unit only. This unit’s <b>Maulerfiend Fists</b> have <k>[Cleave 2]</k>.",
         "de": "Nur für eine <k>Klauenmonstrum</k>-Einheit. Die <b>Klauenmonstrum-Fäuste</b> dieser Einheit haben <k>[Spalten 2]</k>.",
@@ -2177,7 +2182,7 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9dc498a4-7bcb-57d8-beef-2095bcd4d474",
+      "id": "de46c461-6cfd-5d2f-87e3-1da0de00ed0b",
       "name": {
         "en": "Archslaughterer",
         "de": "Erzmetzger",
@@ -2191,6 +2196,7 @@
       "cost": "30",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "<k>World Eaters</k> model only. (Once per battle, per army) In your Command phase, you can use this ability. If you do, every <b>Blessing of Khorne</b> is active for this unit until the start of your next turn.",
         "de": "Nur für ein <k>World</k>-<k>Eaters</k>-Modell. (Einmal pro Schlacht pro Armee) In deiner Befehlsphase kannst du diese Fähigkeit einsetzen. Wenn du dies tust, ist bis zum Beginn deines nächsten Zugs für diese Einheit jeder ­<b>Segen des Khorne</b> aktiv.",
@@ -2209,13 +2215,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "442eb88c-1f69-53b3-a629-788de103fcb6",
+      "id": "77e2546b-863a-5cf9-a323-7e40d3ec12b9",
       "name": {
         "en": "Berzerker Glaive"
       },
       "cost": "35",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. Add 1 to the Attacks and Damage characteristics of melee weapons (excluding Extra Attacks weapons) equipped by the bearer."
       },
@@ -2227,13 +2234,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "f2283b16-6fe6-56a5-99a3-36ccd13bba61",
+      "id": "87835078-656a-5945-94d6-bb424116ae51",
       "name": {
         "en": "Helm of Brazen Ire"
       },
       "cost": "30",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. Each time an attack is allocated to the bearer, subtract 1 from the Damage characteristic of that attack."
       },
@@ -2245,13 +2253,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "1f59b797-8500-53ef-9b88-8fe07f3c6f47",
+      "id": "201c7502-16d9-514f-8cf5-700b754753f3",
       "name": {
         "en": "Favoured of Khorne"
       },
       "cost": "20",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. Each time you make a Blessings of Khorne roll, if the bearer is on the battlefield, you can re-roll up to two of the D6 rolled."
       },
@@ -2263,13 +2272,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "98ceec7f-ddcc-5cb3-86f7-b90f494b390e",
+      "id": "8a54b94a-fde2-54e1-8166-359ea0f93e60",
       "name": {
         "en": "Battle-lust"
       },
       "cost": "20",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. You can re-roll Charge rolls made for the bearer’s unit. In addition, while the Unbridled Bloodlust Blessing of Khorne is active for your army, add 1 to Charge rolls made for the bearer’s unit."
       },
@@ -2281,13 +2291,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "ca725348-e81f-5e5a-b644-94bec74b1f00",
+      "id": "298a5cb9-4e95-599f-ac77-054ffb7daa88",
       "name": {
         "en": "Chosen of the Blood God"
       },
       "cost": "15",
       "keywords": ["Monster", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS MONSTER** model only. Add 3\" to the range of the bearer’s Aura abilities."
       },
@@ -2299,13 +2310,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "073e38de-73ef-5b1f-9d92-4eec4139700c",
+      "id": "cea095c1-2713-5da8-a7d2-bbe4bccab8c7",
       "name": {
         "en": "Butcher Lord"
       },
       "cost": "10",
       "keywords": ["Infantry", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS INFANTRY** model only. The bearer has the **Infiltrators** ability."
       },
@@ -2317,13 +2329,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "a4fc5362-57c5-54ca-be9c-231653da643d",
+      "id": "88413c61-4eb1-51e5-8583-97b42c47ea40",
       "name": {
         "en": "Brazen Form"
       },
       "cost": "25",
       "keywords": ["Monster", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS MONSTER** model only. Add 1 to the bearer’s Toughness characteristic and the bearer has the Feel No Pain 5+ ability."
       },
@@ -2335,13 +2348,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "29b895e0-7a88-57be-b4f6-3ae5f41c4c17",
+      "id": "416788b6-6d56-53d0-8b69-c813c067e806",
       "name": {
         "en": "Strategic Slaughter"
       },
       "cost": "20",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. After both players have deployed their armies, select up to three **JAKHALS** and/or **GOREMONGERS** units from your army and redeploy them. When doing so, you can set those units up in Strategic Reserves, regardless of how many units are already in Strategic Reserves."
       },
@@ -2353,13 +2367,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "62a1e017-06bd-51ee-91f4-cf90ca3d60cb",
+      "id": "e69f63c1-eab1-5115-8bf2-65c4e77900ad",
       "name": {
         "en": "Icon of War"
       },
       "cost": "25",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. While a friendly **BLOOD LEGIONS** unit is within 6\" of the bearer, that unit has the Blessings of Khorne ability. If the Might of Khorne ability is active for your army, then while a friendly **BLOOD LEGIONS** unit is within 6\" of the bearer, you can re-roll Battle-shock tests taken for that unit."
       },
@@ -2371,13 +2386,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "171c4e00-23ee-5cd4-b8a4-f7f5cc4b6866",
+      "id": "7e942793-6870-5b00-ac52-0f507d9e0131",
       "name": {
         "en": "Blood-Forged Armour"
       },
       "cost": "20",
       "keywords": ["World Eaters", "Blood Legions"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**BLOOD LEGIONS** or **WORLD EATERS** model only. The bearer has a Save characteristic of 2+. If the bearer is destroyed, you gain 1 Blood Tithe point."
       },
@@ -2389,13 +2405,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "17350915-d4d8-5d09-859e-255be7dd7430",
+      "id": "186e0ac5-4313-5c32-b861-7299f0749ea4",
       "name": {
         "en": "Disciple of Khorne"
       },
       "cost": "15",
       "keywords": ["Lord on Juggernaut"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**LORD ON JUGGERNAUT** model only. The bearer has the **Deep Strike** ability and it has the **BLOOD LEGIONS** Faction keyword instead of the **WORLD EATERS** Faction keyword."
       },
@@ -2407,13 +2424,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4eef547c-7381-5781-bcaf-8a3500be062d",
+      "id": "a45ffb8b-0223-5d12-aad8-ce138cbccc02",
       "name": {
         "en": "Blade of Endless Bloodshed"
       },
       "cost": "30",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. Add 1 to the Attacks, Strength and Damage characteristics of the bearer’s melee weapons. Each time the bearer’s unit destroys an enemy unit with a melee attack, do not roll to gain a Blood Tithe point, you automatically gain 1 Blood Tithe point instead."
       },
@@ -2425,13 +2443,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "0d010508-17e5-5749-8933-6e9edf738e4a",
+      "id": "4bb93c89-2b1a-5011-a4ec-ba41b2d6cfe5",
       "name": {
         "en": "Malicious Vigour"
       },
       "cost": "30",
       "keywords": ["Slaughterbound"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**SLAUGHTERBOUND** model only. Each time the bearer’s unit makes a Brazen Fury move, it is treated as having rolled a 6 for the distance the unit can be moved."
       },
@@ -2443,13 +2462,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "19e1d5ca-f225-5752-8eca-53462219988d",
+      "id": "35a62b40-7ad4-5ae4-8483-bf3052db11b2",
       "name": {
         "en": "Killing Clarity"
       },
       "cost": "15",
       "keywords": ["Daemon", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS DAEMON** model only. Each time the bearer’s unit destroys an enemy unit, roll one D6: on a 4+, you gain 1CP."
       },
@@ -2461,13 +2481,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4c36203e-2f8f-589e-9d07-b11f6aef4971",
+      "id": "ce8c6bfc-feb5-51b9-84b1-279c0aacb020",
       "name": {
         "en": "Frenzied Focus"
       },
       "cost": "20",
       "keywords": ["Daemon", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS DAEMON** model only. Each time a model in the bearer’s unit makes an attack, a Critical Hit is scored on an unmodified Hit roll of 5+, instead of only a 6."
       },
@@ -2479,13 +2500,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "19705c7f-ec42-58a2-bad5-91ccc9631fbf",
+      "id": "4de2fd44-e48a-56b7-b376-c6b0d350dc5b",
       "name": {
         "en": "Violent Demise"
       },
       "cost": "10",
       "keywords": ["Daemon", "World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS DAEMON** model only. The bearer’s Deadly Demise ability inflicts mortal wounds on a D6 roll of 2+ instead of on a 6. In addition, the bearer has the Deadly Demise D3+1 ability, instead of the Deadly Demise D3 ability."
       },
@@ -2497,13 +2519,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "c35fef81-e9a7-5f23-82e7-6473a6e1b099",
+      "id": "79d98eea-a0b6-5222-a5ca-797fd93c698c",
       "name": {
         "en": "Murderous Onslaught"
       },
       "cost": "5",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. If the bearer’s unit disembarked from a **TRANSPORT** this turn, until the end of the turn, enemy units cannot use the Fire Overwatch Stratagem to shoot at the bearer’s unit."
       },
@@ -2515,13 +2538,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "06315bf9-c77c-5b09-a1cd-70ef0cdc40d1",
+      "id": "4f620138-ad1d-529d-8ccd-712640150a5b",
       "name": {
         "en": "Aggressive Deployment"
       },
       "cost": "20",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. In the Declare Battle Formations step, if the bearer starts the battle embarked within a **DEDICATED TRANSPORT,** that **DEDICATED TRANSPORT** has the Scouts 9\" ability."
       },
@@ -2533,13 +2557,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "4b472260-d0d8-5cc3-939e-ee08bd2a6f80",
+      "id": "da622525-4883-5ff7-97a4-61f34236add4",
       "name": {
         "en": "Unleash Hell"
       },
       "cost": "10",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. At the start of your Shooting phase, you can select one **VEHICLE** model within 6\" of the bearer or, if the bearer is embarked within a **TRANSPORT,** you can select that **TRANSPORT** model. Until the end of the phase, after the selected model has shot, select one enemy unit hit by one or more of those attacks. Until the start of your next turn, that enemy unit is suppressed. While a unit is suppressed, each time a model in that unit makes an attack, subtract 1 from the Hit roll."
       },
@@ -2551,13 +2576,14 @@
       "cardType": "enhancement"
     },
     {
-      "id": "9160fb0d-44ce-5a40-8608-7007f58ded6e",
+      "id": "4420c1f0-83d8-5ce8-85c8-4893352eaa02",
       "name": {
         "en": "Infernal Infusion"
       },
       "cost": "25",
       "keywords": ["World Eaters"],
       "excludes": [],
+      "equipableByNonCharacter": false,
       "description": {
         "en": "**WORLD EATERS** model only. Once per battle, at the start of the Fight phase, the bearer can use this Enhancement. If it does, until the end of the phase, the bearer’s unit has the Fights First ability."
       },
@@ -7192,7 +7218,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **KHORNE BERZERKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Khorne Berzerkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "c7cdcaef-03ab-5051-ac97-17286d4bcb34",
@@ -8005,7 +8038,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EIGHTBOUND** ■ **EXALTED EIGHTBOUND** ■ **KHORNE BERZERKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Eightbound",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Exalted Eightbound",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Khorne Berzerkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "cf56a11c-7b1d-5f58-aa07-b2f04fec0047",
@@ -8209,7 +8259,24 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EIGHTBOUND** ■ **EXALTED EIGHTBOUND** ■ **KHORNE BERZERKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Eightbound",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Exalted Eightbound",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Khorne Berzerkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "7bc729b3-54e2-59cb-8080-daaab3ddbbca",
@@ -8376,7 +8443,14 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **KHORNE BERZERKERS**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Khorne Berzerkers",
+          "targetType": "datasheet"
+        }
+      ]
     },
     {
       "id": "90f24438-6cf8-523c-969d-a952f329016a",
@@ -8749,7 +8823,19 @@
       ],
       "leader": {
         "en": "This model can be attached to the following units:  ■ **EIGHTBOUND** ■ **EXALTED EIGHTBOUND**"
-      }
+      },
+      "attachesTo": [
+        {
+          "type": "leader",
+          "target": "Eightbound",
+          "targetType": "datasheet"
+        },
+        {
+          "type": "leader",
+          "target": "Exalted Eightbound",
+          "targetType": "datasheet"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Regenerated 11th-edition data using the parser changes in ronplanken/datasources-pipeline#50, plus reprocessed changelogs for 895, 909, 912 and 913 against their stored baselines.

**Merge ronplanken/datasources-pipeline#50 first** — this PR is its output.

## Data changes

Datasheets gain `attachesTo`: the source's own record of which units a character can be attached to. It moves independently of the `Leader` prose we publish, so it was previously invisible to change detection — 895 → 909 moved 20 attachment records with no output change at all. Support characters (Apothecary, Ancient, …) have no `Leader` prose, so this is the only record of their attachments.

Enhancements gain `equipableByNonCharacter`.

Ids are de-collided: enhancement ids now key on `(detachment, name)` like stratagem ids, and the Combat Patrol units that shared a name within one file key on their source datasheet id. Those files previously held two entries under one id — the two `’Ardmob Boyz` are genuinely different units, differing in the Boss Nob's loadout — which made the id ambiguous downstream and permanently hid one twin of each pair from the changelog.

## Reprocessed changelogs

Each regenerated by diffing the target export against the previous stored export, so each log reflects what actually changed in that transition. Newly surfaced:

- **895** — Captain in Gravis Armour, Apothecary Biologis, Tor Garadon and Iron Father Feirros gained Eradicator Squad with Heavy Bolters
- **909** — those four lost it again; Uriel Ventris gained Victrix Honour Guard
- **912** — Sanctified Auspexes and Empowered Mechanisms became equipable by non-Character units

The logs also pick up two pipeline improvements that landed after they were last written: detachment-rule diffs, and clearer points wording (`Removed explicit points value (was 0 pts)` instead of `0 -> null pts`). 913's existing curated summary headline is preserved.

Note that a target named by *keyword* rather than by datasheet is the same rule — GW moves targets between the two representations freely, and the parser deliberately does not report that as a change. Several apparent "can no longer be attached to Sternguard Veteran Squad" entries were exactly this and are correctly absent.

## Verification

Entity counts (datasheets, enhancements, stratagems, detachments) are unchanged in all 61 files, and no file contains a duplicate id any more. The 978 removed ids are matched by 978 added — nothing gained or lost.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HSdyobcuHVvZ8y6p49eR9F)_