### PR TITLE
Drop the field label from attachment changelog lines

### DIFF
--- a/11th/changelogs/895_changelog.txt
+++ b/11th/changelogs/895_changelog.txt
@@ -25,13 +25,13 @@ FACTION: Adeptus Astartes
   DATASHEETS:
     Modified (4):
       ~ Apothecary Biologis
-        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Support)
+        - Can now be attached to Eradicator Squad with Heavy Bolters (Support)
       ~ Captain in Gravis Armour
-        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
+        - Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Iron Father Feirros
-        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
+        - Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Tor Garadon
-        - attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
+        - Can now be attached to Eradicator Squad with Heavy Bolters (Leader)
 
   DETACHMENT RULES:
     Modified (1):

--- a/11th/changelogs/909_changelog.txt
+++ b/11th/changelogs/909_changelog.txt
@@ -208,9 +208,9 @@ FACTION: Adeptus Astartes
         - points: 6 models: 180 -> 165 pts
         - points: 3 models: 90 -> 80 pts
       ~ Apothecary Biologis
-        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Support)
+        - Can no longer be attached to Eradicator Squad with Heavy Bolters (Support)
       ~ Captain in Gravis Armour
-        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
+        - Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Captain Titus
         - points: 1 model: 90 -> 100 pts
       ~ Cato Sicarius
@@ -243,7 +243,7 @@ FACTION: Adeptus Astartes
         - abilities.other: added: Hail of Bolts
         - abilities.other: removed: Target Elimination
       ~ Iron Father Feirros
-        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
+        - Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Land Speeder
         - points: 1 model: 95 -> 105 pts
         - additionalCost: Removed additional selection cost (+10 pts)
@@ -284,10 +284,10 @@ FACTION: Adeptus Astartes
         - keywords: removed: Aircraft
         - keywords: removed: Frame
       ~ Tor Garadon
-        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
+        - Can no longer be attached to Eradicator Squad with Heavy Bolters (Leader)
       ~ Uriel Ventris
         - points: 1 model: 95 -> 105 pts
-        - attachesTo: Can now be attached to Victrix Honour Guard (Leader)
+        - Can now be attached to Victrix Honour Guard (Leader)
         - leader: Changed
       ~ Vanguard Veteran Squad with Jump Packs
         - points: 10 models: 210 -> 220 pts


### PR DESCRIPTION
Output of ronplanken/datasources-pipeline#52 — **merge that first.**

An attachment change read `attachesTo: Can now be attached to Eradicator Squad with Heavy Bolters (Leader)`, repeating the technical key in front of a sentence that already said it. The sentence now stands on its own:

```diff
       ~ Apothecary Biologis
-        - attachesTo: Can no longer be attached to Eradicator Squad with Heavy Bolters (Support)
+        - Can no longer be attached to Eradicator Squad with Heavy Bolters (Support)
```

Only 895 and 909 contain attachment changes, so those are the only changelogs that move. The `attachesTo` key in the data files is untouched — it is an internal key, not something a reader sees.

## Verification

No `attachesTo` remains anywhere under `11th/changelogs/`. Data files are unchanged; this is changelog wording only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HSdyobcuHVvZ8y6p49eR9F)_