### PR TITLE
Say "1 model", not "1 models", in the reprocessed changelogs

### DIFF
--- a/11th/changelogs/895_changelog.txt
+++ b/11th/changelogs/895_changelog.txt
@@ -54,13 +54,13 @@ FACTION: Agents of the Imperium
   DATASHEETS:
     Modified (4):
       ~ Callidus Assassin
-        - points: Added 1 models (Veiled Blade Elimination Force) option at 140 pts
+        - points: Added 1 model (Veiled Blade Elimination Force) option at 140 pts
       ~ Culexus Assassin
-        - points: Added 1 models (Veiled Blade Elimination Force) option at 125 pts
+        - points: Added 1 model (Veiled Blade Elimination Force) option at 125 pts
       ~ Eversor Assassin
-        - points: Added 1 models (Veiled Blade Elimination Force) option at 145 pts
+        - points: Added 1 model (Veiled Blade Elimination Force) option at 145 pts
       ~ Vindicare Assassin
-        - points: Added 1 models (Veiled Blade Elimination Force) option at 155 pts
+        - points: Added 1 model (Veiled Blade Elimination Force) option at 155 pts
 
 ------------------------------------------------------------
 FACTION: Leagues of Votann

--- a/11th/changelogs/909_changelog.txt
+++ b/11th/changelogs/909_changelog.txt
@@ -17,13 +17,13 @@ FACTION: Dark Angels
         - points: 6 models: 170 -> 160 pts
         - abilities.other: modified: Braziers of Judgement
       ~ Land Speeder Vengeance
-        - points: 1 models: 120 -> 130 pts
+        - points: 1 model: 120 -> 130 pts
       ~ Lion El’Jonson
-        - points: 1 models: 285 -> 265 pts
+        - points: 1 model: 285 -> 265 pts
         - abilities.primarch: modified: Primarch of the First Legion
         - keywords: added: Mobile
       ~ Nephilim Jetfighter
-        - points: 1 models: 195 -> 180 pts
+        - points: 1 model: 195 -> 180 pts
         - abilities.other: modified: Lightning-fast Manoeuvres
       ~ Ravenwing Black Knights
         - additionalCost: Removed additional selection cost (+10 pts)
@@ -34,10 +34,10 @@ FACTION: Dark Angels
       ~ Ravenwing Dark Talon
         - abilities.other: modified: Stasis Bomb
       ~ Ravenwing Darkshroud
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - abilities.other: modified: Icon of Old Caliban
       ~ Sammael
-        - points: 1 models: 105 -> 95 pts
+        - points: 1 model: 105 -> 95 pts
         - abilities.other: modified: Grand Master of the Ravenwing
 
   STRATAGEMS:
@@ -75,7 +75,7 @@ FACTION: Dark Angels (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Master Zacharial
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Vengeful Brethren Bladeguard Veteran Squad
         - points: 3 models: Removed explicit points value (was 0 pts)
@@ -95,18 +95,18 @@ FACTION: Death Guard
   DATASHEETS:
     Modified (5):
       ~ Chaos Rhino
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Deathshroud Terminators
         - points: 6 models: 320 -> 305 pts
         - abilities.other: modified: Death Approaches
       ~ Defiler
-        - points: 1 models: 290 -> 300 pts
+        - points: 1 model: 290 -> 300 pts
         - additionalCost: Additional selection cost: +30 -> +40 pts
         - wargearOptions: Hades lascannon: 10 -> 15 pts
         - wargearOptions: Heavy reaper autocannon: 10 -> 15 pts
       ~ Mortarion
-        - points: 1 models: 400 -> 390 pts
+        - points: 1 model: 400 -> 390 pts
         - abilities.primarch: modified: Lord of the Death Guard
       ~ Plague Marines
         - points: 10 models: 190 -> 180 pts
@@ -128,15 +128,15 @@ FACTION: Death Guard (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Maggot Lords Chaos Rhino
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Maggot Lords Deathshroud Terminators
         - points: 3 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Plaguespurt Gauntlet: BS/WS: 6+ -> -
         - meleeWeapons: Manreaper – Sweep: A: 4 -> 8
       ~ Septimol Fulg, Maggot Lords Tallyman
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Sholgor the Putrid
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - rangedWeapons: Twin Plague Spewer: BS/WS: 6+ -> -
 
 ------------------------------------------------------------
@@ -146,19 +146,19 @@ FACTION: Tyranids
   DATASHEETS:
     Modified (9):
       ~ Maleceptor
-        - points: 1 models: 180 -> 190 pts
+        - points: 1 model: 180 -> 190 pts
       ~ Neurotyrant
-        - points: 1 models: 115 -> 130 pts
+        - points: 1 model: 115 -> 130 pts
       ~ The Red Terror
         - abilities.other: removed: Serpentine Fiend
         - keywords: added: Mobile
       ~ Toxicrene
-        - points: 1 models: 135 -> 120 pts
+        - points: 1 model: 135 -> 120 pts
       ~ Tyranid Warriors with Melee Bio-weapons
         - abilities.other: added: Adaptive Instincts (Once per turn, per unit)
         - abilities.other: removed: Adaptive Instincts
       ~ Tyrannocyte
-        - points: 1 models: 90 -> 80 pts
+        - points: 1 model: 90 -> 80 pts
         - additionalCost: Added additional selection cost (+10 pts)
         - abilities.other: modified: Aerial Seeding
       ~ Venomthropes
@@ -183,11 +183,11 @@ FACTION: Tyranids (Combat Patrol)
   DATASHEETS:
     Modified (6):
       ~ Terror of Vardenghast
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Vardenghast Swarm Barbgaunts
         - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Vardenghast Swarm Psychophage
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Vardenghast Swarm Termagants
         - points: 10 models: Removed explicit points value (was 0 pts)
         - abilities.other: modified: Skulking Horrors (Once per phase per unit)
@@ -212,27 +212,27 @@ FACTION: Adeptus Astartes
       ~ Captain in Gravis Armour
         - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Captain Titus
-        - points: 1 models: 90 -> 100 pts
+        - points: 1 model: 90 -> 100 pts
       ~ Cato Sicarius
-        - points: 1 models: 95 -> 105 pts
+        - points: 1 model: 95 -> 105 pts
       ~ Centurion Devastator Squad
         - wargearOptions: Twin lascannon: 0 -> 5 pts
       ~ Chaplain with Jump Pack
         - rangedWeapons: Absolvor bolt pistol: Added
         - wargearOptions: Added Absolvor bolt pistol at 0 pts
       ~ Chief Librarian Tigurius
-        - points: 1 models: 95 -> 85 pts
+        - points: 1 model: 95 -> 85 pts
         - abilities.other: modified: Master of Prescience
       ~ Company Heroes
         - abilities.special: removed: Company Heroes
       ~ Drop Pod
-        - points: 1 models: 70 -> 60 pts
+        - points: 1 model: 70 -> 60 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Eradicator Squad with Heavy Bolters
         - points: 3 models: 70 -> 80 pts
         - additionalCost: Removed additional selection cost (+10 pts)
       ~ Impulsor
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Inceptor Squad
         - points: 6 models: 240 -> 250 pts
@@ -245,31 +245,31 @@ FACTION: Adeptus Astartes
       ~ Iron Father Feirros
         - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Land Speeder
-        - points: 1 models: 95 -> 105 pts
+        - points: 1 model: 95 -> 105 pts
         - additionalCost: Removed additional selection cost (+10 pts)
       ~ Librarian
-        - points: 1 models: 60 -> 70 pts
+        - points: 1 model: 60 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Lieutenant with Combi-weapon
-        - points: 1 models: 85 -> 95 pts
+        - points: 1 model: 85 -> 95 pts
       ~ Marneus Calgar in Armour of Antilochus
-        - points: 1 models: 140 -> 155 pts
+        - points: 1 model: 140 -> 155 pts
       ~ Razorback
-        - points: 1 models: 95 -> 85 pts
+        - points: 1 model: 95 -> 85 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Repulsor Executioner
-        - points: 1 models: 230 -> 255 pts
+        - points: 1 model: 230 -> 255 pts
         - wargearOptions: Heavy laser destroyer: 0 -> 10 pts
       ~ Rhino
-        - points: 1 models: 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Roboute Guilliman
-        - points: 1 models: 340 -> 355 pts
+        - points: 1 model: 340 -> 355 pts
         - keywords: added: Mobile
       ~ Sternguard Veteran Squad
         - points: 10 models: 190 -> 200 pts
       ~ Storm Speeder Hammerstrike
-        - points: 1 models: 130 -> 140 pts
+        - points: 1 model: 130 -> 140 pts
       ~ Stormhawk Interceptor
         - keywords: removed: Frame
       ~ Stormraven Gunship
@@ -277,7 +277,7 @@ FACTION: Adeptus Astartes
       ~ Stormtalon Gunship
         - keywords: removed: Frame
       ~ Suboden Khan
-        - points: 1 models: 100 -> 90 pts
+        - points: 1 model: 100 -> 90 pts
       ~ Suppressor Squad
         - points: 3 models: 75 -> 85 pts
       ~ Thunderhawk Gunship
@@ -286,7 +286,7 @@ FACTION: Adeptus Astartes
       ~ Tor Garadon
         - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Uriel Ventris
-        - points: 1 models: 95 -> 105 pts
+        - points: 1 model: 95 -> 105 pts
         - attachesTo: Can now be attached to Victrix Honour Guard (Leader)
         - leader: Changed
       ~ Vanguard Veteran Squad with Jump Packs
@@ -375,7 +375,7 @@ FACTION: Adeptus Astartes (Combat Patrol)
   DATASHEETS:
     Modified (5):
       ~ Assault Force Captain
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
       ~ Assault Force Intercessor Squad
@@ -384,12 +384,12 @@ FACTION: Adeptus Astartes (Combat Patrol)
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
       ~ Assault Force Land Speeder
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
         - loadout: Changed
       ~ Assault Force Librarian
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - rangedWeapons: Bolt Pistol: AP: -1 -> 0
         - abilities.faction: removed: Oath of Moment
         - abilities.faction: removed: Space Marine Chapters
@@ -424,7 +424,7 @@ FACTION: Blood Angels (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Captain Raldeo
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
       ~ Sanguinary Spearhead Assault Intercessor Squad
         - points: 10 models: Removed explicit points value (was 0 pts)
@@ -445,21 +445,21 @@ FACTION: Black Templars
       ~ Chaplain Grimaldus
         - points: 4 models: 110 -> 100 pts
       ~ Crusade Ancient
-        - points: 1 models: 45 -> 40 pts
+        - points: 1 model: 45 -> 40 pts
       ~ Emperor’s Champion
-        - points: 1 models: 100 -> 90 pts
+        - points: 1 model: 100 -> 90 pts
       ~ Execrator
-        - points: 1 models: 60 -> 50 pts
+        - points: 1 model: 60 -> 50 pts
       ~ High Marshal Helbrecht
-        - points: 1 models: 120 -> 110 pts
+        - points: 1 model: 120 -> 110 pts
       ~ Impulsor
-        - points: 1 models: 85 -> 75 pts
-        - points: 1 models: 85 -> 70 pts
+        - points: 1 model: 85 -> 75 pts
+        - points: 1 model: 85 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Marshal
         - additionalCost: Additional selection cost of +10 pts now applies after 2 selections (previously after 1 selection)
       ~ Repulsor Executioner
-        - points: 1 models: 245 -> 255 pts
+        - points: 1 model: 245 -> 255 pts
         - wargearOptions: Heavy laser destroyer: 0 -> 10 pts
 
   STRATAGEMS:
@@ -481,7 +481,7 @@ FACTION: Black Templars (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Emperor's Champion Vedrenn
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Vow-Sworn Bladeguard Veteran Squad
         - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Vow-Sworn Crusader Squad
@@ -498,15 +498,15 @@ FACTION: Space Wolves
   DATASHEETS:
     Modified (7):
       ~ Arjac Rockfist
-        - points: 1 models: 105 -> 95 pts
+        - points: 1 model: 105 -> 95 pts
       ~ Iron Priest
-        - points: 1 models: 55 -> 50 pts
+        - points: 1 model: 55 -> 50 pts
       ~ Logan Grimnar
-        - points: 1 models: 110 -> 100 pts
+        - points: 1 model: 110 -> 100 pts
       ~ Njal Stormcaller
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
       ~ Ragnar Blackmane
-        - points: 1 models: 100 -> 90 pts
+        - points: 1 model: 100 -> 90 pts
       ~ Wolf Guard Terminators
         - additionalCost: Additional selection cost: +10 -> +15 pts; applies after 1 selection -> 2 selections
       ~ Wolf Scouts
@@ -550,7 +550,7 @@ FACTION: Space Wolves (Combat Patrol)
         - wargearOptions: Removed Feral Claws
         - abilities.faction: removed: Oath of Moment
       ~ Fyrri Askar
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - abilities.faction: removed: Oath of Moment
 
 ------------------------------------------------------------
@@ -574,14 +574,14 @@ FACTION: Thousand Sons
   DATASHEETS:
     Modified (10):
       ~ Chaos Predator Annihilator
-        - points: 1 models: 130 -> 140 pts
+        - points: 1 model: 130 -> 140 pts
       ~ Chaos Predator Destructor
-        - points: 1 models: 130 -> 140 pts
+        - points: 1 model: 130 -> 140 pts
       ~ Chaos Rhino
-        - points: 1 models: 90 -> 80 pts
+        - points: 1 model: 90 -> 80 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Defiler
-        - points: 1 models: 290 -> 300 pts
+        - points: 1 model: 290 -> 300 pts
         - additionalCost: Additional selection cost: +30 -> +40 pts
         - wargearOptions: Heavy reaper autocannon: 10 -> 15 pts
         - wargearOptions: Hades lascannon: 10 -> 15 pts
@@ -601,7 +601,7 @@ FACTION: Thousand Sons
       ~ Tzaangor Enlightened
         - points: 3 models: 45 -> 50 pts
       ~ Tzaangor Shaman
-        - points: 1 models: 60 -> 65 pts
+        - points: 1 model: 60 -> 65 pts
 
   STRATAGEMS:
     Modified (2):
@@ -637,13 +637,13 @@ FACTION: Thousand Sons (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Kaa'skrek
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Prism of Zadophon Rubric Marines
         - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Prism of Zadophon Tzaangor Enlightened
         - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Zadophon the Soul Eater
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: World Eaters
@@ -652,13 +652,13 @@ FACTION: World Eaters
   DATASHEETS:
     Modified (13):
       ~ Angron
-        - points: 1 models: 350 -> 330 pts
+        - points: 1 model: 350 -> 330 pts
       ~ Chaos Predator Annihilator
-        - points: 1 models: 135 -> 130 pts
+        - points: 1 model: 135 -> 130 pts
       ~ Chaos Predator Destructor
-        - points: 1 models: 135 -> 130 pts
+        - points: 1 model: 135 -> 130 pts
       ~ Chaos Rhino
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Chaos Terminators
         - points: 10 models: 350 -> 330 pts
@@ -676,17 +676,17 @@ FACTION: World Eaters
         - points: 3 models: 140 -> 130 pts
         - additionalCost: Additional selection cost: +10 -> +15 pts
       ~ Forgefiend
-        - points: 1 models: 160 -> 140 pts
+        - points: 1 model: 160 -> 140 pts
         - wargearOptions: Ectoplasma cannon: 0 -> 5 pts
       ~ Khorne Berzerkers
         - points: 20 models: 345 -> 330 pts
         - points: 10 models: 180 -> 170 pts
       ~ Lord Invocatus
-        - points: 1 models: 110 -> 100 pts
+        - points: 1 model: 110 -> 100 pts
       ~ Lord on Juggernaut
-        - points: 1 models: 105 -> 95 pts
+        - points: 1 model: 105 -> 95 pts
       ~ Maulerfiend
-        - points: 1 models: 145 -> 140 pts
+        - points: 1 model: 145 -> 140 pts
 
   ENHANCEMENTS:
     Modified (4):
@@ -718,9 +718,9 @@ FACTION: World Eaters (Combat Patrol)
         - points: 10 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Bolt Pistol: S: 3 -> 4
       ~ Frenzied Reavers Master of Executions
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Vorrakh, Lord of the Frenzied Reavers
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Heretic Astartes
@@ -729,17 +729,17 @@ FACTION: Heretic Astartes
   DATASHEETS:
     Modified (17):
       ~ Abaddon the Despoiler
-        - points: 1 models: 285 -> 295 pts
+        - points: 1 model: 285 -> 295 pts
       ~ Accursed Cultists
         - additionalCost: Additional selection cost of +20 pts now applies after 2 selections (previously after 1 selection)
       ~ Chaos Lord with Jump Pack
-        - points: 1 models: 90 -> 80 pts
+        - points: 1 model: 90 -> 80 pts
       ~ Chaos Predator Annihilator
-        - points: 1 models: 135 -> 145 pts
+        - points: 1 model: 135 -> 145 pts
       ~ Chaos Predator Destructor
-        - points: 1 models: 140 -> 150 pts
+        - points: 1 model: 140 -> 150 pts
       ~ Chaos Rhino
-        - points: 1 models: 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Chaos Terminator Squad
         - points: 10 models: 360 -> 350 pts
@@ -756,7 +756,7 @@ FACTION: Heretic Astartes
         - wargearOptions: Heavy reaper autocannon: 10 -> 15 pts
         - abilities.other: modified: Daemonforge
       ~ Huron Blackheart
-        - points: 1 models: 120 -> 130 pts
+        - points: 1 model: 120 -> 130 pts
       ~ Masters of the Maelstrom
         - points: 5 models: 135 -> 145 pts
         - abilities.special: removed: Masters of the Maelstrom
@@ -766,11 +766,11 @@ FACTION: Heretic Astartes
         - points: 10 models: 190 -> 180 pts
         - points: 5 models: 110 -> 100 pts
       ~ Red Corsairs Reave-Captain
-        - points: 1 models: 70 -> 60 pts
+        - points: 1 model: 70 -> 60 pts
       ~ Vashtorr the Arkifane
-        - points: 1 models: 205 -> 220 pts
+        - points: 1 model: 205 -> 220 pts
       ~ Venomcrawler
-        - points: 1 models: 110 -> 120 pts
+        - points: 1 model: 110 -> 120 pts
 
   ENHANCEMENTS:
     Modified (1):
@@ -796,7 +796,7 @@ FACTION: Heretic Astartes (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Aranis Zarkan
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Zarkan's Daemonkin Cultist Mob
         - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Zarkan's Daemonkin Legionaries
@@ -811,22 +811,22 @@ FACTION: Legiones Daemonica
   DATASHEETS:
     Modified (7):
       ~ Beasts of Nurgle
-        - points: 1 models: 70 -> 75 pts
+        - points: 1 model: 70 -> 75 pts
       ~ Bloodcrushers
         - points: 6 models: 180 -> 190 pts
         - additionalCost: Additional selection cost: +10 -> +20 pts
       ~ Fluxmaster
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - abilities.other: modified: Fluxmaster
       ~ Kairos Fateweaver
-        - points: 1 models: 295 -> 305 pts
+        - points: 1 model: 295 -> 305 pts
       ~ Lord of Change
-        - points: 1 models: 300 -> 320 pts
+        - points: 1 model: 300 -> 320 pts
         - additionalCost: Additional selection cost: +15 -> +20 pts
       ~ Screamers
         - keywords: removed: Frame
       ~ Shalaxi Helbane
-        - points: 1 models: 340 -> 315 pts
+        - points: 1 model: 340 -> 315 pts
 
   STRATAGEMS:
     Modified (3):
@@ -872,9 +872,9 @@ FACTION: Chaos Knights
         - rangedWeapons: Terrorpulse missiles: A: 2D6 -> D6+6
         - rangedWeapons: Darkflame lance: A: 2D6 -> D6+6
       ~ War Dog Huntsman
-        - points: 1 models: 140 -> 135 pts
+        - points: 1 model: 140 -> 135 pts
       ~ War Dog Stalker
-        - points: 1 models: 140 -> 135 pts
+        - points: 1 model: 140 -> 135 pts
 
   STRATAGEMS:
     Modified (1):
@@ -897,32 +897,32 @@ FACTION: Astra Militarum
   DATASHEETS:
     Modified (23):
       ~ Baneblade
-        - points: 1 models: 450 -> 415 pts
+        - points: 1 model: 450 -> 415 pts
         - additionalCost: Additional selection cost: +20 -> +35 pts
       ~ Banehammer
-        - points: 1 models: 420 -> 385 pts
+        - points: 1 model: 420 -> 385 pts
         - additionalCost: Additional selection cost: +20 -> +35 pts
       ~ Banesword
-        - points: 1 models: 450 -> 415 pts
+        - points: 1 model: 450 -> 415 pts
         - additionalCost: Additional selection cost: +20 -> +35 pts
       ~ Cadian Command Squad
         - points: 5 models: 65 -> 60 pts
       ~ Centaur RSV
-        - points: 1 models: 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Chimera
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Commissar Yarrick
-        - points: 1 models: 130 -> 120 pts
+        - points: 1 model: 130 -> 120 pts
         - abilities.primarch: modified: Hero of Hades Hive
       ~ Doomhammer
-        - points: 1 models: 415 -> 380 pts
+        - points: 1 model: 415 -> 380 pts
         - additionalCost: Additional selection cost: +20 -> +30 pts
       ~ Gaunt’s Ghosts
         - abilities.other: modified: Covert Stealth Team
       ~ Hellhammer
-        - points: 1 models: 420 -> 385 pts
+        - points: 1 model: 420 -> 385 pts
         - additionalCost: Additional selection cost: +20 -> +30 pts
       ~ Kasrkin
         - points: 10 models: 115 -> 105 pts
@@ -930,27 +930,27 @@ FACTION: Astra Militarum
       ~ Krieg Command Squad
         - points: 6 models: 65 -> 60 pts
       ~ Leman Russ Commander
-        - points: 1 models: 235 -> 215 pts
+        - points: 1 model: 235 -> 215 pts
         - wargearOptions: Demolisher battle cannon: 0 -> 15 pts
         - abilities.other: modified: Death Befitting An Officer
       ~ Leman Russ Demolisher
-        - points: 1 models: 190 -> 180 pts
+        - points: 1 model: 190 -> 180 pts
       ~ Militarum Tempestus Command Squad
         - additionalCost: Additional selection cost of +10 pts now applies after 2 selections (previously after 1 selection)
       ~ Shadowsword
-        - points: 1 models: 410 -> 375 pts
+        - points: 1 model: 410 -> 375 pts
         - additionalCost: Additional selection cost: +20 -> +30 pts
       ~ Stormlord
-        - points: 1 models: 430 -> 395 pts
+        - points: 1 model: 430 -> 395 pts
         - additionalCost: Additional selection cost: +20 -> +35 pts
       ~ Stormsword
-        - points: 1 models: 465 -> 430 pts
+        - points: 1 model: 465 -> 430 pts
         - additionalCost: Additional selection cost: +20 -> +35 pts
       ~ Taurox
-        - points: 1 models: 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Taurox Prime
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Tempestus Aquilons
         - points: 10 models: 100 -> 95 pts
@@ -1014,7 +1014,7 @@ FACTION: Imperial Knights
   DATASHEETS:
     Modified (1):
       ~ Knight Castellan
-        - points: 1 models: 400 -> 425 pts
+        - points: 1 model: 400 -> 425 pts
         - additionalCost: Additional selection cost: +20 -> +25 pts
 
   ENHANCEMENTS:
@@ -1046,15 +1046,15 @@ FACTION: Grey Knights
         - points: 10 models: 375 -> 360 pts
         - additionalCost: Removed additional selection cost (+10 pts)
       ~ Grand Master Voldus
-        - points: 1 models: 140 -> 125 pts
+        - points: 1 model: 140 -> 125 pts
         - abilities.other: modified: Sanctuary
       ~ Grey Knights Thunderhawk Gunship
         - keywords: removed: Frame
       ~ Razorback
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Rhino
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Stormhawk Interceptor
         - keywords: removed: Frame
@@ -1113,9 +1113,9 @@ FACTION: Grey Knights (Combat Patrol)
         - points: 10 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Incinerator: BS/WS: 3+ -> -
       ~ Crowe's Sanctifiers Venerable Dreadnought
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Sanctifiers Castellan Crowe
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Adepta Sororitas
@@ -1128,20 +1128,20 @@ FACTION: Adepta Sororitas
       ~ Dominion Squad
         - points: 10 models: 100 -> 90 pts
       ~ Hospitaller
-        - points: 1 models: 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
       ~ Imagifier
-        - points: 1 models: 65 -> 55 pts
+        - points: 1 model: 65 -> 55 pts
       ~ Immolator
-        - points: 1 models: 110 -> 100 pts
+        - points: 1 model: 110 -> 100 pts
         - additionalCost: Additional selection cost: +10 -> +15 pts
       ~ Intranzia Fraye
-        - points: 1 models: 150 -> 135 pts
+        - points: 1 model: 150 -> 135 pts
       ~ Junith Eruita
-        - points: 1 models: 115 -> 105 pts
+        - points: 1 model: 115 -> 105 pts
         - abilities.other: modified: The Pulpit of Saint Holline’s Basilica
         - leader: Changed
       ~ Morvenn Vahl
-        - points: 1 models: 185 -> 200 pts
+        - points: 1 model: 185 -> 200 pts
       ~ Repentia Squad
         - points: 10 models: 160 -> 140 pts
         - points: 5 models: 75 -> 70 pts
@@ -1151,7 +1151,7 @@ FACTION: Adepta Sororitas
       ~ Sisters Novitiate Squad
         - points: 10 models: 100 -> 90 pts
       ~ Sororitas Rhino
-        - points: 1 models: 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Zephyrim Squad
         - points: 10 models: 160 -> 150 pts
@@ -1197,7 +1197,7 @@ FACTION: Adepta Sororitas (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Sanctuary Canoness Adalya
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Sanctuary Guardians Arco-Flagellants
         - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Sanctuary Guardians Battle Sisters Squad
@@ -1234,7 +1234,7 @@ FACTION: Adeptus Mechanicus
       ~ Skitarii Vanguard
         - points: 10 models: 90 -> 85 pts
       ~ Skorpius Dunerider
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Thulia Ghuld
         - abilities.other: removed: Cybernetic Augmentation
@@ -1259,7 +1259,7 @@ FACTION: Adeptus Mechanicus (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Manipulus Skand
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - rangedWeapons: Transonic Cannon: BS/WS: 6+ -> -
       ~ Purge Corps Pteraxii Sterylizors
         - points: 5 models: Removed explicit points value (was 0 pts)
@@ -1284,9 +1284,9 @@ FACTION: Adeptus Custodes
   DATASHEETS:
     Modified (8):
       ~ Aleya
-        - points: 1 models: 65 -> 55 pts
+        - points: 1 model: 65 -> 55 pts
       ~ Anathema Psykana Rhino
-        - points: 1 models: 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Ares Gunship
         - abilities.other: modified: Infernus Firebombs
@@ -1334,7 +1334,7 @@ FACTION: Adeptus Custodes (Combat Patrol)
       ~ Gilded Blades Custodian Wardens
         - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Tristraen of the Gilded Blades
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Agents of the Imperium
@@ -1349,28 +1349,28 @@ FACTION: Agents of the Imperium
       ~ Deathwatch Kill Team
         - points: 10 models (Imperium): 200 -> 190 pts
       ~ Eversor Assassin
-        - points: 1 models: 110 -> 100 pts
-        - points: 1 models (Imperium): 120 -> 110 pts
-        - points: Removed 1 models (Veiled Blade Elimination Force) option
+        - points: 1 model: 110 -> 100 pts
+        - points: 1 model (Imperium): 120 -> 110 pts
+        - points: Removed 1 model (Veiled Blade Elimination Force) option
       ~ Grey Knights Terminator Squad
         - points: 5 models: 190 -> 175 pts
         - points: 5 models (Imperium): 210 -> 190 pts
       ~ Imperial Rhino
-        - points: 1 models: 75 -> 65 pts
-        - points: 1 models (Imperium): 75 -> 65 pts
+        - points: 1 model: 75 -> 65 pts
+        - points: 1 model (Imperium): 75 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Inquisitorial Chimera
-        - points: 1 models: 70 -> 60 pts
-        - points: 1 models (Imperium): 70 -> 60 pts
+        - points: 1 model: 70 -> 60 pts
+        - points: 1 model (Imperium): 70 -> 60 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Sisters of Battle Immolator
-        - points: 1 models: 100 -> 90 pts
-        - points: 1 models (Imperium): 115 -> 105 pts
+        - points: 1 model: 100 -> 90 pts
+        - points: 1 model (Imperium): 115 -> 105 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Sisters of Battle Squad
         - points: 10 models (Imperium): 115 -> 110 pts
       ~ Watch Master
-        - points: 1 models (Imperium): 105 -> 95 pts
+        - points: 1 model (Imperium): 105 -> 95 pts
 
   ENHANCEMENTS:
     Modified (4):
@@ -1406,7 +1406,7 @@ FACTION: Agents of the Imperium (Combat Patrol)
   DATASHEETS:
     Modified (5):
       ~ Inquisitor's Hand Eversor Assassin
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Inquisitor's Hand Inquisitorial Agents
         - points: 6 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Plasma Pistol – Standard: AP: -1 -> -2
@@ -1417,7 +1417,7 @@ FACTION: Agents of the Imperium (Combat Patrol)
       ~ Inquisitor's Hand Vigilant Squad
         - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Preacher Teguen
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - rangedWeapons: Zealot's Vindictor: BS/WS: 3+ -> -
 
 ------------------------------------------------------------
@@ -1427,7 +1427,7 @@ FACTION: Orks
   DATASHEETS:
     Modified (18):
       ~ Big Mek Dakkarig
-        - points: 1 models: 100 -> 115 pts
+        - points: 1 model: 100 -> 115 pts
         - additionalCost: Removed additional selection cost (+10 pts)
       ~ Big Mek with Shokk Attack Gun
         - additionalCost: Additional selection cost of +10 pts now applies after 1 selection (previously after 2 selections)
@@ -1466,18 +1466,18 @@ FACTION: Orks
       ~ Kill Rig
         - keywords: removed: Frame
       ~ Mek
-        - points: 1 models: 45 -> 55 pts
+        - points: 1 model: 45 -> 55 pts
       ~ Painboss
-        - points: 1 models: 60 -> 70 pts
+        - points: 1 model: 60 -> 70 pts
       ~ Painboy
-        - points: 1 models: 80 -> 90 pts
+        - points: 1 model: 80 -> 90 pts
       ~ Shokkjump Dragsta
         - abilities.other: modified: Shokk Tunnel
       ~ Trukk
-        - points: 1 models: 65 -> 55 pts
+        - points: 1 model: 65 -> 55 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Warboss
-        - points: 1 models: 75 -> 85 pts
+        - points: 1 model: 75 -> 85 pts
         - rangedWeapons: Kustom shoota: Added
         - wargearOptions: Added Kustom Choppa at 0 pts
         - wargearOptions: Added Kustom shoota at 0 pts
@@ -1535,11 +1535,11 @@ FACTION: Orks (Combat Patrol)
       ~ ’Ardmob Gretchin
         - points: 10 models: Removed explicit points value (was 0 pts)
       ~ ’Ardmob Warboss
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ ’Ardmob Wartrakk
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ 'Ardmob Weirdboy
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Leagues of Votann
@@ -1548,13 +1548,13 @@ FACTION: Leagues of Votann
   DATASHEETS:
     Modified (5):
       ~ Berehk Stornbröw
-        - points: 1 models: 95 -> 85 pts
+        - points: 1 model: 95 -> 85 pts
       ~ Brôkhyr Iron-master
         - points: 5 models: 75 -> 70 pts
       ~ Buri Aegnirssen
-        - points: 1 models: 95 -> 85 pts
+        - points: 1 model: 95 -> 85 pts
       ~ Kapricus Carrier
-        - points: 1 models: 75 -> 70 pts
+        - points: 1 model: 75 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Sagitaur
         - additionalCost: Added additional selection cost (+10 pts)
@@ -1584,7 +1584,7 @@ FACTION: Leagues of Votann (Combat Patrol)
       ~ Bane-Slayer's Bulwark Hearthkyn Warriors
         - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Vynn Bane-Slayer
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: T’au Empire
@@ -1597,31 +1597,31 @@ FACTION: T’au Empire
       ~ Broadside Battlesuits
         - points: 3 models: 240 -> 255 pts
       ~ Commander Farsight
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
       ~ Devilfish
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Ghostkeel Battlesuit
         - additionalCost: Additional selection cost: +10 -> +15 pts
         - wargearOptions: Cyclic ion raker: 10 -> 15 pts
       ~ Hammerhead Gunship
-        - points: 1 models: 140 -> 150 pts
+        - points: 1 model: 140 -> 150 pts
       ~ Pathfinder Team
         - points: 10 models: 80 -> 85 pts
         - additionalCost: Added additional selection cost (+15 pts)
       ~ Razorshark Strike Fighter
         - keywords: removed: Frame
       ~ Riptide Battlesuit
-        - points: 1 models: 180 -> 190 pts
+        - points: 1 model: 180 -> 190 pts
         - wargearOptions: Ion accelerator: 20 -> 25 pts
       ~ Stormsurge
-        - points: 1 models: 360 -> 375 pts
+        - points: 1 model: 360 -> 375 pts
       ~ Sun Shark Bomber
         - keywords: removed: Frame
       ~ The Twin Lance
         - points: 2 models: 205 -> 220 pts
       ~ Tiger Shark
-        - points: 1 models: 325 -> 375 pts
+        - points: 1 model: 325 -> 375 pts
         - keywords: removed: Frame
 
   ENHANCEMENTS:
@@ -1645,11 +1645,11 @@ FACTION: T’au Empire (Combat Patrol)
   DATASHEETS:
     Modified (4):
       ~ Commander Cloudspear
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Sudden Dawn Cadre Breacher Team
         - points: 10 models: Removed explicit points value (was 0 pts)
       ~ Sudden Dawn Cadre Devilfish
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Sudden Dawn Cadre Pathfinder Team
         - points: 10 models: Removed explicit points value (was 0 pts)
 
@@ -1660,16 +1660,16 @@ FACTION: Necrons
   DATASHEETS:
     Modified (15):
       ~ Canoptek Reanimator
-        - points: 1 models: 70 -> 75 pts
+        - points: 1 model: 70 -> 75 pts
         - abilities.other: modified: Nanoscarab Reanimation Beam
       ~ Catacomb Command Barge
         - abilities.wargear: modified: Resurrection Orb
         - keywords: added: Noble
       ~ Chronomancer
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - abilities.other: modified: Timesplinter Mantle
       ~ Doomsday Ark
-        - points: 1 models: 200 -> 210 pts
+        - points: 1 model: 200 -> 210 pts
         - keywords: added: Frame
       ~ Lokhust Destroyers
         - points: 6 models: 160 -> 170 pts
@@ -1678,7 +1678,7 @@ FACTION: Necrons
       ~ Lokhust Lord
         - abilities.wargear: modified: Resurrection Orb
       ~ Nekrosor Ammentar
-        - points: 1 models: 175 -> 185 pts
+        - points: 1 model: 175 -> 185 pts
       ~ Ophydian Destroyers
         - abilities.other: modified: Tunnelling Horrors
       ~ Overlord
@@ -1688,7 +1688,7 @@ FACTION: Necrons
       ~ Skorpekh Lord
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Tesseract Vault
-        - points: 1 models: 445 -> 465 pts
+        - points: 1 model: 445 -> 465 pts
       ~ The Silent King
         - points: 3 models: 400 -> 420 pts
       ~ Transcendent C’tan
@@ -1734,7 +1734,7 @@ FACTION: Necrons (Combat Patrol)
   DATASHEETS:
     Modified (5):
       ~ Amonhotekh's Guard Canoptek Doomstalker
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
       ~ Amonhotekh's Guard Canoptek Scarab Swarms
         - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Amonhotekh's Guard Necron Warriors
@@ -1742,7 +1742,7 @@ FACTION: Necrons (Combat Patrol)
       ~ Amonhotekh's Guard Skorpekh Destroyers
         - points: 3 models: Removed explicit points value (was 0 pts)
       ~ Overlord Amonhotekh
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Asuryani
@@ -1751,11 +1751,11 @@ FACTION: Asuryani
   DATASHEETS:
     Modified (34):
       ~ Autarch
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
       ~ Autarch Wayleaper
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
       ~ Avatar of Khaine
-        - points: 1 models: 265 -> 250 pts
+        - points: 1 model: 265 -> 250 pts
       ~ Corsair Skyreavers
         - points: 10 models: 150 -> 140 pts
         - points: 5 models: 80 -> 75 pts
@@ -1771,15 +1771,15 @@ FACTION: Asuryani
       ~ D-cannon Platform
         - keywords: added: Frame
       ~ Death Jester
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
       ~ Eldrad Ulthran
         - leader: Changed
       ~ Falcon
         - keywords: added: Frame
       ~ Farseer
-        - points: 1 models: 70 -> 65 pts
+        - points: 1 model: 70 -> 65 pts
       ~ Farseer Skyrunner
-        - points: 1 models: 70 -> 60 pts
+        - points: 1 model: 70 -> 60 pts
       ~ Fire Prism
         - keywords: added: Frame
       ~ Hemlock Wraithfighter
@@ -1789,7 +1789,7 @@ FACTION: Asuryani
       ~ Shadow Weaver Platform
         - keywords: added: Frame
       ~ Shadowseer
-        - points: 1 models: 60 -> 50 pts
+        - points: 1 model: 60 -> 50 pts
       ~ Shining Spears
         - points: 6 models: 210 -> 200 pts
         - points: 3 models: 105 -> 100 pts
@@ -1800,7 +1800,7 @@ FACTION: Asuryani
         - points: 2 models: 105 -> 95 pts
         - abilities.other: modified: Acrobatic Grace
       ~ Starweaver
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
         - keywords: added: Frame
       ~ Swooping Hawks
@@ -1814,26 +1814,26 @@ FACTION: Asuryani
       ~ War Walkers
         - points: 2 models: 170 -> 160 pts
       ~ Warlock Skyrunners
-        - points: 1 models: 45 -> 55 pts
+        - points: 1 model: 45 -> 55 pts
       ~ Warp Spiders
         - points: 5 models: 115 -> 105 pts
         - additionalCost: Additional selection cost: +15 -> +20 pts
       ~ Wave Serpent
-        - points: 1 models: 125 -> 115 pts
+        - points: 1 model: 125 -> 115 pts
         - additionalCost: Added additional selection cost (+10 pts)
         - keywords: added: Frame
       ~ Windriders
         - points: 6 models: 160 -> 170 pts
       ~ Wraithknight
-        - points: 1 models: 415 -> 385 pts
+        - points: 1 model: 415 -> 385 pts
       ~ Wraithknight with Ghostglaive
-        - points: 1 models: 405 -> 380 pts
+        - points: 1 model: 405 -> 380 pts
       ~ Ynnari Raider
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
         - keywords: added: Frame
       ~ Ynnari Venom
-        - points: 1 models: 70 -> 65 pts
+        - points: 1 model: 70 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
         - keywords: added: Frame
 
@@ -1867,7 +1867,7 @@ FACTION: Asuryani (Combat Patrol)
       ~ Kygharil's Protectors Wraithblades
         - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Spiritseer Kygharil
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - abilities.other: modified: Tears of Isha (Psychic)
 
 ------------------------------------------------------------
@@ -1879,17 +1879,17 @@ FACTION: Drukhari
       ~ Archon
         - abilities.wargear: modified: Shadowfield
       ~ Raider
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Ravager
-        - points: 1 models: 100 -> 110 pts
+        - points: 1 model: 100 -> 110 pts
         - additionalCost: Removed additional selection cost (+10 pts)
       ~ Razorwing Jetfighter
         - keywords: removed: Frame
       ~ Scourges with Shardcarbines
         - abilities.other: modified: Swooping Descent
       ~ Venom
-        - points: 1 models: 70 -> 65 pts
+        - points: 1 model: 70 -> 65 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Voidraven Bomber
         - keywords: removed: Frame
@@ -1915,17 +1915,17 @@ FACTION: Drukhari (Combat Patrol)
   DATASHEETS:
     Modified (5):
       ~ Coven of Agonies Cronos
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - rangedWeapons: Spirit Syphon: BS/WS: 6+ -> -
       ~ Coven of Agonies Talos
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - rangedWeapons: Twin Liquifier Gun: BS/WS: 3+ -> -
       ~ Coven of Agonies Wracks
         - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Coven of Agonies Wracks
         - points: 5 models: Removed explicit points value (was 0 pts)
       ~ Xatrophos Nuul
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Genestealer Cults
@@ -1942,7 +1942,7 @@ FACTION: Genestealer Cults
         - points: 10 models: 160 -> 150 pts
         - points: 5 models: 90 -> 85 pts
       ~ Goliath Truck
-        - points: 1 models: 85 -> 75 pts
+        - points: 1 model: 85 -> 75 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Hybrid Metamorphs
         - points: 10 models: 150 -> 140 pts
@@ -1984,7 +1984,7 @@ FACTION: Genestealer Cults (Combat Patrol)
   DATASHEETS:
     Modified (5):
       ~ Claw of Ascension Achilles Ridgerunner
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
         - rangedWeapons: Twin Heavy Stubber: Added
         - rangedWeapons: Missile Launcher: Added
         - meleeWeapons: Twin Heavy Stubber: Removed
@@ -1998,7 +1998,7 @@ FACTION: Genestealer Cults (Combat Patrol)
         - points: 5 models: Removed explicit points value (was 0 pts)
         - rangedWeapons: Hand Flamer: BS/WS: 6+ -> -
       ~ Shanus Daskovian
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ------------------------------------------------------------
 FACTION: Emperor’s Children
@@ -2007,23 +2007,23 @@ FACTION: Emperor’s Children
   DATASHEETS:
     Modified (6):
       ~ Chaos Rhino
-        - points: 1 models: 80 -> 70 pts
+        - points: 1 model: 80 -> 70 pts
         - additionalCost: Added additional selection cost (+10 pts)
       ~ Defiler
-        - points: 1 models: 290 -> 300 pts
+        - points: 1 model: 290 -> 300 pts
         - additionalCost: Additional selection cost: +30 -> +40 pts
         - wargearOptions: Hades lascannon: 10 -> 15 pts
         - wargearOptions: Heavy reaper autocannon: 10 -> 15 pts
       ~ Fulgrim
-        - points: 1 models: 350 -> 340 pts
+        - points: 1 model: 350 -> 340 pts
         - abilities.other: removed: Serpentine
         - keywords: added: Mobile
       ~ Lucius the Eternal
-        - points: 1 models: 130 -> 120 pts
+        - points: 1 model: 130 -> 120 pts
       ~ Maulerfiend
-        - points: 1 models: 130 -> 120 pts
+        - points: 1 model: 130 -> 120 pts
       ~ Sorcerer
-        - points: 1 models: 60 -> 55 pts
+        - points: 1 model: 60 -> 55 pts
 
   STRATAGEMS:
     Modified (1):
@@ -2059,7 +2059,7 @@ FACTION: Emperor’s Children (Combat Patrol)
       ~ Callous Blades Infractors
         - points: Added 10 models option at null pts
       ~ Lord Kaphrael of the Callous Blades
-        - points: 1 models: Removed explicit points value (was 0 pts)
+        - points: 1 model: Removed explicit points value (was 0 pts)
 
 ================================================================================
 STATISTICS

--- a/11th/changelogs/913_changelog.txt
+++ b/11th/changelogs/913_changelog.txt
@@ -6,7 +6,7 @@ Points updates to Agents of the Imperium and minor datasheet changes
 **Agents of the Imperium**
 - Callidus Assassin: decreased points (140→115)
 - Culexus Assassin: decreased points (125→95)
-- Eversor Assassin: added 1 models (Veiled Blade Elimination Force) option at 115 pts
+- Eversor Assassin: added 1 model (Veiled Blade Elimination Force) option at 115 pts
 - Vindicare Assassin: decreased points (155→130)
 
 **Necrons**
@@ -45,13 +45,13 @@ FACTION: Agents of the Imperium
   DATASHEETS:
     Modified (4):
       ~ Callidus Assassin
-        - points: 1 models (Veiled Blade Elimination Force): 140 -> 115 pts
+        - points: 1 model (Veiled Blade Elimination Force): 140 -> 115 pts
       ~ Culexus Assassin
-        - points: 1 models (Veiled Blade Elimination Force): 125 -> 95 pts
+        - points: 1 model (Veiled Blade Elimination Force): 125 -> 95 pts
       ~ Eversor Assassin
-        - points: Added 1 models (Veiled Blade Elimination Force) option at 115 pts
+        - points: Added 1 model (Veiled Blade Elimination Force) option at 115 pts
       ~ Vindicare Assassin
-        - points: 1 models (Veiled Blade Elimination Force): 155 -> 130 pts
+        - points: 1 model (Veiled Blade Elimination Force): 155 -> 130 pts
 
   DETACHMENT RULES:
     Modified (1):

--- a/11th/changelogs/913_summary.md
+++ b/11th/changelogs/913_summary.md
@@ -3,7 +3,7 @@ Points updates to Agents of the Imperium and minor datasheet changes
 **Agents of the Imperium**
 - Callidus Assassin: decreased points (140→115)
 - Culexus Assassin: decreased points (125→95)
-- Eversor Assassin: added 1 models (Veiled Blade Elimination Force) option at 115 pts
+- Eversor Assassin: added 1 model (Veiled Blade Elimination Force) option at 115 pts
 - Vindicare Assassin: decreased points (155→130)
 
 **Necrons**

--- a/11th/changelogs/913_summary_full.md
+++ b/11th/changelogs/913_summary_full.md
@@ -6,7 +6,7 @@ Points updates to Agents of the Imperium and minor datasheet changes
 **Agents of the Imperium**
 - Callidus Assassin: decreased points (140→115)
 - Culexus Assassin: decreased points (125→95)
-- Eversor Assassin: added 1 models (Veiled Blade Elimination Force) option at 115 pts
+- Eversor Assassin: added 1 model (Veiled Blade Elimination Force) option at 115 pts
 - Vindicare Assassin: decreased points (155→130)
 
 **Necrons**


### PR DESCRIPTION
Output of ronplanken/datasources-pipeline#51 — **merge that first.**

The points option label hardcoded the plural, so every single-model reprice read `1 models (Veiled Blade Elimination Force): 140 -> 115 pts`.

The 895, 909, 912 and 913 changelogs are regenerated against their stored baselines. 912 has no single-model reprice so it comes out unchanged.

913's curated summary carried the same wording in its own text, so `913_summary.md` and `913_summary_full.md` are corrected in place rather than left contradicting the detailed changelog directly below them.

## Verification

No `1 models` remains anywhere under `11th/changelogs/`. The only near-match left is `21 models`, which is correct.

Data files are untouched — this is changelog wording only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HSdyobcuHVvZ8y6p49eR9F)_