### PR TITLE
Consolidate the 913 changelog into one complete log

### DIFF
--- a/11th/changelogs/913_changelog.txt
+++ b/11th/changelogs/913_changelog.txt
@@ -1,6 +1,34 @@
 App version: 2.3.1
 Data version: 913
 
+Points updates to Agents of the Imperium and minor datasheet changes
+
+**Agents of the Imperium**
+- Callidus Assassin: decreased points (140→115)
+- Culexus Assassin: decreased points (125→95)
+- Eversor Assassin: added 1 model (Veiled Blade Elimination Force) option at 115 pts
+- Vindicare Assassin: decreased points (155→130)
+
+**Necrons**
+- Night Scythe: updated "Invasion Beams" ability
+- Night Scythe: removed "Frame" keyword
+
+**Emperor's Children (Combat Patrol)**
+- Callous Blades Infractors: "Bolt Pistol" moved from melee weapons to ranged weapons
+
+**Faction-scoped points options**
+- Points options now carry the faction they apply to; 38 datasheets across Adeptus Astartes, Black Templars and Agents of the Imperium were relabelled without any cost changing
+- Repulsor Executioner: the 230 pts option is now listed separately for Deathwatch, Dark Angels, Blood Angels and Space Wolves
+
+**FAQ & Errata**
+- 3 FAQ/errata updates (0 added, 1 changed, 2 removed) across 3 codexes.
+- Codex: Chaos Space Marines: removed ruling on "fights on death" with Dark Pacts
+- Codex: Necrons: removed "Night Scythe" ruling
+- Codex: Tyranids: updated "Venomthropes, Foul Spores ability" errata text
+
+**Missions**
+- Combat Patrol — "Uphold Your Vows": changed scoring input type (stepper→checkbox)
+
 ================================================================================
 DETAILED CHANGES
 ================================================================================
@@ -12,36 +40,29 @@ FACTION: Adeptus Astartes
   DATASHEETS:
     Modified (8):
       ~ Assault Intercessor Squad
-        - points: 5 models: 80 -> 75 pts
-        - points: Added 5 models (Blood Angels) option at 80 pts
+        - points: 5 models at 80 pts: option now scoped to Blood Angels
       ~ Assault Intercessors with Jump Packs
-        - points: Added 10 models (Blood Angels) option at 180 pts
-        - points: Added 5 models (Blood Angels) option at 95 pts
+        - points: 10 models at 180 pts: option now scoped to Blood Angels
+        - points: 5 models at 95 pts: option now scoped to Blood Angels
       ~ Bladeguard Veteran Squad
-        - points: 6 models: 170 -> 160 pts
-        - points: 3 models: 85 -> 80 pts
-        - points: Added 6 models (Blood Angels) option at 170 pts
-        - points: Added 3 models (Blood Angels) option at 85 pts
+        - abilities.other: modified: Bladeguard
+        - points: 6 models at 170 pts: option now scoped to Blood Angels
+        - points: 3 models at 85 pts: option now scoped to Blood Angels
       ~ Captain with Jump Pack
-        - points: 1 model: 80 -> 75 pts
-        - points: Added 1 model (Blood Angels) option at 80 pts
+        - points: 1 model at 80 pts: option now scoped to Blood Angels
       ~ Chaplain with Jump Pack
-        - points: 1 model: 80 -> 75 pts
-        - points: Added 1 model (Blood Angels) option at 80 pts
+        - points: 1 model at 80 pts: option now scoped to Blood Angels
       ~ Outrider Squad
-        - points: 3 models: 75 -> 70 pts
-        - points: Added 4 models (Blood Angels) option at 135 pts
-        - points: Added 3 models (Blood Angels) option at 75 pts
+        - points: 4 models at 135 pts: option now scoped to Blood Angels
+        - points: 3 models at 75 pts: option now scoped to Blood Angels
       ~ Repulsor Executioner
-        - points: 1 model: 230 -> 255 pts
-        - points: Added 1 model (Deathwatch) option at 230 pts
+        - points: 1 model at 230 pts: option now scoped to Deathwatch
         - points: Added 1 model (Dark Angels) option at 230 pts
         - points: Added 1 model (Blood Angels) option at 230 pts
         - points: Added 1 model (Space Wolves) option at 230 pts
       ~ Vanguard Veteran Squad with Jump Packs
-        - points: 10 models: 220 -> 210 pts
-        - points: Added 10 models (Blood Angels) option at 220 pts
-        - points: Added 5 models (Blood Angels) option at 110 pts
+        - points: 10 models at 220 pts: option now scoped to Blood Angels
+        - points: 5 models at 110 pts: option now scoped to Blood Angels
 
 ------------------------------------------------------------
 FACTION: Black Templars
@@ -50,16 +71,7 @@ FACTION: Black Templars
   DATASHEETS:
     Modified (1):
       ~ Impulsor
-        - points: Added 1 model (Black Templars) option at 75 pts
-
-------------------------------------------------------------
-FACTION: Space Wolves
-------------------------------------------------------------
-
-  DATASHEETS:
-    Modified (1):
-      ~ Wolf Guard Headtakers
-        - points: 6 models: 115 -> 170 pts
+        - points: 1 model at 75 pts: option now scoped to Black Templars
 
 ------------------------------------------------------------
 FACTION: Agents of the Imperium
@@ -68,112 +80,142 @@ FACTION: Agents of the Imperium
   DATASHEETS:
     Modified (29):
       ~ Aquila Kill Team
-        - points: Added 10 models (Agents of the Imperium) option at 200 pts
-        - points: Added 5 models (Agents of the Imperium) option at 100 pts
-        - points: Removed 10 models option
-        - points: Removed 5 models option
+        - points: 10 models at 200 pts: option now scoped to Agents of the Imperium
+        - points: 5 models at 100 pts: option now scoped to Agents of the Imperium
       ~ Callidus Assassin
-        - points: Added 1 model (Agents of the Imperium) option at 100 pts
-        - points: Removed 1 model option
+        - points: 1 model (Veiled Blade Elimination Force): 140 -> 115 pts
+        - points: 1 model at 100 pts: option now scoped to Agents of the Imperium
       ~ Corvus Blackstar
-        - points: Added 1 model (Agents of the Imperium) option at 180 pts
-        - points: Removed 1 model option
+        - points: 1 model at 180 pts: option now scoped to Agents of the Imperium
       ~ Culexus Assassin
-        - points: Added 1 model (Agents of the Imperium) option at 85 pts
-        - points: Removed 1 model option
+        - points: 1 model (Veiled Blade Elimination Force): 125 -> 95 pts
+        - points: 1 model at 85 pts: option now scoped to Agents of the Imperium
       ~ Deathwatch Kill Team
-        - points: Added 10 models (Agents of the Imperium) option at 190 pts
-        - points: Added 5 models (Agents of the Imperium) option at 100 pts
-        - points: Removed 10 models option
-        - points: Removed 5 models option
+        - points: 10 models at 190 pts: option now scoped to Agents of the Imperium
+        - points: 5 models at 100 pts: option now scoped to Agents of the Imperium
       ~ Eversor Assassin
-        - points: Added 1 model (Agents of the Imperium) option at 100 pts
-        - points: Removed 1 model option
+        - points: Added 1 model (Veiled Blade Elimination Force) option at 115 pts
+        - points: 1 model at 100 pts: option now scoped to Agents of the Imperium
       ~ Exaction Squad
-        - points: Added 11 models (Agents of the Imperium) option at 90 pts
-        - points: Removed 11 models option
+        - points: 11 models at 90 pts: option now scoped to Agents of the Imperium
       ~ Grey Knights Terminator Squad
-        - points: Added 5 models (Agents of the Imperium) option at 175 pts
-        - points: Removed 5 models option
+        - points: 5 models at 175 pts: option now scoped to Agents of the Imperium
       ~ Imperial Navy Breachers
-        - points: Added 10 models (Agents of the Imperium) option at 90 pts
-        - points: Removed 10 models option
+        - points: 10 models at 90 pts: option now scoped to Agents of the Imperium
       ~ Imperial Rhino
-        - points: Added 1 model (Agents of the Imperium) option at 65 pts
-        - points: Removed 1 model option
+        - points: 1 model at 65 pts: option now scoped to Agents of the Imperium
       ~ Inquisitor
-        - points: Added 1 model (Agents of the Imperium) option at 55 pts
-        - points: Removed 1 model option
+        - points: 1 model at 55 pts: option now scoped to Agents of the Imperium
       ~ Inquisitor Coteaz
-        - points: Added 1 model (Agents of the Imperium) option at 75 pts
-        - points: Removed 1 model option
+        - points: 1 model at 75 pts: option now scoped to Agents of the Imperium
       ~ Inquisitor Draxus
-        - points: Added 1 model (Agents of the Imperium) option at 75 pts
-        - points: Removed 1 model option
+        - points: 1 model at 75 pts: option now scoped to Agents of the Imperium
       ~ Inquisitor Greyfax
-        - points: Added 1 model (Agents of the Imperium) option at 65 pts
-        - points: Removed 1 model option
+        - points: 1 model at 65 pts: option now scoped to Agents of the Imperium
       ~ Inquisitor Kroyle
-        - points: Added 1 model (Agents of the Imperium) option at 100 pts
-        - points: Removed 1 model option
+        - points: 1 model at 100 pts: option now scoped to Agents of the Imperium
       ~ Inquisitorial Agents
-        - points: Added 12 models (Agents of the Imperium) option at 100 pts
-        - points: Added 11 models (Agents of the Imperium) option at 100 pts
-        - points: Added 6 models (Agents of the Imperium) option at 50 pts
-        - points: Removed 12 models option
-        - points: Removed 11 models option
-        - points: Removed 6 models option
+        - points: 12 models at 100 pts: option now scoped to Agents of the Imperium
+        - points: 11 models at 100 pts: option now scoped to Agents of the Imperium
+        - points: 6 models at 50 pts: option now scoped to Agents of the Imperium
       ~ Inquisitorial Chimera
-        - points: Added 1 model (Agents of the Imperium) option at 60 pts
-        - points: Removed 1 model option
+        - points: 1 model at 60 pts: option now scoped to Agents of the Imperium
       ~ Ministorum Priest
-        - points: Added 1 model (Agents of the Imperium) option at 40 pts
-        - points: Removed 1 model option
+        - points: 1 model at 40 pts: option now scoped to Agents of the Imperium
       ~ Navigator
-        - points: Added 1 model (Agents of the Imperium) option at 60 pts
-        - points: Removed 1 model option
+        - points: 1 model at 60 pts: option now scoped to Agents of the Imperium
       ~ Rogue Trader Entourage
-        - points: Added 4 models (Agents of the Imperium) option at 75 pts
-        - points: Removed 4 models option
+        - points: 4 models at 75 pts: option now scoped to Agents of the Imperium
       ~ Sanctifiers
-        - points: Added 9 models (Agents of the Imperium) option at 100 pts
-        - points: Removed 9 models option
+        - points: 9 models at 100 pts: option now scoped to Agents of the Imperium
       ~ Sisters of Battle Immolator
-        - points: Added 1 model (Agents of the Imperium) option at 90 pts
-        - points: Removed 1 model option
+        - points: 1 model at 90 pts: option now scoped to Agents of the Imperium
       ~ Sisters of Battle Squad
-        - points: Added 10 models (Agents of the Imperium) option at 100 pts
-        - points: Removed 10 models option
+        - points: 10 models at 100 pts: option now scoped to Agents of the Imperium
       ~ Subductor Squad
-        - points: Added 11 models (Agents of the Imperium) option at 85 pts
-        - points: Removed 11 models option
+        - points: 11 models at 85 pts: option now scoped to Agents of the Imperium
       ~ Vigilant Squad
-        - points: Added 11 models (Agents of the Imperium) option at 85 pts
-        - points: Removed 11 models option
+        - points: 11 models at 85 pts: option now scoped to Agents of the Imperium
       ~ Vindicare Assassin
-        - points: Added 1 model (Agents of the Imperium) option at 110 pts
-        - points: Removed 1 model option
+        - points: 1 model (Veiled Blade Elimination Force): 155 -> 130 pts
+        - points: 1 model at 110 pts: option now scoped to Agents of the Imperium
       ~ Voidsmen-at-Arms
-        - points: Added 6 models (Agents of the Imperium) option at 50 pts
-        - points: Removed 6 models option
+        - points: 6 models at 50 pts: option now scoped to Agents of the Imperium
       ~ Watch Captain Artemis
-        - points: Added 1 model (Agents of the Imperium) option at 65 pts
-        - points: Removed 1 model option
+        - points: 1 model at 65 pts: option now scoped to Agents of the Imperium
       ~ Watch Master
-        - points: Added 1 model (Agents of the Imperium) option at 95 pts
-        - points: Removed 1 model option
+        - points: 1 model at 95 pts: option now scoped to Agents of the Imperium
+
+  DETACHMENT RULES:
+    Modified (1):
+      ~ Veiled Blade Elimination Force
+        - rules: Extremis Sanction: "Decoy Targets" cost: +40 points -> +15 points
+        - rules: Extremis Sanction: "Esoteric Explosives" cost: +40 points -> +10 points
+        - rules: Extremis Sanction: "Intraneural Biotech" cost: +35 points -> +15 points
+        - rules: Extremis Sanction: "Micromelta Rounds" cost: +45 points -> +20 points
+
+------------------------------------------------------------
+FACTION: Necrons
+------------------------------------------------------------
+
+  DATASHEETS:
+    Modified (1):
+      ~ Night Scythe
+        - abilities.other: modified: Invasion Beams
+        - keywords: removed: Frame
+
+------------------------------------------------------------
+FACTION: Emperor’s Children (Combat Patrol)
+------------------------------------------------------------
+
+  DATASHEETS:
+    Modified (1):
+      ~ Callous Blades Infractors
+        - rangedWeapons: Bolt Pistol: Added
+        - meleeWeapons: Bolt Pistol: Removed
 
 ================================================================================
 STATISTICS
 ================================================================================
 Total factions processed: 54
-Factions with changes: 4
-Factions without changes: 50
+Factions with changes: 5
+Factions without changes: 49
 
-Datasheets:    +0 added, -0 removed, ~39 modified
+Datasheets:    +0 added, -0 removed, ~40 modified
 Stratagems:    +0 added, -0 removed, ~0 modified
 Enhancements:  +0 added, -0 removed, ~0 modified
 Detachments:   +0 added, -0 removed, ~0 modified
-Detach. Rules: +0 added, -0 removed, ~0 modified
+Detach. Rules: +0 added, -0 removed, ~1 modified
 Army Rules:    +0 added, -0 removed, ~0 modified
+================================================================================
+
+================================================================================
+FAQ & ERRATA CHANGES
+================================================================================
+
+  FAQ & ERRATA:
+    Removed (2):
+      - [Codex: Chaos Space Marines] When a model ‘fights on death’, can that model’s unit make a Dark Pact?
+      - [Codex: Necrons] Night Scythe
+    Modified (1):
+      ~ [Codex: Tyranids] Venomthropes, Foul Spores ability
+        - errataText: Changed
+
+FAQ_CHANGE_COUNTS added=0 removed=2 modified=1
+================================================================================
+
+================================================================================
+MISSION CHANGES
+================================================================================
+
+------------------------------------------------------------
+MISSION PACK: Combat Patrol
+------------------------------------------------------------
+
+  PRIMARY MISSIONS:
+    Modified (1):
+      ~ Uphold Your Vows
+        - objectives[END OF THE BATTLE].scoring[0].inputType: stepper → checkbox
+
+MISSION_CHANGE_COUNTS added=0 removed=0 modified=1
 ================================================================================

--- a/11th/changelogs/913_summary.md
+++ b/11th/changelogs/913_summary.md
@@ -1,0 +1,27 @@
+Points updates to Agents of the Imperium and minor datasheet changes
+
+**Agents of the Imperium**
+- Callidus Assassin: decreased points (140→115)
+- Culexus Assassin: decreased points (125→95)
+- Eversor Assassin: added 1 model (Veiled Blade Elimination Force) option at 115 pts
+- Vindicare Assassin: decreased points (155→130)
+
+**Necrons**
+- Night Scythe: updated "Invasion Beams" ability
+- Night Scythe: removed "Frame" keyword
+
+**Emperor's Children (Combat Patrol)**
+- Callous Blades Infractors: "Bolt Pistol" moved from melee weapons to ranged weapons
+
+**Faction-scoped points options**
+- Points options now carry the faction they apply to; 38 datasheets across Adeptus Astartes, Black Templars and Agents of the Imperium were relabelled without any cost changing
+- Repulsor Executioner: the 230 pts option is now listed separately for Deathwatch, Dark Angels, Blood Angels and Space Wolves
+
+**FAQ & Errata**
+- 3 FAQ/errata updates (0 added, 1 changed, 2 removed) across 3 codexes.
+- Codex: Chaos Space Marines: removed ruling on "fights on death" with Dark Pacts
+- Codex: Necrons: removed "Night Scythe" ruling
+- Codex: Tyranids: updated "Venomthropes, Foul Spores ability" errata text
+
+**Missions**
+- Combat Patrol — "Uphold Your Vows": changed scoring input type (stepper→checkbox)

--- a/11th/changelogs/913_summary_full.md
+++ b/11th/changelogs/913_summary_full.md
@@ -1,0 +1,34 @@
+Points updates to Agents of the Imperium and minor datasheet changes
+
+**Adeptus Astartes**
+- Bladeguard Veteran Squad: updated "Bladeguard" ability
+
+**Agents of the Imperium**
+- Callidus Assassin: decreased points (140→115)
+- Culexus Assassin: decreased points (125→95)
+- Eversor Assassin: added 1 model (Veiled Blade Elimination Force) option at 115 pts
+- Vindicare Assassin: decreased points (155→130)
+- Veiled Blade Elimination Force: reduced Extremis Sanction costs (Decoy Targets +40→+15, Esoteric Explosives +40→+10, Intraneural Biotech +35→+15, Micromelta Rounds +45→+20)
+
+**Necrons**
+- Night Scythe: updated "Invasion Beams" ability
+- Night Scythe: removed "Frame" keyword
+
+**Emperor's Children (Combat Patrol)**
+- Callous Blades Infractors: "Bolt Pistol" moved from melee weapons to ranged weapons
+
+**Faction-scoped points options**
+- Points options now carry the faction they apply to; no costs changed
+- Adeptus Astartes: 8 datasheets relabelled (Assault Intercessor Squad, Assault Intercessors with Jump Packs, Bladeguard Veteran Squad, Captain with Jump Pack, Chaplain with Jump Pack, Outrider Squad, Repulsor Executioner, Vanguard Veteran Squad with Jump Packs)
+- Repulsor Executioner: the 230 pts option is now listed separately for Deathwatch, Dark Angels, Blood Angels and Space Wolves
+- Black Templars: Impulsor 75 pts option scoped to Black Templars
+- Agents of the Imperium: 29 datasheets relabelled to the Agents of the Imperium faction
+
+**FAQ & Errata**
+- 3 FAQ/errata updates (0 added, 1 changed, 2 removed) across 3 codexes.
+- Codex: Chaos Space Marines: removed ruling on "fights on death" with Dark Pacts
+- Codex: Necrons: removed "Night Scythe" ruling
+- Codex: Tyranids: updated "Venomthropes, Foul Spores ability" errata text
+
+**Missions**
+- Combat Patrol — "Uphold Your Vows": changed scoring input type (stepper→checkbox)


### PR DESCRIPTION
## What happened

The second pass over source 913 (`a568dde`) regenerated `11th/changelogs/913_changelog.txt` against the already-published 913 data instead of against 912. As a result it:

- dropped the prose summary and all datasheet, detachment-rule, FAQ/errata and mission changes from the first 913 pass,
- deleted `913_summary.md` and `913_summary_full.md` entirely.

## What this changes

- Restores the first pass' content (Agents of the Imperium assassin points, Veiled Blade Elimination Force enhancement costs, Necrons Night Scythe, Emperor's Children Callous Blades Infractors, the FAQ & errata section and the mission change) and merges it with the second pass into a single 912→913 log.
- Recreates both summary files with the merged content.
- Rewrites the second pass' entries. That pass only added a `faction` field to existing points options; because the generator matches options by index, the reordering surfaced as fake cost changes (e.g. "Assault Intercessor Squad 5 models: 80 → 75 pts"). Comparing the data at `8ae7035` (912) with HEAD shows no cost moved on any of those 38 datasheets, so they are now recorded as faction scoping instead.
- Repulsor Executioner is the one real structural change from that pass: its single 230 pts option is now four faction-scoped options (Deathwatch, Dark Angels, Blood Angels, Space Wolves).
- Wolf Guard Headtakers had no change at all against 912, so Space Wolves is no longer listed as a changed faction.
- Statistics updated accordingly: 5 changed factions, 40 modified datasheets, 1 modified detachment rule.

## Verification

Points data for all touched datasheets was diffed programmatically between the last 912 commit and HEAD; the only cost differences are the four assassin entries from the first pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KapjrWEKwRqEXeibkaCwY2)_